### PR TITLE
[Backport release-26.05] noctalia: init at 5.0.1, noctalia-greeter: init at 1.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24460,6 +24460,12 @@
     githubId = 47582;
     name = "Samir Talwar";
   };
+  samiser = {
+    email = "nixos@me.samiser.xyz";
+    github = "samiser";
+    githubId = 32001364;
+    name = "Sam";
+  };
   samlich = {
     email = "nixos@samli.ch";
     github = "samlich";

--- a/pkgs/by-name/no/noctalia-greeter/package.nix
+++ b/pkgs/by-name/no/noctalia-greeter/package.nix
@@ -42,7 +42,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "noctalia-greeter";
-  version = "1.1.0";
+  version = "1.2.1";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "noctalia-dev";
     repo = "noctalia-greeter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3t/+o8Cbve8z43IekUNBj7Ecn/T+v7+p4Ivgs3IEQtk=";
+    hash = "sha256-k/qCnifAoBqpHkRPYn6nUfEoRV1HXac01+Fh4aouWIE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noctalia-greeter/package.nix
+++ b/pkgs/by-name/no/noctalia-greeter/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+
+  cairo,
+  fontconfig,
+  freetype,
+  glib,
+  gtk4,
+  libGL,
+  librsvg,
+  libwebp,
+  libxkbcommon,
+  pango,
+  wayland,
+  wayland-protocols,
+
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noctalia-greeter";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "noctalia-dev";
+    repo = "noctalia-greeter";
+    rev = "367ab83dcd9190010f093cfe0e123ba132a75b5a";
+    hash = "sha256-/jQ/lkgjaH5EOTZRXk4YZaFrjrKhq/fzZsU6nm7wPt0=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    cairo
+    fontconfig
+    freetype
+    glib
+    gtk4
+    libGL
+    librsvg
+    libwebp
+    libxkbcommon
+    pango
+    wayland
+    wayland-protocols
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "`greetd` greeter for Noctalia";
+    homepage = "https://github.com/noctalia-dev/noctalia-greeter";
+    changelog = "https://github.com/noctalia-dev/noctalia-greeter/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      dtomvan
+      spacedentist
+    ];
+    mainProgram = "noctalia-greeter-session";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/no/noctalia-greeter/package.nix
+++ b/pkgs/by-name/no/noctalia-greeter/package.nix
@@ -8,25 +8,41 @@
   pkg-config,
   wayland-scanner,
 
+  bashNonInteractive,
   cairo,
   fontconfig,
   freetype,
   glib,
-  gtk4,
   libGL,
   librsvg,
   libwebp,
   libxkbcommon,
+  nlohmann_json,
   pango,
+  stb,
+  tomlplusplus,
   wayland,
   wayland-protocols,
+  wlroots_0_20,
 
   nix-update-script,
 }:
 
+let
+  # nixpkgs stb doesn't have stb_image_resize2.h which noctalia-greeter needs
+  stb' = stb.overrideAttrs {
+    version = "0-unstable-2025-10-26";
+    src = fetchFromGitHub {
+      owner = "nothings";
+      repo = "stb";
+      rev = "f1c79c02822848a9bed4315b12c8c8f3761e1296";
+      hash = "sha256-BlyXJtAI7WqXCTT3ylww8zoG0hBxaojJnQDvdQOXJPE=";
+    };
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "noctalia-greeter";
-  version = "1.0.0";
+  version = "1.1.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -34,8 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-greeter";
-    rev = "367ab83dcd9190010f093cfe0e123ba132a75b5a";
-    hash = "sha256-/jQ/lkgjaH5EOTZRXk4YZaFrjrKhq/fzZsU6nm7wPt0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3t/+o8Cbve8z43IekUNBj7Ecn/T+v7+p4Ivgs3IEQtk=";
   };
 
   nativeBuildInputs = [
@@ -46,18 +62,22 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    bashNonInteractive
     cairo
     fontconfig
     freetype
     glib
-    gtk4
     libGL
     librsvg
     libwebp
     libxkbcommon
+    nlohmann_json
     pango
+    stb'
+    tomlplusplus
     wayland
     wayland-protocols
+    wlroots_0_20
   ];
 
   passthru.updateScript = nix-update-script { };
