### PR TITLE
nixos/throttled: restart service when configuration changes

### DIFF
--- a/nixos/modules/services/hardware/throttled.nix
+++ b/nixos/modules/services/hardware/throttled.nix
@@ -23,7 +23,10 @@ in
   config = lib.mkIf cfg.enable {
     systemd.packages = [ pkgs.throttled ];
     # The upstream package has this in Install, but that's not enough, see the NixOS manual
-    systemd.services.throttled.wantedBy = [ "multi-user.target" ];
+    systemd.services.throttled = {
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ config.environment.etc."throttled.conf".source ];
+    };
 
     environment.etc."throttled.conf".source =
       if cfg.extraConfig != "" then


### PR DESCRIPTION
Changing `services.throttled.extraConfig` updates `/etc/throttled.conf` without changing the service unit, leaving the running daemon on its previous configuration. Add the configuration source to `restartTriggers` so a configuration change schedules a restart during activation.

Validation on x86_64-linux: evaluated disabled, default and custom configurations; the disabled case adds neither the service nor the configuration file. Built `system.build.etc` for the default and custom cases and verified that each generated `X-Restart-Triggers` contains its configuration source and changes between the two. Official treefmt and `git diff --check` passed. No live service activation or NixOS VM test was run.

Implementation and validation were assisted by OpenAI Codex (gpt-5.6-sol and gpt-5.6-luna), including the evaluation harness. This PR description was also prepared with OpenAI Codex.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
