### PR TITLE
various: fix deprecated `lgpl2` license

### DIFF
--- a/pkgs/by-name/ch/chmlib/package.nix
+++ b/pkgs/by-name/ch/chmlib/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "http://www.jedrea.com/chmlib";
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.lgpl21Plus;
     description = "Library for dealing with Microsoft ITSS/CHM format files";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/ci/cinnamon-menus/package.nix
+++ b/pkgs/by-name/ci/cinnamon-menus/package.nix
@@ -37,8 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/linuxmint/cinnamon-menus";
     description = "Menu system for the Cinnamon project";
     license = [
-      lib.licenses.gpl2
-      lib.licenses.lgpl2
+      lib.licenses.gpl2Plus # All files
+      lib.licenses.lgpl2Plus # Debian package definitions
     ];
     platforms = lib.platforms.linux;
     teams = [ lib.teams.cinnamon ];

--- a/pkgs/by-name/ci/cinnamon-screensaver/package.nix
+++ b/pkgs/by-name/ci/cinnamon-screensaver/package.nix
@@ -110,8 +110,8 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/linuxmint/cinnamon-screensaver";
     description = "Cinnamon screen locker and screensaver program";
     license = [
-      lib.licenses.gpl2
-      lib.licenses.lgpl2
+      lib.licenses.gpl2Plus # All files
+      lib.licenses.lgpl2Plus # Debian package definition
     ];
     platforms = lib.platforms.linux;
     teams = [ lib.teams.cinnamon ];

--- a/pkgs/by-name/dm/dmtx-utils/package.nix
+++ b/pkgs/by-name/dm/dmtx-utils/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Data matrix command-line utilities";
     homepage = "https://github.com/dmtx/dmtx-utils";
     changelog = "https://github.com/dmtx/dmtx-utils/blob/v${finalAttrs.version}/ChangeLog";
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.lgpl21Plus;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/eg/eggdbus/package.nix
+++ b/pkgs/by-name/eg/eggdbus/package.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://hal.freedesktop.org/releases/";
     description = "D-Bus bindings for GObject";
     platforms = lib.platforms.linux;
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.lgpl2Plus;
   };
 })

--- a/pkgs/by-name/fr/freetds/package.nix
+++ b/pkgs/by-name/fr/freetds/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Libraries to natively talk to Microsoft SQL Server and Sybase databases";
     homepage = "https://www.freetds.org";
     changelog = "https://github.com/FreeTDS/freetds/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.lgpl2Plus;
     maintainers = with lib.maintainers; [ peterhoeg ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/fs/fsarchiver/package.nix
+++ b/pkgs/by-name/fs/fsarchiver/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
       corrupt, you just loose the current file, not the whole archive.
     '';
     homepage = "https://www.fsarchiver.org/";
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.gpl2Only;
     maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "fsarchiver";

--- a/pkgs/by-name/fs/fsv/package.nix
+++ b/pkgs/by-name/fs/fsv/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       by the host computer's memory and graphics hardware.
     '';
     homepage = "https://github.com/jabl/fsv";
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ rnhmjoj ];
     mainProgram = "fsv";

--- a/pkgs/by-name/gl/gl2ps/package.nix
+++ b/pkgs/by-name/gl/gl2ps/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://geuz.org/gl2ps";
     description = "OpenGL to PostScript printing library";
     platforms = lib.platforms.all;
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.lgpl2Plus;
     maintainers = with lib.maintainers; [
       raskin
       twhitehead


### PR DESCRIPTION
`lgpl2` as a license is deprecated, both because it doesn't specify whether it is plus or only and because it's easily confusable with `lgpl21`. For each commit here, I went through upstream license files to determine whether the package is LGPLv2+ or only, and also fixed it to LGPLv2.1 when relevant.

Found instances via `git grep -P 'lgpl2(?!Only|Plus|1)'`.
Part of #301908.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
