### PR TITLE
python3Packages.pysdl3: 0.9.11b1 -> 0.9.12b1

### DIFF
--- a/pkgs/development/python-modules/pysdl3/default.nix
+++ b/pkgs/development/python-modules/pysdl3/default.nix
@@ -19,18 +19,18 @@
 let
   dochash =
     if stdenv.hostPlatform.isLinux then
-      "sha256-7Uc1kfbfizpRmAr5h3rpTX565wvbZfbbbYcJh9s96DY="
+      "sha256-mTuEUOWfGR0BGg+NCRi2ybtXPcYH+NaPi7Ov1yXihBY="
     else if stdenv.hostPlatform.isDarwin then
-      "sha256-gumVIn/st/mgdPpQA/BLZD0sI5qLf1EJRQ90rKLXjvQ="
+      "sha256-U/N2wrRL0DSWlfz5b1mmbbVUGzQx1+oax+mHaswufFc="
     else if stdenv.hostPlatform.isWindows then
-      "sha256-55Ti6HUzlptSf9ozaz0kmYMz+6EAcOcnZ0R64rZYISY="
+      "sha256-laj/aX4AAmLnIDlp/hiftOH3vJo41anfIGZm0pBHpgM="
     else
       throw "PySDL3 does not support ${stdenv.hostPlatform.uname.system}";
   lib_ext = stdenv.hostPlatform.extensions.sharedLibrary;
 in
 buildPythonPackage rec {
   pname = "pysdl3";
-  version = "0.9.11b1";
+  version = "0.9.12b1";
   pyproject = true;
 
   pythonImportsCheck = [ "sdl3" ];
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     owner = "Aermoss";
     repo = "PySDL3";
     tag = "v${version}";
-    hash = "sha256-fATBYZ4DYpOYYr09SwfODaWqEwQtig0smqI2Pjnv9uo=";
+    hash = "sha256-CI/WQ6JxcyUVYZh0AJQMkdh1YGXZAO/xf3sZcjbqkIY=";
   };
 
   docfile = fetchurl {


### PR DESCRIPTION
Update package (using the update script) and dochashes.

Haven't got around to figuring out the right set of update combinators to get hashes updated with the actual package, so it's still done manually (in the repl using fetchurl).

This update seems to mirror SDL3 changes (3.4.8 -> 3.4.16): https://github.com/Aermoss/PySDL3/compare/v0.9.11b1...v0.9.12b1.
The SDL3 update [was merged into staging](https://github.com/NixOS/nixpkgs/pull/559287) a couple days ago and is not yet in master, but that shouldn't be a practical issue.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
    - dochash is correct
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x[ Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
