### PR TITLE
vimPlugins.blink-pairs: 0.6.0 -> 0.6.0-unstable-2026-09-04

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/blink-pairs/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/blink-pairs/default.nix
@@ -9,13 +9,13 @@
   nix-update-script,
 }:
 let
-  version = "0.6.0";
+  version = "0.6.0-unstable-2026-09-04";
 
   src = fetchFromGitHub {
     owner = "Saghen";
     repo = "blink.pairs";
-    tag = "v${version}";
-    hash = "sha256-XWrsZAH0tIPyRjr3PnAS2QAGE3+1z00jdnsxkKG0qPE=";
+    rev = "21c2ac9164b36ae5e22f84a2dd0f02eaf107f8fe";
+    hash = "sha256-z+1CnzU/YGLTES2b/B+ELPAZ4+aeChJpgEA3Use94q0=";
   };
 
   blink-pairs-lib = rustPlatform.buildRustPackage {
@@ -72,7 +72,7 @@ vimUtils.buildVimPlugin {
   meta = {
     description = "Rainbow highlighting and intelligent auto-pairs for Neovim";
     homepage = "https://github.com/Saghen/blink.pairs";
-    changelog = "https://github.com/Saghen/blink.pairs/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/Saghen/blink.pairs/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       isabelroses


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Looking to pick up these changes I made:

https://github.com/saghen/blink.pairs/commits?author=evanwporter

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
