### PR TITLE
catt: 0.13.1 -> 0.13.2

### DIFF
--- a/pkgs/by-name/ca/catt/package.nix
+++ b/pkgs/by-name/ca/catt/package.nix
@@ -1,16 +1,21 @@
 {
   lib,
-  fetchPypi,
+  fetchFromGitHub,
+  nix-update-script,
   python3Packages,
+  versionCheckHook,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "catt";
-  version = "0.13.1";
+  version = "0.13.2";
   pyproject = true;
+  __structuredAttrs = true;
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-hlCB06l4nzafvcnBNCXWiJsJNmP8n731bQgq5xvUZvM=";
+  src = fetchFromGitHub {
+    owner = "skorokithakis";
+    repo = "catt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VjwYfaBoQ7HMKG6BztAB3mmQps42MoHSAiC2jHbRS/Q=";
   };
 
   build-system = [
@@ -25,18 +30,33 @@ python3Packages.buildPythonApplication (finalAttrs: {
     python3Packages.yt-dlp
   ];
 
-  doCheck = false; # attempts to access various URLs
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Require network access.
+    "test_stream_info_youtube_video"
+    "test_stream_info_youtube_playlist"
+    "test_stream_info_other_video"
+    "test_stream_info_direct_link"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   pythonImportsCheck = [
     "catt"
   ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
-    description = "Send media from online sources to Chromecast devices";
+    description = "Allows you to send videos from many, many online sources to your Chromecast";
     homepage = "https://github.com/skorokithakis/catt";
     changelog = "https://github.com/skorokithakis/catt/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.aaravrav ];
     mainProgram = "catt";
   };
 })


### PR DESCRIPTION
Updated cat 0.13.1 -> 0.13.2
Added myself as the maintainer
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
