### PR TITLE
nixos/bash: make startup guards nounset-safe

### DIFF
--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -77,16 +77,16 @@ in
       promptInit = lib.mkOption {
         default = ''
           # Provide a nice prompt if the terminal supports it.
-          if [ "$TERM" != "dumb" ] || [ -n "$INSIDE_EMACS" ]; then
+          if [ "''${TERM:-}" != "dumb" ] || [ -n "''${INSIDE_EMACS:-}" ]; then
             PROMPT_COLOR="1;31m"
             ((UID)) && PROMPT_COLOR="1;32m"
-            if [ -n "$INSIDE_EMACS" ]; then
+            if [ -n "''${INSIDE_EMACS:-}" ]; then
               # Emacs term mode doesn't support xterm title escape sequence (\e]0;)
               PS1="\n\[\033[$PROMPT_COLOR\][\u@\h:\w]\\$\[\033[0m\] "
             else
               PS1="\n\[\033[$PROMPT_COLOR\][\[\e]0;\u@\h: \w\a\]\u@\h:\w]\\$\[\033[0m\] "
             fi
-            if test "$TERM" = "xterm"; then
+            if test "''${TERM:-}" = "xterm"; then
               PS1="\[\033]2;\h:\u:\w\007\]$PS1"
             fi
           fi
@@ -131,7 +131,7 @@ in
       shellAliases = builtins.mapAttrs (name: lib.mkDefault) cfge.shellAliases;
 
       shellInit = ''
-        if [ -z "$__NIXOS_SET_ENVIRONMENT_DONE" ]; then
+        if [ -z "''${__NIXOS_SET_ENVIRONMENT_DONE:-}" ]; then
             . ${config.system.build.setEnvironment}
         fi
 
@@ -158,7 +158,7 @@ in
       # This file is read for login shells.
 
       # Only execute this file once per shell.
-      if [ -n "$__ETC_PROFILE_SOURCED" ]; then return; fi
+      if [ -n "''${__ETC_PROFILE_SOURCED:-}" ]; then return; fi
       __ETC_PROFILE_SOURCED=1
 
       # Prevent this file from being sourced by interactive non-login child shells.
@@ -181,18 +181,18 @@ in
       # /etc/bashrc: DO NOT EDIT -- this file has been generated automatically.
 
       # Only execute this file once per shell.
-      if [ -n "$__ETC_BASHRC_SOURCED" ] || [ -n "$NOSYSBASHRC" ]; then return; fi
+      if [ -n "''${__ETC_BASHRC_SOURCED:-}" ] || [ -n "''${NOSYSBASHRC:-}" ]; then return; fi
       __ETC_BASHRC_SOURCED=1
 
       # If the profile was not loaded in a parent process, source
       # it.  But otherwise don't do it because we don't want to
       # clobber overridden values of $PATH, etc.
-      if [ -z "$__ETC_PROFILE_DONE" ]; then
+      if [ -z "''${__ETC_PROFILE_DONE:-}" ]; then
           . /etc/profile
       fi
 
       # We are not always an interactive shell.
-      if [ -n "$PS1" ]; then
+      if [ -n "''${PS1:-}" ]; then
           ${cfg.interactiveShellInit}
       fi
 
@@ -206,7 +206,7 @@ in
       # /etc/bash_logout: DO NOT EDIT -- this file has been generated automatically.
 
       # Only execute this file once per shell.
-      if [ -n "$__ETC_BASHLOGOUT_SOURCED" ] || [ -n "$NOSYSBASHLOGOUT" ]; then return; fi
+      if [ -n "''${__ETC_BASHLOGOUT_SOURCED:-}" ] || [ -n "''${NOSYSBASHLOGOUT:-}" ]; then return; fi
       __ETC_BASHLOGOUT_SOURCED=1
 
       ${cfg.logout}


### PR DESCRIPTION
With `set -u`, sourcing the generated profile, bashrc or bash_logout can fail on unset one-shot markers, opt-out variables or prompt variables. Use empty defaults for these optional variables, preserving the existing tests when they are set.

Validated the generated shell code on x86_64-linux against the parent commit: reproduced the unset-variable failures and checked profile initialization, bashrc's profile fallback, logout, and prompt initialization with `TERM`/`INSIDE_EMACS` absent and with `TERM=dumb`. The candidate passes these cases. Official treefmt and `git diff --check` passed; no full NixOS system build or VM test was run.

This change covers the guards in `bash.nix`; it does not establish complete nounset compatibility for shell initialization. In particular, enabled bash completion still fails if `NIX_PROFILES` is unset in `bash-completion.nix`.

Implementation and validation were assisted by OpenAI Codex (gpt-5.6-sol and gpt-5.6-luna), including the generated-shell regression harness. This PR description was also prepared with OpenAI Codex.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
