### PR TITLE
libff: fix header installation with CMake 4.3+

### DIFF
--- a/pkgs/by-name/li/libff/package.nix
+++ b/pkgs/by-name/li/libff/package.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace CMakeLists.txt --replace "VERSION 2.8" "VERSION 3.10"
+    # CMake >= 4.3 treats install(DIRECTORY "" ...) as a no-op instead of
+    # installing the current source directory, so no headers get installed.
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/27568
+    substituteInPlace libff/CMakeLists.txt \
+      --replace-fail 'DIRECTORY "" DESTINATION "include/libff"' 'DIRECTORY "./" DESTINATION "include/libff"'
   ''
   + lib.optionalString (!enableStatic) ''
     substituteInPlace libff/CMakeLists.txt --replace "STATIC" "SHARED"


### PR DESCRIPTION
CMake 4.3 (commit 4e7e6928cb, "install: Fix bugs around empty directories") changed install(DIRECTORY "" ...): the empty string used to silently expand to the current source directory, and is now a no-op that creates the destination directory but installs nothing into it. libff uses that form for its headers, so since the cmake 4.3.4 bump the package ships an empty include/libff and dependents such as hevm fail to compile with:

  fatal error: libff/algebra/fields/bigint.hpp: No such file or directory

Replace the empty string with "./" so the header tree is installed again.

See https://gitlab.kitware.com/cmake/cmake/-/issues/27568

Assisted-by: Claude Code (Claude Fable 5.1)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
