### PR TITLE
python3Packages.jax: fix cuda support with cuda 13

### DIFF
--- a/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
@@ -105,8 +105,27 @@ buildPythonPackage (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ natsukium ];
     platforms = lib.attrNames platforms;
-    # see CUDA compatibility matrix
-    # https://jax.readthedocs.io/en/latest/installation.html#pip-installation-nvidia-gpu-cuda-installed-locally-harder
-    broken = !(lib.versionAtLeast cudaPackages.cudnn.version "9.1");
+    problems =
+      lib.optionalAttrs (cudaPackages.cudaMajorVersion != "12") {
+        unsupported-cuda-version = {
+          message = ''
+            Incompatible cudaPackages version.
+              - Expected: 12
+              - Got: ${cudaPackages.cudaMajorVersion}
+          '';
+          kind = "broken";
+        };
+      }
+      // lib.optionalAttrs (lib.versionAtLeast cudaPackages.cudnn.version "10.0") {
+        unsupported-cudnn-version = {
+          message = ''
+            cudaPackages.cudnn is too new (${cudaPackages.cudnn.version}).
+
+            See CUDA compatibility matrix
+            https://docs.jax.dev/en/latest/installation.html#pip-installation-nvidia-gpu-cuda-installed-locally-harder
+          '';
+          kind = "broken";
+        };
+      };
   };
 })

--- a/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
@@ -103,6 +103,7 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/jax-ml/jax/tree/main/jax_plugins/cuda";
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     license = lib.licenses.asl20;
+    teams = [ lib.teams.cuda ];
     maintainers = with lib.maintainers; [
       GaetanLepage
       natsukium

--- a/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
@@ -103,7 +103,10 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/jax-ml/jax/tree/main/jax_plugins/cuda";
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ natsukium ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      natsukium
+    ];
     platforms = lib.attrNames platforms;
     problems =
       lib.optionalAttrs (cudaPackages.cudaMajorVersion != "12") {

--- a/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
@@ -71,10 +71,12 @@ buildPythonPackage (finalAttrs: {
   # * https://github.com/NixOS/nixpkgs/pull/288829#discussion_r1493852211
   # for more info.
   postInstall = ''
-    mkdir -p $out/${python.sitePackages}/jax_plugins/nvidia/cuda_nvcc/bin
-    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "ptxas"} $out/${python.sitePackages}/jax_plugins/nvidia/cuda_nvcc/bin/ptxas
-    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "nvlink"} $out/${python.sitePackages}/jax_plugins/nvidia/cuda_nvcc/bin/nvlink
-    ln -s ${cudaPackages.cuda_nvcc}/nvvm $out/${python.sitePackages}/jax_plugins/nvidia/cuda_nvcc/nvvm
+    export OUTPATH="$out/${python.sitePackages}/jax_plugins/nvidia/cuda_nvcc"
+    export BINPATH="$OUTPATH/bin"
+    mkdir -p $BINPATH
+    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "ptxas"} $BINPATH/ptxas
+    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "nvlink"} $BINPATH/nvlink
+    ln -s ${cudaPackages.cuda_nvcc}/nvvm $OUTPATH/nvvm
   '';
 
   # jax-cuda12-pjrt contains shared libraries that open other shared libraries via dlopen

--- a/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
@@ -70,9 +70,10 @@ buildPythonPackage {
   # * https://github.com/NixOS/nixpkgs/pull/375186
   # for more info.
   postInstall = ''
-    mkdir -p $out/${python.sitePackages}/jax_cuda12_plugin/cuda/bin
-    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "ptxas"} $out/${python.sitePackages}/jax_cuda12_plugin/cuda/bin
-    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "nvlink"} $out/${python.sitePackages}/jax_cuda12_plugin/cuda/bin
+    export BINPATH="$out/${python.sitePackages}/jax_cuda12_plugin/cuda/bin"
+    mkdir -p $BINPATH
+    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "ptxas"} $BINPATH/ptxas
+    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "nvlink"} $BINPATH/nvlink
   '';
 
   # jax-cuda12-plugin contains shared libraries that open other shared libraries via dlopen

