### PR TITLE
python3Packages.procmon-parser: 0.3.13 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/procmon-parser/default.nix
+++ b/pkgs/development/python-modules/procmon-parser/default.nix
@@ -3,31 +3,32 @@
   buildPythonPackage,
   construct,
   fetchFromGitHub,
+  hatchling,
   pytestCheckHook,
   python-dateutil,
-  six,
+  rich,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "procmon-parser";
-  version = "0.3.13";
-  format = "setuptools";
+  version = "0.4.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "eronnen";
     repo = "procmon-parser";
-    tag = "v${version}";
-    hash = "sha256-XkMf3MQK4WFRLl60XHDG/j2gRHAiz7XL9MmC6SRg9RE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hM+/sdW/H8QVt5kckAP1M96nn6mJmV8oWVl9RsjDf88=";
   };
 
-  propagatedBuildInputs = [
-    construct
-    six
-  ];
+  build-system = [ hatchling ];
+
+  dependencies = [ construct ];
 
   nativeCheckInputs = [
     pytestCheckHook
     python-dateutil
+    rich
   ];
 
   pythonImportsCheck = [ "procmon_parser" ];
@@ -35,8 +36,8 @@ buildPythonPackage rec {
   meta = {
     description = "Parser to process monitor file formats";
     homepage = "https://github.com/eronnen/procmon-parser/";
-    changelog = "https://github.com/eronnen/procmon-parser/releases/tag/v${version}";
+    changelog = "https://github.com/eronnen/procmon-parser/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/eronnen/procmon-parser/compare/v0.3.13...v0.4.0

Changelog: https://github.com/eronnen/procmon-parser/releases/tag/v0.4.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
