### PR TITLE
eaglemode: try to improve platform support

### DIFF
--- a/pkgs/by-name/ea/eaglemode/package.nix
+++ b/pkgs/by-name/ea/eaglemode/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gccStdenv,
   fetchurl,
   perl,
   libx11,
@@ -17,6 +17,7 @@
   libxxf86vm,
   poppler,
   vlc,
+  vlc-bin,
   ghostscript,
   makeWrapper,
   tzdata,
@@ -30,9 +31,10 @@
   xz,
   zip,
   extraRuntimeDeps ? [ ],
+  # vlc currently doesn't build on darwin
+  useVlc ? if gccStdenv.hostPlatform.isDarwin then vlc-bin else vlc,
 }:
-
-stdenv.mkDerivation (finalAttrs: {
+gccStdenv.mkDerivation (finalAttrs: {
   pname = "eaglemode";
   version = "0.96.3";
 
@@ -48,6 +50,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace makers/emPdf.maker.pm \
       --replace-fail gtk+-2.0 gtk+-3.0
+
+    substituteInPlace src/emX11/emX11ExtDynamic.cpp \
+      --replace-fail /usr/X11/lib/libXext.6.dylib ${libxext}/lib/libXext.dylib \
+      --replace-fail /usr/X11/lib/libXxf86vm.1.dylib ${libxxf86vm}/lib/libXxf86vm.dylib \
+      --replace-fail /usr/X11/lib/libXinerama.1.dylib ${libxinerama}/lib/libXinerama.dylib
   '';
 
   nativeBuildInputs = [
@@ -69,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxxf86vm
     libxext
     poppler
-    vlc
+    useVlc
     ghostscript
   ];
 
@@ -78,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
     export NIX_LDFLAGS="$NIX_LDFLAGS -lXxf86vm -lXext -lXinerama"
-    perl make.pl build
+    perl make.pl build continue=no
     runHook postBuild
   '';
 
@@ -106,11 +113,15 @@ stdenv.mkDerivation (finalAttrs: {
         ]
         ++ extraRuntimeDeps
       );
+      ldenv = if gccStdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
     in
     ''
       runHook preInstall
       perl make.pl install dir=$out
-      wrapProgram $out/bin/eaglemode --set EM_DIR "$out" --prefix LD_LIBRARY_PATH : "$out/lib" --prefix PATH : "${runtimeDeps}"
+      wrapProgram $out/bin/eaglemode \
+        --set EM_DIR "$out" \
+        --prefix ${ldenv} : "$out/lib" \
+        --prefix PATH : "${runtimeDeps}"
       for i in 32 48 96; do
         mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps
         ln -s $out/res/icons/eaglemode$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/eaglemode.png
@@ -147,6 +158,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       chuangzhu
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
+    broken = gccStdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/vl/vlc-bin/package.nix
+++ b/pkgs/by-name/vl/vlc-bin/package.nix
@@ -2,12 +2,12 @@
   lib,
   fetchurl,
   makeWrapper,
-  stdenv,
+  stdenvNoCC,
   undmg,
   variant ?
-    if (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) then
+    if (stdenvNoCC.hostPlatform.isDarwin && stdenvNoCC.hostPlatform.isAarch64) then
       "arm64"
-    else if (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) then
+    else if (stdenvNoCC.hostPlatform.isDarwin && stdenvNoCC.hostPlatform.isx86_64) then
       "intel64"
     else
       "universal", # not reachable by normal means
@@ -18,7 +18,7 @@ assert builtins.elem variant [
   "intel64"
   "universal"
 ];
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "vlc-bin-${variant}";
   version = "3.0.23";
 
@@ -43,12 +43,21 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/Applications $out/bin
+    mkdir -p $out/Applications $out/bin $out/lib
     cp -r "VLC.app" $out/Applications
     makeWrapper "$out/Applications/VLC.app/Contents/MacOS/VLC" "$out/bin/vlc"
+    ln -s "$out/Applications/VLC.app/Contents/MacOS/lib"/* "$out/lib/"
+
+    mkdir -p "$dev"
+    cp -r "VLC.app/Contents/MacOS/include" "$dev"
 
     runHook postInstall
   '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   meta = {
     description = "Cross-platform media player and streaming server; precompiled binary for MacOS, repacked from official website";


### PR DESCRIPTION
The program now compiles on Darwin, although it still doesn't run due to macOS not having an X server, and installing XQuartz didn't really help in my case. Still, the program is supposed to work on all Unix-like platforms, so I marked it as such while also marking as broken on Darwin. Packages `vlc` and `vlc-bin` only support Linux and Darwin respectively, so there's little hope for compiling EM for, say, FreeBSD in the near time. But this PR lays some foundation for possible future work.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
