### PR TITLE
pnpm: remove dead code used by dropped pnpm_8

### DIFF
--- a/pkgs/development/tools/pnpm/generic.nix
+++ b/pkgs/development/tools/pnpm/generic.nix
@@ -69,27 +69,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       runHook postInstall
     '';
 
-  postInstall =
-    if lib.toInt (lib.versions.major version) < 9 then
-      ''
-        export HOME="$PWD"
-        node $out/bin/pnpm install-completion bash
-        node $out/bin/pnpm install-completion fish
-        node $out/bin/pnpm install-completion zsh
-        sed -i '1 i#compdef pnpm' .config/tabtab/zsh/pnpm.zsh
-        installShellCompletion \
-          .config/tabtab/bash/pnpm.bash \
-          .config/tabtab/fish/pnpm.fish \
-          .config/tabtab/zsh/pnpm.zsh
-      ''
-    else
-      ''
-        node $out/bin/pnpm completion bash >pnpm.bash
-        node $out/bin/pnpm completion fish >pnpm.fish
-        node $out/bin/pnpm completion zsh >pnpm.zsh
-        sed -i '1 i#compdef pnpm' pnpm.zsh
-        installShellCompletion pnpm.{bash,fish,zsh}
-      '';
+  postInstall = ''
+    node $out/bin/pnpm completion bash >pnpm.bash
+    node $out/bin/pnpm completion fish >pnpm.fish
+    node $out/bin/pnpm completion zsh >pnpm.zsh
+    sed -i '1 i#compdef pnpm' pnpm.zsh
+    installShellCompletion pnpm.{bash,fish,zsh}
+  '';
 
   passthru =
     let


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