@@ -65,7 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "`greetd` greeter for Noctalia";
     homepage = "https://github.com/noctalia-dev/noctalia-greeter";
-    changelog = "https://github.com/noctalia-dev/noctalia-greeter/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       dtomvan

--- a/pkgs/by-name/no/noctalia-greeter/package.nix
+++ b/pkgs/by-name/no/noctalia-greeter/package.nix
@@ -88,6 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       dtomvan
+      samiser
       spacedentist
     ];
     mainProgram = "noctalia-greeter-session";

--- a/pkgs/by-name/no/noctalia-greeter/package.nix
+++ b/pkgs/by-name/no/noctalia-greeter/package.nix
@@ -42,7 +42,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "noctalia-greeter";
-  version = "1.3.0";
+  version = "1.3.1";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "noctalia-dev";
     repo = "noctalia-greeter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-veowX6t9Vo6nV6BzJ3YKSUDXgfgX8k8yHccd+6fYlBo=";
+    hash = "sha256-1ZdtgBwndNHDltX8J7DLLl2/LBgywQhmt1JNcanfeMA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noctalia-greeter/package.nix
+++ b/pkgs/by-name/no/noctalia-greeter/package.nix
@@ -42,7 +42,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "noctalia-greeter";
-  version = "1.2.1";
+  version = "1.3.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "noctalia-dev";
     repo = "noctalia-greeter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-k/qCnifAoBqpHkRPYn6nUfEoRV1HXac01+Fh4aouWIE=";
+    hash = "sha256-veowX6t9Vo6nV6BzJ3YKSUDXgfgX8k8yHccd+6fYlBo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -21,10 +21,12 @@
   harfbuzz,
   jemalloc,
   libGL,
+  libical,
   libjxl,
   libqalculate,
   librsvg,
   libsecret,
+  libsndfile,
   libsodium,
   libwebp,
   libxkbcommon,
@@ -63,13 +65,13 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "noctalia";
-  version = "5.0.0-beta.6";
+  version = "5.0.0-beta.7";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VJXqeaxCqyMOt/k7ePNoD4nAHdF1eTSuuddmrh/5O6Q=";
+    hash = "sha256-9RlJNIy2DFVm9SB2vwGEBsbHc1r3dIB+K+b+nd6Bdho=";
   };
 
   strictDeps = true;
@@ -92,10 +94,12 @@ stdenv.mkDerivation (finalAttrs: {
     harfbuzz
     jemalloc
     libGL
+    libical
     libjxl
     libqalculate
     librsvg
     libsecret
+    libsndfile
     libsodium
     libwebp
     libxkbcommon

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -65,13 +65,13 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "noctalia";
-  version = "5.0.0-beta.7";
+  version = "5.0.0-beta.8";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9RlJNIy2DFVm9SB2vwGEBsbHc1r3dIB+K+b+nd6Bdho=";
+    hash = "sha256-qy3Cheg/FQ9ZaBPTIgdq4IkmkNtC6XBpmtC8nT+wU/Y=";
   };
 
   strictDeps = true;
@@ -117,6 +117,10 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-protocols
     wireplumber
+  ];
+
+  mesonFlags = [
+    (lib.mesonEnable "tests" false)
   ];
 
   mesonBuildType = "release";

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -127,7 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonBuildType = "release";
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd noctalia \
       --bash <($out/bin/noctalia completions bash) \
       --fish <($out/bin/noctalia completions fish) \

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -61,13 +61,13 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "noctalia";
-  version = "5.0.0-beta.4";
+  version = "5.0.0-beta.5";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jXz2vFHgidbyU46ScROLSuBIhsqqtyqNu2M0tmGX/FA=";
+    hash = "sha256-iq/Eqx62P/JJDpW7CgEsMWWPwOexIWRKXtqKF/drawA=";
   };
 
   strictDeps = true;
