### PR TITLE
mac80211-hwsim-mgmt: init at unstable-2017-02-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12627,6 +12627,11 @@
     githubId = 47289484;
     name = "Jack Avery";
   };
+  jacka10086 = {
+    github = "Jacka10086";
+    githubId = 111729221;
+    name = "Jacka";
+  };
   jackcres = {
     email = "crespomerchano@gmail.com";
     github = "omarcresp";

--- a/pkgs/by-name/ma/mac80211-hwsim-mgmt/package.nix
+++ b/pkgs/by-name/ma/mac80211-hwsim-mgmt/package.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation (finalAttrs: {
     libnl
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   installPhase = ''
     runHook preInstall
     install -Dm755 hwsim_mgmt/hwsim_mgmt $out/bin/hwsim_mgmt

--- a/pkgs/by-name/ma/mac80211-hwsim-mgmt/package.nix
+++ b/pkgs/by-name/ma/mac80211-hwsim-mgmt/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libevent,
+  libnl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mac80211-hwsim-mgmt";
+  version = "unstable-2017-02-28";
+
+  src = fetchFromGitHub {
+    owner = "patgrosse";
+    repo = "mac80211_hwsim_mgmt";
+    rev = "d6a7e3bf683731805c761dbd56af11fb6d6c7e76";
+    hash = "sha256-kVt+NtOKgep3Tnq4llkExM08Q09Nq90XEu06IOrrBMI=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libevent
+    libnl
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 hwsim_mgmt/hwsim_mgmt $out/bin/hwsim_mgmt
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Management tool for the mac80211_hwsim kernel module";
+    homepage = "https://github.com/patgrosse/mac80211_hwsim_mgmt";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jacka10086 ];
+    mainProgram = "hwsim_mgmt";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
###### Motivation for this change

First-time introduction of `mac80211-hwsim-mgmt`, the management tool for the `mac80211_hwsim` kernel module (create/delete radios, set per-radio properties via netlink genl). It is a dependency of Mininet-WiFi setups used for wireless SDN experiments.

Upstream: https://github.com/patgrosse/mac80211_hwsim_mgmt (MIT, no releases/tags, so a pinned `unstable` revision).

###### Things done

- Added `pkgs/by-name/ma/mac80211-hwsim-mgmt/package.nix` (by-name layout).
- Verified with `nix-build -A mac80211-hwsim-mgmt` on x86_64-linux; the resulting `hwsim_mgmt` binary runs and prints usage.

- Built on platform(s)
  - [x] x86_64-linux
- Tested, as applicable:
  - [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` (not run yet; package has no dependents)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)