### PR TITLE
python3Packages.aiolibrenms: init at 0.0.3

### DIFF
--- a/pkgs/development/python-modules/aiolibrenms/default.nix
+++ b/pkgs/development/python-modules/aiolibrenms/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  aiohttp,
+  aiointercept,
+  buildPythonPackage,
+  fetchFromGitHub,
+  mashumaro,
+  pytest-asyncio,
+  pytestCheckHook,
+  setuptools,
+  syrupy,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "aiolibrenms";
+  version = "0.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mib1185";
+    repo = "aiolibrenms";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mfOLB2br4RZHl4ky1vZDcSmh6szzDKvnGawHMpxWihg=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    mashumaro
+  ];
+
+  nativeCheckInputs = [
+    aiointercept
+    pytest-asyncio
+    pytestCheckHook
+    syrupy
+  ];
+
+  pythonImportsCheck = [ "aiolibrenms" ];
+
+  meta = {
+    description = "Asynchronous library to fetch data from a LibreNMS instance";
+    homepage = "https://github.com/mib1185/aiolibrenms";
+    changelog = "https://github.com/mib1185/aiolibrenms/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3921,7 +3921,8 @@
       ];
     "librenms" =
       ps: with ps; [
-      ]; # missing inputs: aiolibrenms
+        aiolibrenms
+      ];
     "lichess" =
       ps: with ps; [
         aiolichess
@@ -8855,6 +8856,7 @@
     "lg_thinq"
     "lg_tv_rs232"
     "libre_hardware_monitor"
+    "librenms"
     "lichess"
     "lidarr"
     "liebherr"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -402,6 +402,8 @@ self: super: with self; {
 
   aiokem = callPackage ../development/python-modules/aiokem { };
 
+  aiolibrenms = callPackage ../development/python-modules/aiolibrenms { };
+
   aiolichess = callPackage ../development/python-modules/aiolichess { };
 
   aiolifx = callPackage ../development/python-modules/aiolifx { };


### PR DESCRIPTION
- https://pypi.org/project/aiolibrenms/
- https://github.com/mib1185/aiolibrenms
- https://www.home-assistant.io/integrations/librenms/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
