### PR TITLE
execline: prepend target triple to pkg-config calls when cross

### DIFF
--- a/pkgs/development/skaware-packages/build-skaware-package.nix
+++ b/pkgs/development/skaware-packages/build-skaware-package.nix
@@ -90,7 +90,7 @@ lib.extendMkDerivation {
           "--with-sysdep-devurandom=yes"
           (if stdenv.hostPlatform.isDarwin then "--disable-shared" else "--enable-shared")
           # Use pkg-config
-          "--with-pkgconfig=pkg-config"
+          "--with-pkgconfig=${stdenv.cc.targetPrefix}pkg-config"
           "--enable-pkgconfig"
         ]
         # On Darwin, the target triplet from -dumpmachine includes version number,

--- a/pkgs/development/skaware-packages/execline/default.nix
+++ b/pkgs/development/skaware-packages/execline/default.nix
@@ -4,6 +4,7 @@
   skalibs,
   execline,
   writeTextFile,
+  stdenv,
 }:
 
 let
@@ -70,10 +71,10 @@ skawarePackages.buildPackage {
       -Wall -Wpedantic \
       -D "EXECLINEB_PATH()=\"$bin/bin/.execlineb-wrapped\"" \
       -D "EXECLINE_BIN_PATH()=\"$bin/bin\"" \
-      $(pkg-config --cflags libskarnet) \
+      $(${stdenv.cc.targetPrefix}pkg-config --cflags libskarnet) \
       -o "$bin/bin/execlineb" \
       ${./execlineb-wrapper.c} \
-      $(pkg-config --libs libskarnet)
+      $(${stdenv.cc.targetPrefix}pkg-config --libs libskarnet)
   '';
 
   # Write an execline script.


### PR DESCRIPTION
This is a fix for https://github.com/NixOS/nixpkgs/issues/559916. I don't know if it's the best possible fix


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
