### PR TITLE
dora-ssr: init at 1.9.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30127,6 +30127,11 @@
     githubId = 98685984;
     name = "utopiatopia";
   };
+  uuxyz = {
+    github = "uuxyz";
+    githubId = 51853008;
+    name = "uuxyz";
+  };
   uvnikita = {
     email = "uv.nikita@gmail.com";
     github = "uvNikita";

--- a/pkgs/by-name/do/dora-ssr/package.nix
+++ b/pkgs/by-name/do/dora-ssr/package.nix
@@ -1,0 +1,217 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  xmake,
+  gnumake,
+  lua5_1,
+  go,
+  rustc,
+  cargo,
+  makeWrapper,
+  openssl,
+  dbus,
+  libGL,
+  libx11,
+  libxext,
+  libxcb,
+  alsa-lib,
+  libpulseaudio,
+  systemdLibs,
+  zlib,
+  rustPlatform,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  hostArch =
+    if stdenv.hostPlatform.isx86_64 then
+      "x86_64"
+    else if stdenv.hostPlatform.isAarch64 then
+      "aarch64"
+    else
+      throw "dora-ssr: unsupported host architecture";
+
+  bgfxArch = if stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64";
+  waGoArch = if stdenv.hostPlatform.isAarch64 then "arm64" else "amd64";
+  waLibArch = if stdenv.hostPlatform.isAarch64 then "aarch64" else "amd64";
+  rustTarget = stdenv.hostPlatform.rust.rustcTargetSpec;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dora-ssr";
+  version = "1.9.2";
+
+  src = fetchFromGitHub {
+    owner = "IppClub";
+    repo = "Dora-SSR";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-b9M/OZmDeEOpMdJWSLwmk1bO1fhHYy/5ypKf/Jxb4YQ=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src cargoRoot;
+    hash = "sha256-uBCttYQX6A3OcW60LO1c9WpWukAAq4/HgKR/n12gnTg=";
+  };
+
+  cargoRoot = "Source/Rust";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontConfigure = true;
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+    xmake
+    gnumake
+    lua5_1
+    lua5_1.pkgs.luafilesystem
+    go
+    rustc
+    cargo
+    rustPlatform.cargoSetupHook
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    openssl
+    dbus
+    libGL
+    libx11
+    libxext
+    libxcb
+    alsa-lib
+    libpulseaudio
+    systemdLibs
+    zlib
+  ];
+
+  # Dora depends on its SDL2 fork, customized bgfx build, curated Love subset,
+  # and portable decoder-only Theora integration. The corresponding nixpkgs
+  # packages are not drop-in replacements for these bundled components.
+  buildPhase = ''
+    runHook preBuild
+
+    HOST_ARCH="${hostArch}"
+    BGFX_ARCH="${bgfxArch}"
+    WA_GO_ARCH="${waGoArch}"
+    WA_LIB_ARCH="${waLibArch}"
+    RUST_TARGET="${rustTarget}"
+
+    echo "=== [1/6] SDL2 ==="
+    cd Source/3rdParty/SDL2
+    cmake -S . -B build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+      -DSDL_CMAKE_DEBUG_POSTFIX= \
+      -DSDL_SHARED=OFF -DSDL_STATIC=ON -DSDL_STATIC_PIC=ON \
+      -DSDL_PIPEWIRE=OFF -DSDL_TEST=OFF -DSDL_TESTS=OFF \
+      -DSDL2_DISABLE_INSTALL=ON
+    cmake --build build --target SDL2-static --parallel $NIX_BUILD_CORES
+    mkdir -p Lib/Linux/"$HOST_ARCH"
+    cp build/libSDL2.a Lib/Linux/"$HOST_ARCH"/
+    cd ../../..
+
+    echo "=== [2/6] bgfx ==="
+    cd Source/3rdParty/bgfx
+    xmake f -p linux -a "$BGFX_ARCH" -m release -y
+    xmake build -j "$NIX_BUILD_CORES"
+    cd ../../..
+
+    echo "=== [3/6] Love ==="
+    cd Source/3rdParty/Love
+    xmake f -p linux -a "$BGFX_ARCH" -m release -y
+    xmake build -j "$NIX_BUILD_CORES" love
+    mkdir -p Artifacts/Linux/"$HOST_ARCH"
+    cp build/linux/"$BGFX_ARCH"/release/liblove.a Artifacts/Linux/"$HOST_ARCH"/
+    cd ../../..
+
+    echo "=== [4/6] Theora ==="
+    cd Source/3rdParty/theora
+    xmake f -p linux -a "$BGFX_ARCH" -m release -y
+    xmake build -j "$NIX_BUILD_CORES" theoradec
+    mkdir -p Lib/Linux/"$HOST_ARCH"
+    cp build/linux/"$BGFX_ARCH"/release/libtheoradec.a Lib/Linux/"$HOST_ARCH"/
+    cd ../../..
+
+    echo "=== [5/6] Wa ==="
+    cd Source/3rdParty/Wa/Source
+    mkdir -p ../Lib/Linux/"$WA_LIB_ARCH"
+    GOOS=linux GOARCH="$WA_GO_ARCH" CGO_ENABLED=1 GOFLAGS="-mod=vendor" \
+      go build -trimpath -buildmode=c-archive -ldflags="-s -w" \
+      -o ../Lib/Linux/"$WA_LIB_ARCH"/libwa.a .
+    cd ../../../..
+
+    echo "=== [6/6] Rust ==="
+    cd Source/Rust
+    cargo build --release --target "$RUST_TARGET"
+    mkdir -p lib/Linux/"$HOST_ARCH"
+    cp target/"$RUST_TARGET"/release/libdora_runtime.a lib/Linux/"$HOST_ARCH"/
+    cd ../..
+
+    echo "=== CMake link ==="
+    cd Projects/Linux
+    [ -d build ] || mkdir build
+    cd ../../Tools/tolua++ && lua tolua++.lua && cd ../../Projects/Linux
+    cd build && cmake -DCMAKE_BUILD_TYPE=release ..
+    make -j"$NIX_BUILD_CORES"
+    cd ../../..
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/dora-ssr
+    DORA_BIN=$(find Projects/Linux/build -name dora-ssr -type f -executable | head -1)
+    if [ -z "$DORA_BIN" ]; then
+      DORA_BIN=$(find Projects/Linux/build -name dora-ssr -type f | head -1)
+    fi
+    install -Dm755 "$DORA_BIN" $out/libexec/dora-ssr
+    cp -r Assets $out/share/dora-ssr/Assets
+    install -Dm644 LICENSE.txt "$out/share/licenses/dora-ssr/LICENSE.txt"
+    install -Dm644 LICENSES.3rdparty.md "$out/share/licenses/dora-ssr/LICENSES.3rdparty.md"
+    install -Dm644 Source/3rdParty/spine/LICENSE "$out/share/licenses/dora-ssr/Spine-Runtimes-License"
+    makeWrapper "$out/libexec/dora-ssr" "$out/bin/dora-ssr" \
+      --add-flags "--asset $out/share/dora-ssr/Assets" \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          alsa-lib
+          libpulseaudio
+          systemdLibs
+        ]
+      }"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    "$out/bin/dora-ssr" cli --help > /dev/null
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Cross-platform game engine for making 2D and 3D games";
+    homepage = "https://dora-ssr.net/";
+    license = [
+      lib.licenses.mit
+      lib.licenses.unfreeRedistributable
+    ];
+    maintainers = [ lib.maintainers.uuxyz ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "dora-ssr";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add Dora SSR game engine package.

Dora SSR is a cross-platform 2D/3D game engine with Lua scripting support. This package builds its bundled/forked engine components from source, including SDL2, bgfx, the Love2D subset, the Wa runtime, and the Rust runtime. These bundled components are statically linked into the Dora SSR executable, which remains dynamically linked to system libraries such as glibc, OpenGL, X11, and D-Bus.

Homepage: https://dora-ssr.net/

- License: MIT + Spine Runtimes License (`unfreeRedistributable`)
- Platforms: x86_64-linux, aarch64-linux
- Build time: ~20 minutes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

AI assistance disclosure: This contribution was prepared with non-trivial assistance from OpenAI Codex. I reviewed the changes and take responsibility for them.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test