--- a/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
@@ -98,6 +98,7 @@ buildPythonPackage {
     homepage = "https://github.com/jax-ml/jax/tree/main/jax_plugins/cuda";
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     license = lib.licenses.asl20;
+    teams = [ lib.teams.cuda ];
     maintainers = with lib.maintainers; [
       GaetanLepage
       natsukium

--- a/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
@@ -98,7 +98,10 @@ buildPythonPackage {
     homepage = "https://github.com/jax-ml/jax/tree/main/jax_plugins/cuda";
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ natsukium ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      natsukium
+    ];
     platforms = lib.attrNames platforms;
     problems =
       lib.optionalAttrs (cudaPackages.cudaMajorVersion != "12") {

--- a/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
@@ -100,8 +100,27 @@ buildPythonPackage {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ natsukium ];
     platforms = lib.attrNames platforms;
-    # see CUDA compatibility matrix
-    # https://jax.readthedocs.io/en/latest/installation.html#pip-installation-nvidia-gpu-cuda-installed-locally-harder
-    broken = !(lib.versionAtLeast cudaPackages.cudnn.version "9.1");
+    problems =
+      lib.optionalAttrs (cudaPackages.cudaMajorVersion != "12") {
+        unsupported-cuda-version = {
+          message = ''
+            Incompatible cudaPackages version.
+              - Expected: 12
+              - Got: ${cudaPackages.cudaMajorVersion}
+          '';
+          kind = "broken";
+        };
+      }
+      // lib.optionalAttrs (lib.versionAtLeast cudaPackages.cudnn.version "10.0") {
+        unsupported-cudnn-version = {
+          message = ''
+            cudaPackages.cudnn is too new (${cudaPackages.cudnn.version}).
+
+            See CUDA compatibility matrix
+            https://docs.jax.dev/en/latest/installation.html#pip-installation-nvidia-gpu-cuda-installed-locally-harder
+          '';
+          kind = "broken";
+        };
+      };
   };
 }

