### PR TITLE
python3Packages.parsedmarc: 10.4.3 -> 11.0.1

### DIFF
--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   fetchurl,
@@ -31,6 +32,8 @@
   xmltodict,
 
   # test
+  iana-etc,
+  libredirect,
   pytestCheckHook,
 }:
 
@@ -42,14 +45,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "parsedmarc";
-  version = "10.4.3";
+  version = "11.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "domainaware";
     repo = "parsedmarc";
     tag = finalAttrs.version;
-    hash = "sha256-q5Zc0iWDBuuYfesmB2r8BeE32EmVsFPiChnXLEwX+SE=";
+    hash = "sha256-tPGpYIKIi5TK5t4vwo/bUpVfgq4UhYW0IAn5sFYexrs=";
   };
 
   postPatch = ''
@@ -95,11 +98,15 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  preCheck = lib.optionalString stdenv.hostPlatform.isLinux ''
+    echo "nameserver 127.0.0.1" > resolv.conf
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf) \
+      LD_PRELOAD=${libredirect}/lib/libredirect.so
+  '';
+
   disabledTests = [
     # contacts DNS servers at 1.1.1.1 and 8.8.8.8
     "test_general_dns_settings_with_defaults"
-    "testErrorRaisedAfterRetriesExhausted"
-    "testTransientErrorIsRetried"
     # AssertionError
     "testWithoutAssumeUtcNaiveIsLocal"
   ];


### PR DESCRIPTION
Changelog: https://github.com/domainaware/parsedmarc/releases/tag/11.0.1

Addresses #559762 for `master`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
