### PR TITLE
python3Packages.aiohortos: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/aiohortos/default.nix
+++ b/pkgs/development/python-modules/aiohortos/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytestCheckHook,
+  pythonOlder,
+  yarl,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "aiohortos";
+  version = "0.3.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.13";
+
+  src = fetchFromGitHub {
+    owner = "wildekek";
+    repo = "aiohortos";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8CBD9hncGHitGOThZATxsH7Z45EQ6taGFPq4cRwcK/8=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    aiohttp
+    yarl
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "aiohortos" ];
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
+    description = "Async client for the Ridder HortOS Automation API";
+    homepage = "https://github.com/wildekek/aiohortos";
+    changelog = "https://github.com/wildekek/aiohortos/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2924,7 +2924,8 @@
       ];
     "hortimax" =
       ps: with ps; [
-      ]; # missing inputs: aiohortos
+        aiohortos
+      ];
     "hotspring" =
       ps: with ps; [
         python-hotspring
@@ -8755,6 +8756,7 @@
     "homeworks"
     "honeywell"
     "honeywell_string_lights"
+    "hortimax"
     "hotspring"
     "hr_energy_qube"
     "html5"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -334,6 +334,8 @@ self: super: with self; {
 
   aiohomematic-test-support = callPackage ../development/python-modules/aiohomematic-test-support { };
 
+  aiohortos = callPackage ../development/python-modules/aiohortos { };
+
   aiohttp = callPackage ../development/python-modules/aiohttp { };
 
   aiohttp-apispec = callPackage ../development/python-modules/aiohttp-apispec { };


### PR DESCRIPTION
- https://pypi.org/project/aiohortos/
- https://github.com/wildekek/aiohortos
- https://www.home-assistant.io/integrations/hortimax/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
