### PR TITLE
knobkraft-orm: 2.7.2 -> 2.10.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -45,6 +45,10 @@
 
 - `databricks-cli` has been updated from `0.290.2` to `1.x.x`, the first major release. OAuth tokens for interactive logins (`auth_type = databricks-cli`) are now stored in the OS-native secure store by default (Secret Service on Linux) instead of `~/.databricks/token-cache.json`; cached tokens from older versions are not migrated, so run `databricks auth login` once per profile after upgrading. To keep the previous file-backed storage, set `DATABRICKS_AUTH_STORAGE=plaintext` or add `auth_storage = plaintext` under `[__settings__]` in `~/.databrickscfg`. Additionally, the `vector_search_endpoints` DABs resource renamed `min_qps` to `target_qps` (and the `vector-search-endpoints` command renamed `--min-qps` to `--target-qps`). See the [upstream changelog](https://github.com/databricks/cli/blob/main/CHANGELOG.md) for details.
 
+- `knobkraft-orm` has been updated from 2.7.2 to 2.10.0. Orm automatically backs up the database before attempting the schema migration introduced in 2.8.0.
+  For affected Roland JV/JD-Xi/XV synthesizers, use **Edit > Reindex patches...** after restarting Orm and before importing more patches. Duplicate sounds may merge, and recordings named by old fingerprints are not automatically renamed.
+  See the [upstream migration instructions](https://github.com/christofmuc/KnobKraft-orm/blob/2.10.0/docs/roland-fingerprints.md).
+
 - Gradle 7 has been removed because it is end-of-life. Please [upgrade to a newer version of Gradle](https://docs.gradle.org/current/userguide/upgrading_version_7.html).
 
 - `hurl` has been updated to `8.x.x` which has some breaking changes. See [upstream changelog](https://github.com/Orange-OpenSource/hurl/releases/tag/8.0.0) for details.

--- a/pkgs/by-name/kn/knobkraft-orm/package.nix
+++ b/pkgs/by-name/kn/knobkraft-orm/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  makeWrapper,
   pkg-config,
 
   gtk3,
@@ -38,18 +39,19 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "KnobKraft-orm";
 
-  version = "2.7.2";
+  version = "2.10.0";
 
   src = fetchFromGitHub {
     owner = "christofmuc";
     repo = "knobkraft-orm";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-1mPeiey0hbJmg5k9R06wnDIGDDxbOfRixQ0zoFa4zYA=";
+    hash = "sha256-5d1sYoNBLspBc8b8dwNS1H7dTSFiMBPHE7Ti1MV3Sv0=";
   };
 
   nativeBuildInputs = [
     cmake
+    makeWrapper
     pkg-config
   ];
 
@@ -84,18 +86,34 @@ stdenv.mkDerivation (finalAttrs: {
     libwebp
   ];
 
-  # Issue has been raised and should be resolved with next release.
-  # CMakeLists.txt needs three more lines to properly build.
+  # Archive toolchain workaround and version injection for sources without Git metadata.
+  # Upstream discussion: https://github.com/christofmuc/KnobKraft-orm/pull/486
   patches = [ ./temporary.patch ];
 
+  postPatch = ''
+    # Keep bundled adaptations and their support modules out of bin.
+    substituteInPlace adaptations/CMakeLists.txt \
+      --replace-fail 'DESTINATION bin' 'DESTINATION share/knobkraft-orm/adaptations'
+    # Update Python imports, discovery, built-in names and adaptation export.
+    substituteInPlace adaptations/GenericAdaptation.cpp \
+      --replace-fail 'getChildFile("adaptations")' 'getChildFile("../share/knobkraft-orm/adaptations")'
+  '';
+
   cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_INTERPROCEDURAL_OP" "off")
+    (lib.cmakeFeature "CMAKE_INTERPROCEDURAL_OPTIMIZATION" "OFF")
+    (lib.cmakeFeature "KNOBKRAFT_EXTERNAL_VERSION" finalAttrs.version)
     (lib.cmakeFeature "PYTHON_VERSION_TO_EMBED" "${python312.pythonVersion}")
   ];
 
   makeFlags = [
     "package"
   ];
+
+  postInstall = ''
+    # Embedded Python must find its own standard-library extension modules.
+    wrapProgram "$out/bin/KnobKraftOrm" \
+      --set PYTHONHOME "${python312}"
+  '';
 
   meta = {
     homepage = "https://github.com/christofmuc/KnobKraft-orm";

--- a/pkgs/by-name/kn/knobkraft-orm/temporary.patch
+++ b/pkgs/by-name/kn/knobkraft-orm/temporary.patch
@@ -34,7 +34,7 @@ index 1c7186e..39cebd0 100644
 -
 -# Start project
 -project(KnobKraftOrm VERSION ${PROJECT_VERSION})
-+project(KnobKraftOrm VERSION 2.7.1)
++project(KnobKraftOrm VERSION ${KNOBKRAFT_EXTERNAL_VERSION})
  
  # Now you can use PROJECT_DEV_TAG in your CMake scripts or in your code to handle the "-dev" part.
  # For example, you could add a preprocessor definition that your code could use:


### PR DESCRIPTION
Update KnobKraft Orm from 2.7.2 to 2.10.0, using the upstream release tag and a new source hash including submodules.

The existing downstream patch hardcodes the application's version as 2.7.1. Pass the package version through CMake instead, so the application and package agree and future updates do not need another patch edit. Also correct `CMAKE_INTERPROCEDURAL_OP` to `CMAKE_INTERPROCEDURAL_OPTIMIZATION` so CMake recognizes the existing option. Retain the existing archive workaround. Upstream PR https://github.com/christofmuc/KnobKraft-orm/pull/486 was closed without merging.

Install the 83 bundled Python adaptations and their five support packages under `share/knobkraft-orm/adaptations`. Update all four bundled-adaptation lookup locations so Python imports, discovery, built-in synth names and adaptation export use this directory. Wrap the launcher with `PYTHONHOME` pointing at the packaged Python 3.12 runtime, so standard-library extension modules such as `math`, `_struct` and `binascii` can be imported. Without these two fixes the application opens but lacks some or all Python synth support.

Related: https://github.com/NixOS/nixpkgs/pull/493880 is an open automated update to 2.9.0. This proposed update targets the newer upstream release and fixes the stale application version as well.

Release notes: https://github.com/christofmuc/KnobKraft-orm/releases/tag/2.10.0

Upgrade considerations: updates from 2.7.x cross the database migration introduced in 2.8.0; Orm automatically backs up the database before attempting the migration. Version 2.10.0 also requires an explicit reindex for affected Roland JV/JD-Xi/XV patches, and recordings named by old fingerprints are not automatically renamed. See https://github.com/christofmuc/KnobKraft-orm/blob/2.10.0/docs/roland-fingerprints.md and https://github.com/christofmuc/KnobKraft-orm/blob/2.10.0/release_notes/2.8.0.md.

## Validation

The exact PR commit `71d7582d2c0c01100d7ce8fc9ea0775761694e6b` built successfully on x86_64-linux using Nix 2.18.1 in Ubuntu 24.04 WSL2. Nix verified the source and submodule hash. The resulting store path was `/nix/store/13gf4wzskf8g0b71gpm8zxlqqpbkmk6z-KnobKraft-orm-2.10.0`.

The installed package contains all 83 Python adaptations and five support packages under `share/knobkraft-orm/adaptations`; `bin/adaptations` is absent. Starting the generated wrapper without manually setting `PYTHONHOME` opened the V2.10.0 main and Quick Access windows under Xvfb. The fresh application log contains 83 `Loaded module` entries and no warnings, errors, failures or tracebacks.

`nixpkgs-review pr 559948` completed successfully on x86_64-linux. It built `knobkraft-orm` and the affected `nixpkgs-manual`; its unrelated NixOS test-system entry was blacklisted by the tool. `Lint / treefmt`, parsing, nixpkgs-vet, commit checks and package evaluation passed in upstream CI. The initially rate-limited labeling job was rerun by Nixpkgs automation and now passes.

No hardware MIDI test was possible because WSL has no `/dev/snd/seq`. aarch64 builds and full interactive desktop use were not tested.

## Things done

- Built on platform:
  - [x] x86_64-linux.
  - [ ] aarch64-linux: not built.
- [x] Ran `nixpkgs-review` on x86_64-linux.
- [x] Tested the packaged launcher, application startup and all 83 Python adaptation imports.
- [x] Added the database upgrade and Roland reindexing notice to Nixpkgs release notes.
- [x] Reviewed contribution guidelines, commit conventions and disclosure requirements.
- [x] Follows the automation/AI policy; the changes were reviewed by @christofmuc before submission.

AI disclosure: OpenAI Codex using GPT-5.6-sol assisted with the packaging changes, investigation, validation commands and this description. The changes were reviewed by @christofmuc before submission.