### PR TITLE
pnpm_12: init at 12.3.4

### DIFF
--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -65,5 +65,14 @@ let
     );
 
   mkPnpm = versionSuffix: variant: nameValuePair "pnpm_${versionSuffix}" (callPnpm variant);
+
+  pnpm_12 = callPackage ./next.nix {
+    version = "12.3.4";
+    hash = "sha256-EAF5ZeABBX4Wdn08OVria9zKcTIJ8i9EIjb9gsaCAo4=";
+    cargoHash = "sha256-I54W1Ig6mn3/BsBiL5qc8aUZmSY2IGEY2QSXG0V1W1w=";
+  };
 in
-mapAttrs' mkPnpm variants
+(mapAttrs' mkPnpm variants)
+// {
+  inherit pnpm_12;
+}

--- a/pkgs/development/tools/pnpm/next.nix
+++ b/pkgs/development/tools/pnpm/next.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  pkg-config,
+  testers,
+
+  version,
+  hash,
+  cargoHash,
+  knownVulnerabilities ? [ ],
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pnpm";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "pnpm";
+    repo = "pnpm";
+    tag = "v${finalAttrs.version}";
+    inherit hash;
+  };
+
+  inherit cargoHash;
+
+  cargoBuildFlags = [
+    "--bin"
+    "pnpm"
+  ];
+
+  # Integration tests require running network and external fixtures
+  doCheck = false;
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
+
+  # TODO: find a proper way to provide pnpx/pnx (which run `pnpm dlx "$@"`).
+  postInstall = ''
+    install -d $out/bin
+    ln -s pnpm $out/bin/pn
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    $out/bin/pnpm completion bash > pnpm.bash
+    $out/bin/pnpm completion fish > pnpm.fish
+    $out/bin/pnpm completion zsh > pnpm.zsh
+    installShellCompletion pnpm.{bash,fish,zsh}
+  '';
+
+  passthru = {
+    tests = {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+      };
+    };
+  };
+
+  meta = {
+    description = "Fast, disk space efficient package manager for JavaScript";
+    homepage = "https://pnpm.io/";
+    changelog = "https://github.com/pnpm/pnpm/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      Scrumplex
+      gepbird
+    ];
+    platforms = lib.platforms.all;
+    mainProgram = "pnpm";
+    inherit knownVulnerabilities;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2733,6 +2733,7 @@ with pkgs;
     pnpm_10_34_0
     pnpm_10
     pnpm_11
+    pnpm_12
     ;
   pnpm = pnpm_11;
 


### PR DESCRIPTION
 This is an initial build attempt for pnpm 12, which has been rewritten in Rust upstream. I built and briefly used it locally, and it works fine. The default `pnpm` is kept as `pnpm_11` for now due to `pnpmBuildHook` etc.
 
cc @Scrumplex @gepbird

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