@@ -129,9 +129,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "A sleek, customizable desktop shell crafted for Wayland.";
-    homepage = "https://github.com/noctalia-dev/noctalia";
-    changelog = "https://github.com/noctalia-dev/noctalia/releases/tag/v${finalAttrs.version}";
+    description = "Sleek, customizable desktop shell crafted for Wayland";
+    homepage = "https://noctalia.dev";
+    changelog = "https://noctalia.dev/changelogs#v${finalAttrs.version}";
     license = with lib.licenses; [
       mit
       asl20 # material_color_utilities is Apache 2.0

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -11,6 +11,7 @@
   wayland-scanner,
   makeBinaryWrapper,
   autoAddDriverRunpath,
+  installShellFiles,
 
   # libraries
   cairo,
@@ -83,6 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     wayland-scanner
     makeBinaryWrapper
     autoAddDriverRunpath
+    installShellFiles
   ];
 
   buildInputs = [
@@ -124,6 +126,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonBuildType = "release";
+
+  postInstall = ''
+    installShellCompletion --cmd noctalia \
+      --bash <($out/bin/noctalia completions bash) \
+      --fish <($out/bin/noctalia completions fish) \
+      --zsh <($out/bin/noctalia completions zsh)
+  '';
 
   # plugins are installed by cloning their repos
   postFixup = ''

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -10,6 +10,7 @@
   pkg-config,
   wayland-scanner,
   makeBinaryWrapper,
+  autoAddDriverRunpath,
 
   # libraries
   cairo,
@@ -79,6 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     wayland-scanner
     makeBinaryWrapper
+    autoAddDriverRunpath
   ];
 
   buildInputs = [

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # build
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+  makeBinaryWrapper,
+
+  # libraries
+  cairo,
+  curl,
+  fontconfig,
+  freetype,
+  glib,
+  harfbuzz,
+  jemalloc,
+  libGL,
+  libqalculate,
+  librsvg,
+  libsecret,
+  libsodium,
+  libwebp,
+  libxkbcommon,
+  libxml2,
+  md4c,
+  nlohmann_json,
+  pam,
+  pango,
+  pipewire,
+  polkit,
+  sdbus-cpp_2,
+  stb,
+  systemdLibs,
+  tomlplusplus,
+  wayland,
+  wayland-protocols,
+  wireplumber,
+
+  # runtime
+  gitMinimal,
+}:
+
+let
+  # nixpkgs stb doesn't have stb_image_resize2.h which noctalia needs
+  stb' = stb.overrideAttrs {
+    version = "0-unstable-2025-10-26";
+    src = fetchFromGitHub {
+      owner = "nothings";
+      repo = "stb";
+      rev = "f1c79c02822848a9bed4315b12c8c8f3761e1296";
+      hash = "sha256-BlyXJtAI7WqXCTT3ylww8zoG0hBxaojJnQDvdQOXJPE=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "noctalia";
+  version = "5.0.0-beta.4";
+
+  src = fetchFromGitHub {
+    owner = "noctalia-dev";
+    repo = "noctalia";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jXz2vFHgidbyU46ScROLSuBIhsqqtyqNu2M0tmGX/FA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    cairo
+    curl
+    fontconfig
+    freetype
+    glib
+    harfbuzz
+    jemalloc
+    libGL
+    libqalculate
+    librsvg
+    libsecret
+    libsodium
+    libwebp
+    libxkbcommon
+    libxml2
+    md4c
+    nlohmann_json
+    pam
+    pango
+    pipewire
+    polkit
+    sdbus-cpp_2
+    stb'
+    systemdLibs
+    tomlplusplus
+    wayland
+    wayland-protocols
+    wireplumber
+  ];
+
+  mesonBuildType = "release";
+
+  # plugins are installed by cloning their repos
+  postFixup = ''
+    wrapProgram $out/bin/noctalia \
+      --prefix PATH : ${lib.makeBinPath [ gitMinimal ]}
+  '';
+
+  # remove --version=unstable once 5.0.0 stable is released
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version=unstable"
+      "--version-regex"
+      "v(5\\..*)"
+    ];
+  };
+
+  meta = {
+    description = "A sleek, customizable desktop shell crafted for Wayland.";
+    homepage = "https://github.com/noctalia-dev/noctalia";
+    changelog = "https://github.com/noctalia-dev/noctalia/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20 # material_color_utilities is Apache 2.0
+    ];
+    mainProgram = "noctalia";
+    maintainers = with lib.maintainers; [
+      samiser
+      pyrox0
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -20,6 +20,7 @@
   harfbuzz,
   jemalloc,
   libGL,
+  libjxl,
   libqalculate,
   librsvg,
   libsecret,
@@ -61,13 +62,13 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "noctalia";
-  version = "5.0.0-beta.5";
+  version = "5.0.0-beta.6";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-iq/Eqx62P/JJDpW7CgEsMWWPwOexIWRKXtqKF/drawA=";
+    hash = "sha256-VJXqeaxCqyMOt/k7ePNoD4nAHdF1eTSuuddmrh/5O6Q=";
   };
 
   strictDeps = true;
