### PR TITLE
vscode-html-languageserver: init at 1.136.1

### DIFF
--- a/pkgs/by-name/vs/vscode-html-languageserver/package.nix
+++ b/pkgs/by-name/vs/vscode-html-languageserver/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nodejs,
+  typescript,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "vscode-html-languageserver";
+  version = "1.136.1";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vscode";
+    tag = finalAttrs.version;
+    hash = "sha256-Y6FRttdpn353w/ykJbaE+NjM1NfXQewl9Fgux7m10lk=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/extensions/html-language-features/server";
+
+  npmDepsHash = "sha256-3LdWhp2wJwa0jQgkVZPH3ae8RexS1SU07xaPjM+XcWQ=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    typescript
+  ];
+
+  preBuild = ''
+    ln -s ${typescript}/lib/node_modules/typescript node_modules/typescript
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    tsc -p . \
+      --typeRoots ./node_modules/@types \
+      --moduleResolution bundler
+
+    runHook postBuild
+  '';
+
+  dontNpmBuild = true;
+
+  postInstall = ''
+    ln -s ${typescript}/lib/node_modules/typescript \
+      $out/lib/node_modules/vscode-html-languageserver/node_modules/typescript
+
+    makeBinaryWrapper ${lib.getExe nodejs} $out/bin/vscode-html-languageserver \
+      --add-flags $out/lib/node_modules/vscode-html-languageserver/out/node/htmlServerMain.js
+
+    ln -s $out/bin/vscode-html-languageserver $out/bin/vscode-html-language-server
+  '';
+
+  meta = {
+    description = "HTML language server";
+    homepage = "https://github.com/microsoft/vscode/tree/${finalAttrs.src.tag}/extensions/html-language-features/server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryota2357 ];
+    mainProgram = "vscode-html-languageserver";
+  };
+})


### PR DESCRIPTION
HTML language server under VSCode.

https://github.com/microsoft/vscode/tree/main/extensions/html-language-features/server

Supersedes #422691, updated to the latest release with cleaner packaging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
