### PR TITLE
treewide: convert deprecated apsl{10,20} to non-deprecated variant

### DIFF
--- a/pkgs/os-specific/darwin/by-name/ad/adv_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/ad/adv_cmds/package.nix
@@ -99,7 +99,7 @@ mkAppleDerivation {
     description = "Advanced commands package for Darwin";
     license = [
       lib.licenses.apple-psl10
-      lib.licenses.apsl20
+      lib.licenses.apple-psl20
     ];
   };
 }

--- a/pkgs/os-specific/darwin/by-name/ad/adv_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/ad/adv_cmds/package.nix
@@ -98,7 +98,7 @@ mkAppleDerivation {
   meta = {
     description = "Advanced commands package for Darwin";
     license = [
-      lib.licenses.apsl10
+      lib.licenses.apple-psl10
       lib.licenses.apsl20
     ];
   };

--- a/pkgs/os-specific/darwin/by-name/lo/locale/package.nix
+++ b/pkgs/os-specific/darwin/by-name/lo/locale/package.nix
@@ -57,7 +57,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/apple-oss-distributions/adv_cmds";
     license = [
       lib.licenses.apple-psl10
-      lib.licenses.apsl20
+      lib.licenses.apple-psl20
     ];
     teams = [ lib.teams.darwin ];
   };

--- a/pkgs/os-specific/darwin/by-name/lo/locale/package.nix
+++ b/pkgs/os-specific/darwin/by-name/lo/locale/package.nix
@@ -56,7 +56,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Locale data for Darwin";
     homepage = "https://github.com/apple-oss-distributions/adv_cmds";
     license = [
-      lib.licenses.apsl10
+      lib.licenses.apple-psl10
       lib.licenses.apsl20
     ];
     teams = [ lib.teams.darwin ];


### PR DESCRIPTION
`apsl10` and `apsl20` (the Apple Public Source License) are deprecated in favor of `apple-psl10` and `apple-psl20` to reduce the risk of confusion with Apache 2.0. Convert all remaining instances these identifiers after #560052 to the non-deprecated version. I couldn't find a clear license statement upstream, but I'm assuming the preexisting license was correct because they're both Apple packages.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
