### PR TITLE
python3Packages.ida-domain: 0.5.0 -> 0.5.1, python3Packages.ida-hcli: 0.18.5 -> 0.21.0

### DIFF
--- a/pkgs/development/python-modules/ida-domain/default.nix
+++ b/pkgs/development/python-modules/ida-domain/default.nix
@@ -3,19 +3,19 @@
   buildPythonPackage,
   fetchFromGitHub,
   graphviz,
+  hatchling,
   idapro,
   nix-update-script,
   packaging,
   pytest-cov-stub,
   pytestCheckHook,
-  setuptools,
   typing-extensions,
   writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "ida-domain";
-  version = "0.5.0";
+  version = "0.5.1";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -24,10 +24,10 @@ buildPythonPackage (finalAttrs: {
     owner = "HexRaysSA";
     repo = "ida-domain";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oa3VQgWDEr4tPQ166EugfS7QrW1DlRb/hwypwKP+Xv4=";
+    hash = "sha256-vlVJnRaRNMelQ3w1SgCDvtIQJKBuULLOqKKdAvDK2y4=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ hatchling ];
 
   dependencies = [
     idapro

--- a/pkgs/development/python-modules/ida-hcli/default.nix
+++ b/pkgs/development/python-modules/ida-hcli/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "ida-hcli";
-  version = "0.18.5";
+  version = "0.21.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -36,7 +36,7 @@ buildPythonPackage (finalAttrs: {
     owner = "HexRaysSA";
     repo = "ida-hcli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-n8hLgVgxqaU7Au6HVgOEUKOm1LV3Wx/v42gi2gOD3Jk=";
+    hash = "sha256-GCR+DcZ3RZevfS2OO44LpkiQ7Fk1WtZpivLh2VONbHg=";
   };
 
   build-system = [ setuptools ];
@@ -73,7 +73,6 @@ buildPythonPackage (finalAttrs: {
     "tests/integration/"
     "tests/lib/test_ida_python.py"
     "tests/lib/test_ida.py"
-    "tests/lib/test_plugin_bundle_install.py"
     "tests/lib/test_plugin_collisions.py"
     "tests/lib/test_plugin_install.py"
     "tests/lib/test_plugin_records.py"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