--- a/pkgs/development/python-modules/jax-cuda13-pjrt/default.nix
+++ b/pkgs/development/python-modules/jax-cuda13-pjrt/default.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  addDriverRunpath,
+  autoPatchelfHook,
+  pypaInstallHook,
+  wheelUnpackHook,
+  cudaPackages,
+  python,
+  jaxlib,
+}:
+let
+  inherit (jaxlib) version;
+
+  platforms = {
+    x86_64-linux = {
+      name = "manylinux_2_27_x86_64";
+      hash = "sha256-TKiiYaVIWtuFL96VTkuRRfVCwNivRwSojgX67jVBryE=";
+    };
+    aarch64-linux = {
+      name = "manylinux_2_27_aarch64";
+      hash = "sha256-gZx0TjXd8Cckv0WWpijSvjhzaah82mBXUTfuQ37NeXo=";
+    };
+  };
+  currentPlatform = platforms.${stdenv.hostPlatform.system};
+
+  cudaLibPath = lib.makeLibraryPath (
+    with cudaPackages;
+    [
+      (lib.getLib libcublas) # libcublas.so
+      (lib.getLib cuda_cupti) # libcupti.so
+      (lib.getLib cuda_cudart) # libcudart.so
+      (lib.getLib cudnn) # libcudnn.so
+      (lib.getLib libcufft) # libcufft.so
+      (lib.getLib libcusolver) # libcusolver.so
+      (lib.getLib libcusparse) # libcusparse.so
+      (lib.getLib nccl) # libnccl.so
+      (lib.getLib libnvjitlink) # libnvJitLink.so
+      (lib.getLib addDriverRunpath.driverLink) # libcuda.so
+    ]
+  );
+
+in
+buildPythonPackage (finalAttrs: {
+  pname = "jax-cuda13-pjrt";
+  inherit version;
+  pyproject = false;
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "jax_cuda13_pjrt";
+    inherit version;
+    format = "wheel";
+    python = "py3";
+    dist = "py3";
+    platform = currentPlatform.name;
+    inherit (currentPlatform) hash;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    pypaInstallHook
+    wheelUnpackHook
+  ];
+
+  # jax-cuda13-pjrt looks for ptxas, nvlink and nvvm at runtime, eg when running `jax.random.PRNGKey(0)`.
+  # Linking into $out is the least bad solution. See
+  # * https://github.com/NixOS/nixpkgs/pull/164176#discussion_r828801621
+  # * https://github.com/NixOS/nixpkgs/pull/288829#discussion_r1493852211
+  # for more info.
+  postInstall = ''
+    export OUTPATH="$out/${python.sitePackages}/jax_plugins/nvidia/cu13"
+    export BINPATH="$OUTPATH/bin"
+    mkdir -p $BINPATH
+    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "ptxas"} $BINPATH/ptxas
+    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "nvlink"} $BINPATH/nvlink
+    ln -s ${cudaPackages.cuda_nvcc}/nvvm $OUTPATH/nvvm
+  '';
+
+  # jax-cuda13-pjrt contains shared libraries that open other shared libraries via dlopen
+  # and these implicit dependencies are not recognized by ldd or
+  # autoPatchelfHook. That means we need to sneak them into rpath. This step
+  # must be done after autoPatchelfHook and the automatic stripping of
+  # artifacts. autoPatchelfHook runs in postFixup and auto-stripping runs in the
+  # patchPhase.
+  preInstallCheck = ''
+    patchelf --add-rpath "${cudaLibPath}" $out/${python.sitePackages}/jax_plugins/xla_cuda13/xla_cuda_plugin.so
+  '';
+
+  # FIXME: there are no tests, but we need to run preInstallCheck above
+  doCheck = true;
+
+  pythonImportsCheck = [ "jax_plugins" ];
+
+  passthru = {
+    inherit cudaLibPath;
+  };
+
+  meta = {
+    description = "JAX XLA PJRT Plugin for NVIDIA GPUs";
+    homepage = "https://github.com/jax-ml/jax/tree/main/jax_plugins/cuda";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.cuda ];
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.attrNames platforms;
+    problems =
+      lib.optionalAttrs (cudaPackages.cudaMajorVersion != "13") {
+        unsupported-cuda-version = {
+          message = ''
+            Incompatible cudaPackages version.
+              - Expected: 13
+              - Got: ${cudaPackages.cudaMajorVersion}
+          '';
+          kind = "broken";
+        };
+      }
+      // lib.optionalAttrs (lib.versionAtLeast cudaPackages.cudnn.version "10.0") {
+        unsupported-cudnn-version = {
+          message = ''
+            cudaPackages.cudnn is too new (${cudaPackages.cudnn.version}).
+
+            See CUDA compatibility matrix
+            https://docs.jax.dev/en/latest/installation.html#pip-installation-nvidia-gpu-cuda-installed-locally-harder
+          '';
+          kind = "broken";
+        };
+      };
+  };
+})

