### PR TITLE
python3Packages.flow-it-api: init at 0.0.1.1

### DIFF
--- a/pkgs/development/python-modules/flow-it-api/default.nix
+++ b/pkgs/development/python-modules/flow-it-api/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
+  httpx,
+  pydantic,
+  pytest-asyncio,
+  pytest-httpx,
+  pytestCheckHook,
+  websockets,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "flow-it-api";
+  version = "0.0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "albertogeniola";
+    repo = "flow-it-api";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/X/sFtoqIu4lVUXOAgPI3299N2N0adDZILeBnpSL3GM=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    httpx
+    pydantic
+    websockets
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-httpx
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "flow_it_api" ];
+
+  meta = {
+    description = "Python API library client for the FlowIt VMC machine";
+    homepage = "https://github.com/albertogeniola/flow-it-api";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2169,9 +2169,10 @@
       ];
     "flow_it" =
       ps: with ps; [
+        flow-it-api
         ifaddr
         zeroconf
-      ]; # missing inputs: flow-it-api
+      ];
     "flume" =
       ps: with ps; [
         pyflume
@@ -8617,6 +8618,7 @@
     "flic"
     "flipr"
     "flo"
+    "flow_it"
     "flume"
     "fluss"
     "flux"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6343,6 +6343,8 @@ self: super: with self; {
 
   floret = callPackage ../development/python-modules/floret { };
 
+  flow-it-api = callPackage ../development/python-modules/flow-it-api { };
+
   flow-record = callPackage ../development/python-modules/flow-record { };
 
   flower = callPackage ../development/python-modules/flower { };


### PR DESCRIPTION
- https://pypi.org/project/flow-it-api/
- https://github.com/albertogeniola/flow-it-api
- https://www.home-assistant.io/integrations/flow_it/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
