### PR TITLE
vikunja-desktop: fix desktop file and actually install it

### DIFF
--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   makeWrapper,
   makeDesktopItem,
+  copyDesktopItems,
   darwin,
   pnpm_10,
   pnpmConfigHook,
@@ -56,6 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpmConfigHook
     vikunja.passthru.frontend
   ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ copyDesktopItems ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.autoSignDarwinBinariesHook
   ];
@@ -124,18 +126,20 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   # The desktop item properties should be kept in sync with data from upstream:
-  desktopItem = makeDesktopItem {
-    name = "vikunja-desktop";
-    exec = executableName;
-    icon = "vikunja";
-    desktopName = "Vikunja Desktop";
-    genericName = "To-Do list app";
-    comment = finalAttrs.meta.description;
-    categories = [
-      "ProjectManagement"
-      "Office"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "vikunja-desktop";
+      exec = executableName;
+      icon = "vikunja";
+      desktopName = "Vikunja Desktop";
+      genericName = "To-Do list app";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "ProjectManagement"
+        "Office"
+      ];
+    })
+  ];
 
   meta = {
     description = "Desktop App of the Vikunja to-do list app";

--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -125,18 +125,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
-  # The desktop item properties should be kept in sync with data from upstream:
   desktopItems = [
     (makeDesktopItem {
       name = "vikunja-desktop";
-      exec = executableName;
-      icon = "vikunja";
+      exec = "${executableName} %U";
+      icon = "vikunja-desktop";
+      terminal = false;
       desktopName = "Vikunja Desktop";
       genericName = "To-Do list app";
       comment = finalAttrs.meta.description;
       categories = [
         "ProjectManagement"
         "Office"
+      ];
+      mimeTypes = [
+        "x-scheme-handler/vikunja-desktop"
       ];
     })
   ];


### PR DESCRIPTION
The desktop file we generated for Vikunja wasn't actually installed, and it is missing some required keys to support logging in on instances using OIDC.

For the record, the Vikunja Desktop AppImage ships the following desktop file:
```
[Desktop Entry]
Name=Vikunja Desktop
Exec=AppRun --no-sandbox %U
Terminal=false
Type=Application
Icon=vikunja-desktop
StartupWMClass=Vikunja Desktop
X-AppImage-Version=2.6.0
Comment=Vikunja’s frontend as a standalone desktop application.
MimeType=x-scheme-handler/vikunja-desktop;
Categories=Productivity;
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
