### PR TITLE
lldb: fix regressions from strictDeps and __structuredAttrs; cleanup

### DIFF
--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -107,6 +107,7 @@ stdenv.mkDerivation (
       libxml2
       libllvm
       python3
+      lua5_3
       # Starting with LLVM 16, the resource dir patch is no longer enough to get
       # libclang into the rpath of the lldb executables. By putting it into
       # buildInputs cc-wrapper will set up rpath correctly for us.

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -223,8 +223,12 @@ stdenv.mkDerivation (
 
     # manually install lldb man page
     installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/share/man/man1
       install docs/man/lldb.1 -t $out/share/man/man1/
+
+      runHook postInstall
     '';
 
     postPatch = null;

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -28,6 +28,7 @@
   fetchpatch,
   fetchpatch2,
   replaceVars,
+  versionCheckHook,
 }:
 
 let
@@ -35,6 +36,7 @@ let
     name = "lldb-dap";
     version = "0.2.0";
   };
+  canRunLldb = !enableManpages && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 in
 
 stdenv.mkDerivation (
@@ -152,18 +154,12 @@ stdenv.mkDerivation (
     ++ devExtraCmakeFlags;
 
     doCheck = false;
-    doInstallCheck = false;
+    doInstallCheck = canRunLldb;
 
-    # TODO: cleanup with mass-rebuild
-    installCheckPhase = ''
-      if [ ! -e ''${!outputLib}/${python3.sitePackages}/lldb/_lldb*.so ] ; then
-          echo "ERROR: python files not installed where expected!";
-          return 1;
-      fi
-      if [ ! -e "''${!outputLib}/lib/lua/${lua5_3.luaversion}/lldb.so" ] ; then
-          echo "ERROR: lua files not installed where expected!";
-          return 1;
-      fi
+    nativeInstallCheckInputs = lib.optionals canRunLldb [ versionCheckHook ];
+
+    preVersionCheck = ''
+      version=${release_version}
     '';
 
     postInstall =

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -162,6 +162,21 @@ stdenv.mkDerivation (
       version=${release_version}
     '';
 
+    installCheckPhase = ''
+      runHook preInstallCheck
+
+      pythonOutput=$($out/bin/lldb --batch -o 'script print(1000+100+10+1)' 2>&1)
+      echo "$pythonOutput"
+      grep -Fx 1111 <<< "$pythonOutput"
+
+      luaOutput=$($out/bin/lldb --batch --script-language lua \
+        -o 'script io.stdout:write(1000+100+10+1, "\n")' 2>&1)
+      echo "$luaOutput"
+      grep -Fx 1111 <<< "$luaOutput"
+
+      runHook postInstallCheck
+    '';
+
     postInstall =
       let
         # Needed after https://github.com/llvm/llvm-project/commit/5f0f0fcd62227fb864203acc1a57e3ebf7a254a3

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -106,6 +106,7 @@ stdenv.mkDerivation (
       libedit
       libxml2
       libllvm
+      python3
       # Starting with LLVM 16, the resource dir patch is no longer enough to get
       # libclang into the rpath of the lldb executables. By putting it into
       # buildInputs cc-wrapper will set up rpath correctly for us.

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -24,17 +24,14 @@
   monorepoSrc ? null,
   enableManpages ? false,
   devExtraCmakeFlags ? [ ],
-  getVersionFile,
-  fetchpatch,
-  fetchpatch2,
-  replaceVars,
   versionCheckHook,
 }:
 
 let
-  vscodeExt = {
+  vscodeExt = rec {
     name = "lldb-dap";
     version = "0.2.0";
+    uniqueId = "llvm-org.${name}-${version}";
   };
   canRunLldb = !enableManpages && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 in
@@ -42,7 +39,6 @@ in
 stdenv.mkDerivation (
   finalAttrs:
   {
-    passthru.monorepoSrc = monorepoSrc;
     pname = "lldb";
     inherit version;
 
@@ -191,14 +187,18 @@ stdenv.mkDerivation (
 
         # Editor support
         # vscode:
-        install -D ${packageJsonPath} $out/share/vscode/extensions/llvm-org.${vscodeExt.name}-${vscodeExt.version}/package.json
-        mkdir -p $out/share/vscode/extensions/llvm-org.${vscodeExt.name}-${vscodeExt.version}/bin
-        ln -s $out/bin/*${vscodeExt.name} $out/share/vscode/extensions/llvm-org.${vscodeExt.name}-${vscodeExt.version}/bin
+        vscodeExtDir="$out/share/vscode/extensions/${vscodeExt.uniqueId}"
+        install -D ${packageJsonPath} "$vscodeExtDir/package.json"
+        mkdir -p "$vscodeExtDir/bin"
+        ln -s $out/bin/*${vscodeExt.name} "$vscodeExtDir/bin"
       '';
 
-    passthru.vscodeExtName = vscodeExt.name;
-    passthru.vscodeExtPublisher = "llvm";
-    passthru.vscodeExtUniqueId = "llvm-org.${vscodeExt.name}-${vscodeExt.version}";
+    passthru = {
+      inherit monorepoSrc;
+      vscodeExtName = vscodeExt.name;
+      vscodeExtPublisher = "llvm";
+      vscodeExtUniqueId = vscodeExt.uniqueId;
+    };
 
     __structuredAttrs = true;
 

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -219,8 +219,6 @@ stdenv.mkDerivation (
 
     ninjaFlags = [ "docs-lldb-man" ];
 
-    propagatedBuildInputs = [ ];
-
     # manually install lldb man page
     installPhase = ''
       runHook preInstall
@@ -231,12 +229,9 @@ stdenv.mkDerivation (
       runHook postInstall
     '';
 
-    postPatch = null;
     postInstall = null;
 
     outputs = [ "out" ];
-
-    doCheck = false;
 
     meta = llvm_meta // {
       description = "man pages for LLDB ${version}";

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (
     patches = [
       ./gnu-install-dirs.patch
     ]
-    ++ lib.optional (lib.versions.major release_version == "18") [
+    ++ lib.optionals (lib.versions.major release_version == "18") [
       # Fix build with gcc15
       # https://github.com/llvm/llvm-project/commit/bb59f04e7e75dcbe39f1bf952304a157f0035314
       ./lldb-add-include-cstdint.patch

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -145,7 +145,7 @@ stdenv.mkDerivation (
     ]
     ++ lib.optionals finalAttrs.finalPackage.doCheck [
       (lib.cmakeFeature "LLDB_TEST_C_COMPILER" "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc")
-      (lib.cmakeFeature "-DLLDB_TEST_CXX_COMPILER" "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++")
+      (lib.cmakeFeature "LLDB_TEST_CXX_COMPILER" "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++")
     ]
     ++ devExtraCmakeFlags;
 


### PR DESCRIPTION
A few things got broken in lldb by https://github.com/NixOS/nixpkgs/pull/553112

- patches were not applied because of a nested list in the `patches` attribute
- python was not added to runtime dependencies, breaking lldb completely
- lua was not added to runtime dependencies, which built lldb without lua support

These are fixed. While at it, also did a few cleanups in the package, and added
build time checks that llvm --version doesn't crash plus that python and lua
scripting works.

See also https://github.com/NixOS/nixpkgs/pull/560071 for `mlir`.

Commits:
- **llvmPackages.lldb: add Python runtime dependency**
- **llvmPackages.lldb: restore Lua support**
- **llvmPackages.lldb: add version install check**
- **llvmPackages.lldb: check scripting support**
- **llvmPackages.lldb: clean up package expression**
- **llvmPackages_18.lldb: fix patch list**
- **llvmPackages.lldb: fix C++ test compiler flag**
- **llvmPackages.lldb-manpages: run install hooks**
- **llvmPackages.lldb-manpages: remove redundant attributes**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
