### PR TITLE
gtksourceview: drop unversioned alias

### DIFF
--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -16,7 +16,7 @@
   glib,
   glib-networking,
   gtk3,
-  gtksourceview,
+  gtksourceview3,
   kakasi,
   keybinder3,
   libappindicator,
@@ -89,7 +89,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     glib
     glib-networking
     gtk3
-    gtksourceview
+    gtksourceview3
     kakasi
     keybinder3
     libappindicator

--- a/pkgs/by-name/de/denemo/package.nix
+++ b/pkgs/by-name/de/denemo/package.nix
@@ -15,7 +15,7 @@
   libsndfile,
   aubio,
   gtk3,
-  gtksourceview,
+  gtksourceview3,
   evince,
   fluidsynth,
   rubberband,
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsndfile
     aubio
     gtk3
-    gtksourceview
+    gtksourceview3
     evince
     fluidsynth
     rubberband

--- a/pkgs/by-name/lu/lutris/package.nix
+++ b/pkgs/by-name/lu/lutris/package.nix
@@ -18,7 +18,7 @@ let
   gnomeDeps =
     pkgs: with pkgs; [
       zenity
-      gtksourceview
+      gtksourceview3
       gnome-desktop
       libgnome-keyring
       webkitgtk_4_1

--- a/pkgs/by-name/ma/marker/package.nix
+++ b/pkgs/by-name/ma/marker/package.nix
@@ -8,7 +8,7 @@
   pkg-config,
   wrapGAppsHook3,
   gtk3,
-  gtksourceview,
+  gtksourceview3,
   gtkspell3,
   webkitgtk_4_1,
   pandoc,
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     gtk3
-    gtksourceview
+    gtksourceview3
     gtkspell3
     webkitgtk_4_1
     pandoc

--- a/pkgs/by-name/re/rednotebook/package.nix
+++ b/pkgs/by-name/re/rednotebook/package.nix
@@ -6,7 +6,7 @@
   glib,
   gobject-introspection,
   gtk3,
-  gtksourceview,
+  gtksourceview3,
   pango,
   webkitgtk_4_1,
 }:
@@ -34,7 +34,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     gdk-pixbuf
     glib
     gtk3
-    gtksourceview
+    gtksourceview3
     pango
     webkitgtk_4_1
   ]

--- a/pkgs/by-name/ya/yad/package.nix
+++ b/pkgs/by-name/ya/yad/package.nix
@@ -8,7 +8,7 @@
   gettext,
   gspell,
   gtk3,
-  gtksourceview,
+  gtksourceview3,
   libappindicator,
   netpbm,
   webkitgtk_4_1,
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gspell
     gtk3
-    gtksourceview
+    gtksourceview3
     libappindicator
     webkitgtk_4_1
   ];

--- a/pkgs/development/ocaml-modules/lablgtk3/sourceview3.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/sourceview3.nix
@@ -1,12 +1,12 @@
 {
   buildDunePackage,
-  gtksourceview,
+  gtksourceview3,
   lablgtk3,
 }:
 
 buildDunePackage {
   pname = "lablgtk3-sourceview3";
-  buildInputs = lablgtk3.buildInputs ++ [ gtksourceview ];
+  buildInputs = lablgtk3.buildInputs ++ [ gtksourceview3 ];
   propagatedBuildInputs = [ lablgtk3 ];
   inherit (lablgtk3)
     src

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1109,6 +1109,7 @@ mapAliases {
   gtklp = throw "'gtklp' has been removed, as it depended on GTK 2. Consider using 'system-config-printer' instead."; # Added 2026-05-22
   gtkmm2 = throw "'gtkmm2' has been removed as it depended on the deprecated gtk2. Consider using 'gtkmm3' or 'gtkmm4' instead."; # Added 2026-08-09
   gtkradiant = throw "'gtkradiant' has been removed, as it relies on gtk2"; # Added 2026-06-18
+  gtksourceview = throw "'gtksourceview' attribute has been removed from nixpkgs. Use a 'gtksourceview*' attribute with an explicit ABI version instead."; # Added 2026-09-04
   gtkspell2 = throw "'gtkspell2' has been removed as it depended on the deprecated GTK2 engine. Consider using 'gtkspell3' instead"; # Added 2026-07-23
   gtuber = throw "'gtuber' has been removed due to being discontinued by upstream."; # Added 2025-12-12
   gui-for-clash = throw "'gui-for-clash' has been removed, as it is unmaintained"; # Added 2026-05-28

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5795,8 +5795,6 @@ with pkgs;
 
   gtk-mac-integration-gtk3 = gtk-mac-integration;
 
-  gtksourceview = gtksourceview3;
-
   gtksourceview3 = callPackage ../development/libraries/gtksourceview/3.x.nix { };
 
   gtksourceview4 = callPackage ../development/libraries/gtksourceview/4.x.nix { };
@@ -9052,7 +9050,7 @@ with pkgs;
   };
 
   quodlibet-full = quodlibet.override {
-    inherit gtksourceview;
+    inherit gtksourceview3;
     kakasi = kakasi;
     keybinder3 = keybinder3;
     libappindicator = libappindicator;


### PR DESCRIPTION
Having the older ABI version as the default seems odd and the different gtksourceview packages appear to be fundamentally incompatible, so drop the unsuffixed version similar to webkitgtk and as discussed in https://github.com/NixOS/nixpkgs/pull/543345#issuecomment-5199018730.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