--- a/pkgs/development/python-modules/jax-cuda13-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda13-plugin/default.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  autoPatchelfHook,
+  pypaInstallHook,
+  wheelUnpackHook,
+  cudaPackages,
+  python,
+  jaxlib,
+  jax-cuda13-pjrt,
+}:
+let
+  inherit (jaxlib) version;
+  inherit (jax-cuda13-pjrt) cudaLibPath;
+
+  platforms = {
+    x86_64-linux = {
+      name = "manylinux_2_27_x86_64";
+      hashes = {
+        cp312 = "sha256-2zSLkZmBC+W1OAwRObTUgC1t7G8Mpr8Z/LgYgFNB9ZA=";
+        cp313 = "sha256-C1ebRy0AbJPOUGORCbdkhfLReJ3k4b+fAOz2eXN9Jf0=";
+        cp314 = "sha256-6CAG8dgVLjTPUySYWk1tcKHfrSXSWzP6Qhfhh8Z9vNI=";
+      };
+    };
+    aarch64-linux = {
+      name = "manylinux_2_27_aarch64";
+      hashes = {
+        cp312 = "sha256-9udjg5/ChxzqewgrphHNOlufxQhstED7tMkgmPmxtWc=";
+        cp313 = "sha256-TqmizXyPmKVGVCF1mZW1HntI20yopYFFvOUyYnYC2CA=";
+        cp314 = "sha256-74XFhZxLy91yNLtvh152zfh0ElzV4eZBfJVzfUzeRNc=";
+      };
+    };
+  };
+  currentPlatform =
+    platforms.${stdenv.hostPlatform.system}
+      or (throw "jax-cuda13-plugin is not supported on ${stdenv.hostPlatform.system}");
+
+  dist = "cp${lib.replaceStrings [ "." ] [ "" ] python.pythonVersion}";
+in
+buildPythonPackage {
+  pname = "jax-cuda13-plugin";
+  inherit version;
+  pyproject = false;
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "jax_cuda13_plugin";
+    inherit version dist;
+    format = "wheel";
+    python = dist;
+    abi = dist;
+    platform = currentPlatform.name;
+    hash =
+      currentPlatform.hashes.${dist}
+        or (throw "python${python.pythonVersion}Packages.jax-cuda12-plugin is not supported");
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    pypaInstallHook
+    wheelUnpackHook
+  ];
+
+  # jax-cuda13-plugin looks for ptxas at runtime, e.g. with a triton kernel.
+  # Linking into $out is the least bad solution. See
+  # * https://github.com/NixOS/nixpkgs/pull/164176#discussion_r828801621
+  # * https://github.com/NixOS/nixpkgs/pull/288829#discussion_r1493852211
+  # * https://github.com/NixOS/nixpkgs/pull/375186
+  # for more info.
+  postInstall = ''
+    export BINPATH="$out/${python.sitePackages}/jax_cuda13_plugin/cuda/bin"
+    mkdir -p $BINPATH
+    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "ptxas"} $BINPATH
+    ln -s ${lib.getExe' cudaPackages.cuda_nvcc "nvlink"} $BINPATH
+  '';
+
+  # jax-cuda12-plugin contains shared libraries that open other shared libraries via dlopen
+  # and these implicit dependencies are not recognized by ldd or
+  # autoPatchelfHook. That means we need to sneak them into rpath. This step
+  # must be done after autoPatchelfHook and the automatic stripping of
+  # artifacts. autoPatchelfHook runs in postFixup and auto-stripping runs in the
+  # patchPhase.
+  preInstallCheck = ''
+    patchelf --add-rpath "${cudaLibPath}" $out/${python.sitePackages}/jax_cuda13_plugin/*.so
+  '';
+
+  dependencies = [ jax-cuda13-pjrt ];
+
+  pythonImportsCheck = [ "jax_cuda13_plugin" ];
+
+  # FIXME: there are no tests, but we need to run preInstallCheck above
+  doCheck = true;
+
+  meta = {
+    description = "JAX Plugin for CUDA13";
+    homepage = "https://github.com/jax-ml/jax/tree/main/jax_plugins/cuda";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.cuda ];
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.attrNames platforms;
+    problems =
+      lib.optionalAttrs (cudaPackages.cudaMajorVersion != "13") {
+        unsupported-cuda-version = {
+          message = ''
+            Incompatible cudaPackages version.
+              - Expected: 13
+              - Got: ${cudaPackages.cudaMajorVersion}
+          '';
+          kind = "broken";
+        };
+      }
+      // lib.optionalAttrs (lib.versionAtLeast cudaPackages.cudnn.version "10.0") {
+        unsupported-cudnn-version = {
+          message = ''
+            cudaPackages.cudnn is too new (${cudaPackages.cudnn.version}).
+
+            See CUDA compatibility matrix
+            https://docs.jax.dev/en/latest/installation.html#pip-installation-nvidia-gpu-cuda-installed-locally-harder
+          '';
+          kind = "broken";
+        };
+      };
+  };
+}

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -101,11 +101,7 @@ buildPythonPackage (finalAttrs: {
     pytest-xdist
   ];
 
-  # high parallelism will result in the tests getting stuck
-  dontUsePytestXdist = true;
-
   pytestFlags = [
-    "--numprocesses=4"
     "-Wignore::DeprecationWarning"
   ];
 

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -7,6 +7,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   cudaSupport ? config.cudaSupport,
+  cudaPackages,
 
   # build-system
   setuptools,
@@ -20,6 +21,7 @@
 
   # optional-dependencies
   jax-cuda12-plugin,
+  jax-cuda13-plugin,
 
   # tests
   absl-py,
@@ -69,11 +71,25 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.optionals cudaSupport finalAttrs.passthru.optional-dependencies.cuda;
 
-  optional-dependencies = lib.fix (self: {
-    cuda = [ jax-cuda12-plugin ];
-    cuda12 = self.cuda;
-    cuda12_local = self.cuda;
-  });
+  optional-dependencies =
+    let
+      inherit (cudaPackages) cudaMajorVersion;
+      cuda12 = [ jax-cuda12-plugin ];
+      cuda13 = [ jax-cuda13-plugin ];
+    in
+    {
+      cuda =
+        if cudaMajorVersion == "12" then
+          cuda12
+        else if cudaMajorVersion == "13" then
+          cuda13
+        else
+          throw "Unsupported cudaPackages version (${cudaMajorVersion}). Supported versions are 12 and 13.";
+      cuda12 = cuda12;
+      cuda12_local = cuda12;
+      cuda13 = cuda13;
+      cuda13_local = cuda13;
+    };
 
   nativeCheckInputs = [
     absl-py
@@ -101,13 +117,18 @@ buildPythonPackage (finalAttrs: {
     "tests/"
   ];
 
-  # Prevents `tests/export_back_compat_test.py::CompatTest::test_*` tests from failing on darwin with
-  # PermissionError: [Errno 13] Permission denied: '/tmp/back_compat_testdata/test_*.py'
-  # See https://github.com/google/jax/blob/jaxlib-v0.4.27/jax/_src/internal_test_util/export_back_compat_test_util.py#L240-L241
-  # NOTE: this doesn't seem to be an issue on linux
-  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    export TEST_UNDECLARED_OUTPUTS_DIR=$(mktemp -d)
-  '';
+  preCheck =
+    # Prevents `tests/export_back_compat_test.py::CompatTest::test_*` tests from failing on darwin with
+    # PermissionError: [Errno 13] Permission denied: '/tmp/back_compat_testdata/test_*.py'
+    # See https://github.com/google/jax/blob/jaxlib-v0.4.27/jax/_src/internal_test_util/export_back_compat_test_util.py#L240-L241
+    # NOTE: this doesn't seem to be an issue on linux
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export TEST_UNDECLARED_OUTPUTS_DIR=$(mktemp -d)
+    ''
+    # Disable CUDA during tests when cudaSupport is enabled but no GPU is available
+    + lib.optionalString cudaSupport ''
+      export JAX_PLATFORMS=cpu
+    '';
 
   disabledTests = [
     # Exceeds tolerance when the machine is busy
@@ -128,6 +149,13 @@ buildPythonPackage (finalAttrs: {
     "test_custom_linear_solve_cholesky"
     "test_custom_root_with_aux"
     "testEigvalsGrad_shape"
+  ]
+  ++ lib.optionals cudaSupport [
+    # AssertionError: 'INFO' not found in "DEBUG:2026-09-05 10:11:42,262:jax._src.path:40: etils.epath was not found...
+    "test_subprocess_stderr_debug_logging"
+
+    # AssertionError: 'INFO' not found in 'I0905 10:11:44.349869   24500 pjrt_api.cc:119] GetPjrtApi was found for cuda at...
+    "test_subprocess_stderr_info_logging"
   ]
   ++ lib.optionals stdenv.hostPlatform.isx86_64 [
     # The Mosaic GPU interpreter emulates tcgen05 MMA on the CPU backend and compares the

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -194,6 +194,7 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/jax-ml/jax";
     changelog = "https://docs.jax.dev/en/latest/changelog.html";
     license = lib.licenses.asl20;
+    teams = [ lib.teams.cuda ];
     maintainers = with lib.maintainers; [
       GaetanLepage
       samuela

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -175,18 +175,19 @@ buildPythonPackage (finalAttrs: {
   # Run these tests with eg
   #
   #   NIXPKGS_ALLOW_UNFREE=1 nixglhost -- nix run --impure .#python3Packages.jax.passthru.tests.test_cuda_jaxlibBin
-  passthru.tests = {
-    # jaxlib-build is broken as of 2024-12-20
-    # test_cuda_jaxlibSource = callPackage ./test-cuda.nix {
-    #   jax = jax.override { jaxlib = jaxlib-build; };
-    # };
-    test_cuda_jaxlibBin = callPackage ./test-cuda.nix {
-      jax = jax.override { jaxlib = jaxlib-bin; };
+  passthru = {
+    tests = {
+      # jaxlib-build is broken as of 2024-12-20
+      # test_cuda_jaxlibSource = callPackage ./test-cuda.nix {
+      #   jax = jax.override { jaxlib = jaxlib-build; };
+      # };
+      test_cuda_jaxlibBin = callPackage ./test-cuda.nix {
+        jax = jax.override { jaxlib = jaxlib-bin; };
+      };
+      # updater fails to pick the correct branch
+      skipBulkUpdate = true;
     };
   };
-
-  # updater fails to pick the correct branch
-  passthru.skipBulkUpdate = true;
 
   meta = {
     description = "Source-built JAX frontend: differentiate, compile, and transform Numpy code";

--- a/pkgs/development/python-modules/jaxlib/prefetch.sh
+++ b/pkgs/development/python-modules/jaxlib/prefetch.sh
@@ -16,6 +16,8 @@ for py in "312" "313" "314"; do
   prefetch "$py" "aarch64-darwin" "jaxlib-bin"
   prefetch "$py" "x86_64-linux" "jax-cuda12-plugin"
   prefetch "$py" "aarch64-linux" "jax-cuda12-plugin"
+  prefetch "$py" "x86_64-linux" "jax-cuda13-plugin"
+  prefetch "$py" "aarch64-linux" "jax-cuda13-plugin"
 done
 
 for arch in "x86_64-linux" "aarch64-linux"; do

--- a/pkgs/development/python-modules/jaxlib/prefetch.sh
+++ b/pkgs/development/python-modules/jaxlib/prefetch.sh
@@ -20,4 +20,5 @@ done
 
 for arch in "x86_64-linux" "aarch64-linux"; do
   prefetch "312" "$arch" "jax-cuda12-pjrt"
+  prefetch "312" "$arch" "jax-cuda13-pjrt"
 done

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8694,6 +8694,8 @@ self: super: with self; {
 
   jax-cuda13-pjrt = callPackage ../development/python-modules/jax-cuda13-pjrt { };
 
+  jax-cuda13-plugin = callPackage ../development/python-modules/jax-cuda13-plugin { };
+
   jax-jumpy = callPackage ../development/python-modules/jax-jumpy { };
 
   jax-tap = callPackage ../development/python-modules/jax-tap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8692,6 +8692,8 @@ self: super: with self; {
 
   jax-cuda12-plugin = callPackage ../development/python-modules/jax-cuda12-plugin { };
 
+  jax-cuda13-pjrt = callPackage ../development/python-modules/jax-cuda13-pjrt { };
+
   jax-jumpy = callPackage ../development/python-modules/jax-jumpy { };
 
   jax-tap = callPackage ../development/python-modules/jax-tap { };


### PR DESCRIPTION


## Things done

```
gaetan in 🌐 cuda in nixpkgs on  master [!]
❯ python -c "import jax; print(jax.devices())"
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1788556283.098583 1802767 cudart_stub.cc:31] Could not find cuda drivers on your machine, GPU will not be used.
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1788556283.104447 1802767 cudart_stub.cc:31] Could not find cuda drivers on your machine, GPU will not be used.
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1788556283.105113 1802767 cudart_stub.cc:31] Could not find cuda drivers on your machine, GPU will not be used.
Jax plugin configuration error: Exception when calling jax_plugins.xla_cuda12.initialize()
Traceback (most recent call last):
  File "/nix/store/xl7sik3pggjslja81myqzav5p5syb5yn-python3-3.14.7-env/lib/python3.14/site-packages/jax_plugins/xla_cuda12/__init__.py", line 201, in _version_check
    version = get_version()
RuntimeError: jaxlib/cuda/versions_helpers.cc:38: operation cudaRuntimeGetVersion(&version) failed: Error loading CUDA libraries. GPU will not be used.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/nix/store/xl7sik3pggjslja81myqzav5p5syb5yn-python3-3.14.7-env/lib/python3.14/site-packages/jax/_src/xla_bridge.py", line 495, in discover_pjrt_plugins
    plugin_module.initialize()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/nix/store/xl7sik3pggjslja81myqzav5p5syb5yn-python3-3.14.7-env/lib/python3.14/site-packages/jax_plugins/xla_cuda12/__init__.py", line 370, in initialize
    _check_cuda_versions(raise_on_first_error = True)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/xl7sik3pggjslja81myqzav5p5syb5yn-python3-3.14.7-env/lib/python3.14/site-packages/jax_plugins/xla_cuda12/__init__.py", line 233, in _check_cuda_versions
    _version_check("CUDA", cuda_versions.cuda_runtime_get_version,
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   cuda_versions.cuda_runtime_build_version,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   scale_for_comparison=10,
                   ^^^^^^^^^^^^^^^^^^^^^^^^
                   min_supported_version=12010)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/xl7sik3pggjslja81myqzav5p5syb5yn-python3-3.14.7-env/lib/python3.14/site-packages/jax_plugins/xla_cuda12/__init__.py", line 205, in _version_check
    raise RuntimeError(err_msg) from e
RuntimeError: Unable to load CUDA. Is it installed?
An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.
[CpuDevice(id=0)]
```

- **python3Packages.jax-cuda12-pjrt: cleanup postInstall**
- **python3Packages.jax-cuda12-pjrt: use meta.problems to handle cuda compat**
- **python3Packages.jax-cuda12-pjrt: add GaetanLepage to maintainers**
- **python3Packages.jax-cuda12-pjrt: add cuda to meta.teams**
- **python3Packages.jax-cuda12-plugin: cleanup postInstall**
- **python3Packages.jax-cuda12-plugin: use meta.problems to handle cuda compat**
- **python3Packages.jax-cuda12-plugin: add GaetanLepage to maintainers**
- **python3Packages.jax-cuda12-plugin: add cuda to meta.teams**
- **python3Packages.jax-cuda13-pjrt: init at 0.11.1**
- **python3Packages.jax-cuda13-plugin: init at 0.11.1**
- **python3Packages.jax: fix cuda support with cuda 13**
- **python3Packages.jax: enable pytest-xdist**
- **python3Packages.jax: passthru cleanup**
- **python3Packages.jax: add cuda to meta.teams**

cc @NixOS/cuda-maintainers

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
