### PR TITLE
vscode-css-languageserver: 1.105.0 -> 1.136.1

### DIFF
--- a/pkgs/by-name/vs/vscode-css-languageserver/package.nix
+++ b/pkgs/by-name/vs/vscode-css-languageserver/package.nix
@@ -9,18 +9,20 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "vscode-css-languageserver";
-  version = "1.105.0";
+  version = "1.136.1";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "vscode";
     tag = finalAttrs.version;
-    hash = "sha256-t3S8PHxuwz1DxJ+FPJkRCyaPm4tPW/fHKj3aiIaTuls=";
+    hash = "sha256-Y6FRttdpn353w/ykJbaE+NjM1NfXQewl9Fgux7m10lk=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/extensions/css-language-features/server";
 
-  npmDepsHash = "sha256-duYwm1Hf9oLyu0gapdEGbXqdwFV4svkX2tGhvyoZ5Lo=";
+  npmDepsHash = "sha256-12WHnmL68AmlZTIvghnBSsKn4zRLJaTtufkwdSbLRQE=";
+
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     makeBinaryWrapper
@@ -29,14 +31,19 @@ buildNpmPackage (finalAttrs: {
 
   buildPhase = ''
     runHook preBuild
-    tsc -p .
+
+    tsc -p . \
+      --typeRoots ./node_modules/@types \
+      --module nodenext \
+      --moduleResolution nodenext
+
     runHook postBuild
   '';
 
   dontNpmBuild = true;
 
   postInstall = ''
-    makeBinaryWrapper ${nodejs}/bin/node $out/bin/vscode-css-languageserver \
+    makeBinaryWrapper ${lib.getExe nodejs} $out/bin/vscode-css-languageserver \
       --add-flags $out/lib/node_modules/vscode-css-languageserver/out/node/cssServerMain.js
     ln -s $out/bin/vscode-css-languageserver $out/bin/vscode-css-language-server
   '';


### PR DESCRIPTION
The automated update failed: https://nixpkgs-update-logs.nix-community.org/vscode-css-languageserver/2026-09-03.log

Building the server standalone fails to resolve types/modules with upstream's `tsconfig.json`, so we needed to explicitly pass `--typeRoots` and `--moduleResolution nodenext` to `tsc`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
