### PR TITLE
buzz-cli: 0.1.0-unstable-2026-08-27 -> 0.1.0-unstable-2026-09-02

### DIFF
--- a/pkgs/by-name/bu/buzz-cli/package.nix
+++ b/pkgs/by-name/bu/buzz-cli/package.nix
@@ -8,7 +8,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "buzz-cli";
-  version = "0.1.0-unstable-2026-08-27";
+  version = "0.1.0-unstable-2026-09-02";
   __structuredAttrs = true;
   __darwinAllowLocalNetworking = true;
   strictDeps = true;
@@ -16,11 +16,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "block";
     repo = "buzz";
-    rev = "0808ab485c39c3c12ef02af2188c65a5145eb99d";
-    hash = "sha256-+vYRX6yZmyWxtpcaQj62ujmcG2uwo3fdaX5Oo6Q1jEE=";
+    rev = "47d068e2109d077414cbf2f4f1c927f6d051037a";
+    hash = "sha256-sLIyStOy330KzzVF9QnIn27loT5QXCRz0U4NN9bxU40=";
   };
 
-  cargoHash = "sha256-y067FJWvsJAe6mvtnLPSW1YK0/gcBrKuZX45OCO8/2U=";
+  cargoHash = "sha256-q8FUmTHnPfy/Ub+TNs3UK3exOoX1GdZGwHkH5pDteKE=";
   cargoBuildFlags = [ "--package=buzz-cli" ];
   cargoTestFlags = [ "--package=buzz-cli" ];
 


### PR DESCRIPTION
Updates `buzz-cli` from `0.1.0-unstable-2026-08-27` to
`0.1.0-unstable-2026-09-02`, the latest upstream commit that changes
`crates/buzz-cli`.

Upstream change: [`47d068e`](https://github.com/block/buzz/commit/47d068e2109d077414cbf2f4f1c927f6d051037a)
adds the `buzz gifs` command group and NIP-30 emoji tags on messages. The source
and Cargo vendor hashes are updated accordingly.

## Validation

- `x86_64-linux`, natively on NixOS with sandboxing enabled:
  - `nix build .#buzz-cli` succeeded.
  - Rust tests: **463 passed, 0 failed**; one doc test ignored.
  - `buzz --help` and `buzz gifs --help` succeeded.
  - `nixpkgs-vet` reported `Validated successfully`.
  - `nixpkgs-review` built `buzz-cli` successfully.
- `aarch64-darwin`, natively on Apple Silicon:
  - `nix build .#buzz-cli` succeeded.
  - Rust tests: **463 passed, 0 failed**; one doc test ignored.
  - `buzz --help` and `buzz gifs --help` succeeded.
  - The result is an arm64 Mach-O executable.
- `nixfmt --check`, `git diff --check`, version evaluation, platform evaluation,
  and maintainer evaluation passed.

## Automation/AI disclosure

OpenAI Codex (gpt-5.6-sol) materially assisted with the package update,
validation, commit preparation, and this pull-request description. The commit
carries the required `Assisted-by: OpenAI Codex (gpt-5.6-sol)` trailer.

Sebastian W. Friedrich reviewed the complete final diff, validation evidence,
and pull-request text. He understands the changes and accepts responsibility for
their correctness, licensing, and published text.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR (`x86_64-linux`). See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
