### PR TITLE
python3Packages.iseo-argo-ble: init at 0.9.6

### DIFF
--- a/pkgs/development/python-modules/iseo-argo-ble/default.nix
+++ b/pkgs/development/python-modules/iseo-argo-ble/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  bleak,
+  buildPythonPackage,
+  cryptography,
+  fetchFromGitHub,
+  hatchling,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "iseo-argo-ble";
+  version = "0.9.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "FezVrasta";
+    repo = "iseo-argo-ble";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kIdAN8OhzSNW6jqN9ZNli0/RDZr7WNHNPulNYs9+o7U=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    bleak
+    cryptography
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "iseo_argo_ble" ];
+
+  meta = {
+    description = "ISEO Argo BLE Lock protocol library";
+    homepage = "https://github.com/FezVrasta/iseo-argo-ble";
+    changelog = "https://github.com/FezVrasta/iseo-argo-ble/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3433,13 +3433,14 @@
         hassil
         home-assistant-intents
         ifaddr
+        iseo-argo-ble
         mutagen
         pymicro-vad
         pysmlight
         pyspeex-noise
         serialx
         zeroconf
-      ]; # missing inputs: iseo-argo-ble
+      ];
     "iskra" =
       ps: with ps; [
         pyiskra
@@ -8803,6 +8804,7 @@
     "irm_kmi"
     "iron_os"
     "isal"
+    "iseo_argo_ble"
     "iskra"
     "islamic_prayer_times"
     "israel_rail"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8538,6 +8538,8 @@ self: super: with self; {
 
   isbnlib = callPackage ../development/python-modules/isbnlib { };
 
+  iseo-argo-ble = callPackage ../development/python-modules/iseo-argo-ble { };
+
   islpy = callPackage ../development/python-modules/islpy { isl = pkgs.isl_0_27; };
 
   ismartgate = callPackage ../development/python-modules/ismartgate { };


### PR DESCRIPTION
- https://pypi.org/project/iseo-argo-ble/
- https://github.com/FezVrasta/iseo-argo-ble
- https://www.home-assistant.io/integrations/iseo_argo_ble/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