@@ -89,6 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     harfbuzz
     jemalloc
     libGL
+    libjxl
     libqalculate
     librsvg
     libsecret

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -65,13 +65,13 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "noctalia";
-  version = "5.0.0-beta.8";
+  version = "5.0.0-beta.9";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qy3Cheg/FQ9ZaBPTIgdq4IkmkNtC6XBpmtC8nT+wU/Y=";
+    hash = "sha256-O07tHqxugZ/XE/90kx/UCZ0YCbHSI88v2ct2ezuCKi4=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -62,6 +62,16 @@ let
       hash = "sha256-BlyXJtAI7WqXCTT3ylww8zoG0hBxaojJnQDvdQOXJPE=";
     };
   };
+  # libqalculate 5.10.0 makes noctalia segfault, 5.12.0 works
+  libqalculate' = libqalculate.overrideAttrs {
+    version = "5.12.0";
+    src = fetchFromGitHub {
+      owner = "qalculate";
+      repo = "libqalculate";
+      tag = "v5.12.0";
+      hash = "sha256-f9FzFcu2LtBM6B6apYo7uobeR5uZVb02FxX7Kng/rRI=";
+    };
+  };
 in
 stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
@@ -99,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     libical
     libjxl
-    libqalculate
+    libqalculate'
     librsvg
     libsecret
     libsndfile

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -123,6 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     (lib.mesonEnable "tests" false)
+    (lib.mesonEnable "jemalloc" (!stdenv.hostPlatform.isMusl))
   ];
 
   mesonBuildType = "release";

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -66,13 +66,13 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "noctalia";
-  version = "5.0.0-beta.9";
+  version = "5.0.0-beta.10";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-O07tHqxugZ/XE/90kx/UCZ0YCbHSI88v2ct2ezuCKi4=";
+    hash = "sha256-WijEuINvjcXMO/e/zMqwG1lyGiWNosnVt1QY+ko0Rw8=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -66,13 +66,13 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "noctalia";
-  version = "5.0.0-beta.10";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WijEuINvjcXMO/e/zMqwG1lyGiWNosnVt1QY+ko0Rw8=";
+    hash = "sha256-diS3b69rt/IqehH/8Tsd8/JEQmogVc1ml6FP+iTwBzg=";
   };
 
   strictDeps = true;
@@ -141,14 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PATH : ${lib.makeBinPath [ gitMinimal ]}
   '';
 
-  # remove --version=unstable once 5.0.0 stable is released
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version=unstable"
-      "--version-regex"
-      "v(5\\..*)"
-    ];
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Sleek, customizable desktop shell crafted for Wayland";

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -42,6 +42,7 @@
   stb,
   systemdLibs,
   tomlplusplus,
+  tzdata,
   wayland,
   wayland-protocols,
   wireplumber,
@@ -122,7 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    (lib.mesonEnable "tests" false)
+    (lib.mesonEnable "tests" true)
     (lib.mesonEnable "jemalloc" (!stdenv.hostPlatform.isMusl))
   ];
 
@@ -140,6 +141,13 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/noctalia \
       --prefix PATH : ${lib.makeBinPath [ gitMinimal ]}
   '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  nativeCheckInputs = [
+    tzdata
+    gitMinimal
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
backports `noctalia` 5.0.1 (C++ rewrite of `noctalia-shell`) and `noctalia-greeter` 1.3.1 (its greetd greeter) to 26.05 now that they both have stable releases. both are new leaf packages and the commits are mostly cherry-picked from master.

there's a couple of differences from master:

- kept the pinned stb override (as in i didn't include the removal commit), since stable's stb still doesn't have stb_image_resize2.h
- noctalia pins libqalculate 5.12.0 since stable's 5.10.0 causes it to segfault, and a global bump wouldn't make sense for backporting

built on x86_64-linux, noctalia's test suite (110 tests) passes.

i used Claude Code (Opus 5) to help with the cherry picking process but i reviewed and take responsibility for the changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
