### PR TITLE
vscode-json-languageserver: 1.3.4 -> 1.136.1

### DIFF
--- a/pkgs/by-name/vs/vscode-json-languageserver/package.nix
+++ b/pkgs/by-name/vs/vscode-json-languageserver/package.nix
@@ -2,35 +2,52 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  makeBinaryWrapper,
+  nodejs,
   typescript,
 }:
 
 buildNpmPackage (finalAttrs: {
   pname = "vscode-json-languageserver";
-  version = "1.3.4";
+  version = "1.136.1";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "vscode";
-    tag = "1.101.2";
-    hash = "sha256-wdI6VlJ4WoSNnwgkb6dkVYcq/P/yzflv5mE9PuYBVx4=";
+    tag = finalAttrs.version;
+    hash = "sha256-Y6FRttdpn353w/ykJbaE+NjM1NfXQewl9Fgux7m10lk=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/extensions/json-language-features/server";
 
-  npmDepsHash = "sha256-akQukdYTe6um4xo+7T3wHxx+WrXfKYl5a1qwmqX72HQ=";
+  npmDepsHash = "sha256-kVZ7pnC/3m0I1jwuN3Ad6carWpj+O7IYnRZ3cx5W00g=";
 
-  nativeBuildInputs = [ typescript ];
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    typescript
+  ];
 
   buildPhase = ''
     runHook preBuild
-    tsc -p .
+
+    tsc -p . \
+      --typeRoots ./node_modules/@types \
+      --module nodenext \
+      --moduleResolution nodenext
+
     runHook postBuild
   '';
 
   dontNpmBuild = true;
 
+  # Upstream's bin script still uses require() in a "type": "module" package.
   postInstall = ''
+    rm $out/bin/vscode-json-languageserver
+    makeBinaryWrapper ${lib.getExe nodejs} $out/bin/vscode-json-languageserver \
+      --add-flags $out/lib/node_modules/vscode-json-languageserver/out/node/jsonServerMain.js
+
     ln -s $out/bin/vscode-json-languageserver $out/bin/vscode-json-language-server
   '';
 


### PR DESCRIPTION
Switch `version` to track the VS Code release tag directly instead of the outdated npm package version (1.3.4), which has not been updated since 2021.

Along with the update, two fixes were added:
  - Pass `--typeRoots` and `--moduleResolution nodenext` to `tsc` to resolve types/modules when building standalone.
  - Wrap `jsonServerMain.js` directly with `makeBinaryWrapper` (upstream's `bin/` script is an abandoned artifact from npm that no longer runs in ESM).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
