### PR TITLE
libjpeg_turbo: 3.1.4.1 -> 3.2.0

### DIFF
--- a/pkgs/by-name/li/libjpeg_turbo/package.nix
+++ b/pkgs/by-name/li/libjpeg_turbo/package.nix
@@ -5,6 +5,7 @@
   cmake,
   nasm,
   openjdk,
+  jna,
   enableJava ? false, # whether to build the java wrapper
   enableJpeg7 ? false, # whether to build libjpeg with v7 compatibility
   enableJpeg8 ? false, # whether to build libjpeg with v8 compatibility
@@ -32,13 +33,13 @@ assert !(enableJpeg7 && enableJpeg8); # pick only one or none, not both
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libjpeg-turbo";
-  version = "3.1.4.1";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "libjpeg-turbo";
     repo = "libjpeg-turbo";
     tag = finalAttrs.version;
-    hash = "sha256-jBajigX4/j4jG11prTPeGkTVRrRzheFL/LxgnPufzb4=";
+    hash = "sha256-SPxWCDt9hFQ8uRaaKLkpWp9oPhfcRkDBm5MarTgdmV4=";
   };
 
   patches =
@@ -66,9 +67,11 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_STATIC" enableStatic)
     (lib.cmakeBool "ENABLE_SHARED" enableShared)
-    (lib.cmakeBool "WITH_JAVA" enableJava)
     (lib.cmakeBool "WITH_JPEG7" enableJpeg7)
     (lib.cmakeBool "WITH_JPEG8" enableJpeg8)
+  ]
+  ++ lib.optionals enableJava [
+    (lib.cmakeFeature "WITH_JNA" "${jna}/share/java/jna.jar")
   ]
   ++ lib.optionals stdenv.hostPlatform.isRiscV [
     # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/428

--- a/pkgs/by-name/li/libjpeg_turbo/package.nix
+++ b/pkgs/by-name/li/libjpeg_turbo/package.nix
@@ -64,22 +64,16 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DENABLE_STATIC=${if enableStatic then "1" else "0"}"
-    "-DENABLE_SHARED=${if enableShared then "1" else "0"}"
-  ]
-  ++ lib.optionals enableJava [
-    "-DWITH_JAVA=1"
-  ]
-  ++ lib.optionals enableJpeg7 [
-    "-DWITH_JPEG7=1"
-  ]
-  ++ lib.optionals enableJpeg8 [
-    "-DWITH_JPEG8=1"
+    (lib.cmakeBool "ENABLE_STATIC" enableStatic)
+    (lib.cmakeBool "ENABLE_SHARED" enableShared)
+    (lib.cmakeBool "WITH_JAVA" enableJava)
+    (lib.cmakeBool "WITH_JPEG7" enableJpeg7)
+    (lib.cmakeBool "WITH_JPEG8" enableJpeg8)
   ]
   ++ lib.optionals stdenv.hostPlatform.isRiscV [
     # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/428
     # https://github.com/libjpeg-turbo/libjpeg-turbo/commit/88bf1d16786c74f76f2e4f6ec2873d092f577c75
-    "-DFLOATTEST=fp-contract"
+    (lib.cmakeFeature "FLOATTEST" "fp-contract")
   ];
 
   doInstallCheck = true;


### PR DESCRIPTION
changelog: https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/3.2.0
diff: https://github.com/libjpeg-turbo/libjpeg-turbo/compare/3.1.4.1...3.2.0

i'm not really familiar with the whole JNA thing going on here (see the changes to `BUILDING.md`) as opposed to the old JNI interface, so i've tried enabling it using the new method but not sure that's correct. i have built `turbovnc`, the lone user of `enableJava = true;`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (builds on x86_64-linux)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
