### PR TITLE
treewide: fix typos of `asl20` license as `apsl20`

### DIFF
--- a/pkgs/by-name/cl/cloudlens/package.nix
+++ b/pkgs/by-name/cl/cloudlens/package.nix
@@ -38,7 +38,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "K9s like CLI for AWS and GCP";
     homepage = "https://github.com/one2nc/cloudlens";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ByteSudoer ];
     mainProgram = "cloudlens";
   };

--- a/pkgs/by-name/ed/eden/package.nix
+++ b/pkgs/by-name/ed/eden/package.nix
@@ -220,7 +220,7 @@ stdenv.mkDerivation (finalAttrs: {
       cc0
 
       # Vendored/incorporated libs
-      apsl20
+      asl20
       llvm-exception
       lib.licenses.boost
       bsd2

--- a/pkgs/by-name/im/imposm/package.nix
+++ b/pkgs/by-name/im/imposm/package.nix
@@ -36,7 +36,7 @@ buildGoModule (finalAttrs: {
     description = "Imports OpenStreetMap data into PostGIS";
     homepage = "https://imposm.org/";
     changelog = "https://github.com/omniscale/imposm3/releases/tag/${finalAttrs.src.rev}";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ sikmir ];
     mainProgram = "imposm";
   };

--- a/pkgs/by-name/ka/kafka-cmak/package.nix
+++ b/pkgs/by-name/ka/kafka-cmak/package.nix
@@ -41,7 +41,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Cluster Manager for Apache Kafka, previously known as Kafka Manager";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ cafkafk ];
     platforms = lib.platforms.unix;
     mainProgram = "cmak";

--- a/pkgs/by-name/rs/rsop/package.nix
+++ b/pkgs/by-name/rs/rsop/package.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Stateless OpenPGP (SOP) based on rpgp";
     license = with lib.licenses; [
       mit
-      apsl20
+      asl20
       cc0
     ];
     maintainers = with lib.maintainers; [ nikstur ];

--- a/pkgs/by-name/sa/saucectl/package.nix
+++ b/pkgs/by-name/sa/saucectl/package.nix
@@ -28,7 +28,7 @@ buildGoModule (finalAttrs: {
     description = "Command line interface for the Sauce Labs platform";
     changelog = "https://github.com/saucelabs/saucectl/releases/tag/v${finalAttrs.version}";
     homepage = "https://github.com/saucelabs/saucectl";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ luftmensch-luftmensch ];
     mainProgram = "saucectl";
   };

--- a/pkgs/by-name/st/stalwart-vandelay/package.nix
+++ b/pkgs/by-name/st/stalwart-vandelay/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/stalwartlabs/vandelay/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.OR [
       lib.licenses.mit
-      lib.licenses.apsl20
+      lib.licenses.asl20
     ];
     mainProgram = "vandelay";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/un/unifly/package.nix
+++ b/pkgs/by-name/un/unifly/package.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Elegant UniFi network management CLI & TUI - for humans and agents";
     homepage = "https://hyperb1iss.github.io/unifly";
     changelog = "https://github.com/hyperb1iss/unifly/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ britter ];
     mainProgram = "unifly";
   };

--- a/pkgs/by-name/wa/watchgha/package.nix
+++ b/pkgs/by-name/wa/watchgha/package.nix
@@ -37,7 +37,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     description = "Live display of current GitHub action runs";
     mainProgram = "watch_gha_runs";
     homepage = "https://github.com/nedbat/watchgha";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ purcell ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/cloudflare/workers-sdk#readme";
     license = with lib.licenses; [
       mit
-      apsl20
+      asl20
     ];
     maintainers = with lib.maintainers; [
       seanrmurphy

--- a/pkgs/development/python-modules/environ-config/default.nix
+++ b/pkgs/development/python-modules/environ-config/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     description = "Python Application Configuration With Environment Variables";
     homepage = "https://github.com/hynek/environ-config";
     changelog = "https://github.com/hynek/environ-config/releases/tag/${version}";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ lykos153 ];
   };
 }

--- a/pkgs/development/python-modules/kestra/default.nix
+++ b/pkgs/development/python-modules/kestra/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage (finalAttrs: {
     description = "Infinitely scalable orchestration and scheduling platform, creating, running, scheduling, and monitoring millions of complex pipelines";
     homepage = "https://github.com/kestra-io/libs";
     changelog = "https://github.com/kestra-io/libs/releases/tag/${finalAttrs.src.tag}";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ DataHearth ];
   };
 })

--- a/pkgs/development/python-modules/retryhttp/default.nix
+++ b/pkgs/development/python-modules/retryhttp/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     description = "Retry potentially transient HTTP errors in Python";
     homepage = "https://github.com/austind/retryhttp";
     changelog = "https://github.com/austind/retryhttp/releases/tag/release%2Fv${version}";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ taranarmo ];
   };
 }

--- a/pkgs/tools/misc/steampipe-packages/steampipe-plugin-azure/default.nix
+++ b/pkgs/tools/misc/steampipe-packages/steampipe-plugin-azure/default.nix
@@ -43,7 +43,7 @@ buildGoModule rec {
     changelog = "https://github.com/turbot/steampipe-plugin-azure/blob/v${version}/CHANGELOG.md";
     description = "Azure Plugin for Steampipe";
     homepage = "https://github.com/turbot/steampipe-plugin-azure";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     longDescription = "Use SQL to instantly query Azure resources across regions and subscriptions.";
     maintainers = [ ];
     platforms = steampipe.meta.platforms;


### PR DESCRIPTION
The identifier `apsl20` for the Apple Public Source License is deprecated, because of the risk of confusion with Apache 2.0. Sure enough, almost every use in tree was a typo. Verified this with each project upstream.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
