### PR TITLE
python3Packages.fastmcp: 3.4.7 -> 4.0.2; python3Packages.fastmcp-tasks: init at 4.0.2; mcp-nixos: 3.0.1 -> 3.1.0

### DIFF
--- a/pkgs/by-name/mc/mcp-nixos/package.nix
+++ b/pkgs/by-name/mc/mcp-nixos/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "mcp-nixos";
-  version = "3.0.1";
+  version = "3.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "utensils";
     repo = "mcp-nixos";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-S6elg+nneCdUwpG6Y9ABMr/bbRfzCvls0ba2Vva22Lk=";
+    hash = "sha256-EjSyb5FcVnZOW0qFbcvxzor/je02duSe/RhJsL5p+14=";
   };
 
   build-system = [ python3Packages.hatchling ];

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -92,6 +92,12 @@ pythonPackages.buildPythonApplication (finalAttrs: {
       --replace-fail "0.0.0" "${finalAttrs.version}" \
       --replace-fail "==" ">="
 
+    # mcp 2 renamed McpError to MCPError; the fastmcp_server provider pins
+    # fastmcp 3 upstream and has not migrated yet (see disabledTestPaths).
+    substituteInPlace \
+      music_assistant/providers/fastmcp_server/tools/_common.py \
+      --replace-fail McpError MCPError
+
     rm -rv \
       music_assistant/providers/airplay/bin/{cliap2-*,cliraop-*} \
       music_assistant/providers/airplay_receiver/bin/{build_binaries.sh,shairport-sync-*} \
@@ -234,6 +240,9 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     "tests/providers/yandex_music"
     "tests/providers/yandex_ynison"
     "tests/providers/zvuk_music"
+    # provider pins fastmcp 3 upstream; elicitation and MCPError semantics
+    # changed in FastMCP 4 / mcp 2 and the tests encode the old behaviour
+    "tests/providers/fastmcp_server"
     # mocking music_assistant.providers.airplay.pairing.AirPlayPairing does not work
     "tests/providers/airplay/test_player.py::test_start_pairing__pin_decision"
   ];

--- a/pkgs/development/python-modules/fastmcp-slim/default.nix
+++ b/pkgs/development/python-modules/fastmcp-slim/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  fetchpatch,
   pythonAtLeast,
   fastmcp,
 
@@ -17,10 +16,12 @@
   exceptiongroup,
   google-genai,
   griffelib,
-  httpx,
+  httpx2,
+  joserfc,
   jsonref,
   jsonschema-path,
   mcp,
+  mcp-types,
   openai,
   openapi-pydantic,
   opentelemetry-api,
@@ -30,13 +31,13 @@
   pydantic,
   pydantic-monty,
   pydantic-settings,
-  pydocket,
   pyjwt,
   pyperclip,
   python-dotenv,
   python-multipart,
   pyyaml,
   rich,
+  starlette,
   typing-extensions,
   uncalled-for,
   uvicorn,
@@ -53,23 +54,13 @@ buildPythonPackage (finalAttrs: {
   sourceRoot = "${finalAttrs.src.name}/fastmcp_slim";
   pyproject = true;
 
-  patches = [
-    # Fix python 3.14 compatibility (https://github.com/PrefectHQ/fastmcp/pull/4796)
-    # TODO: remove when updating to the next release
-    (fetchpatch {
-      url = "https://github.com/PrefectHQ/fastmcp/commit/6be0ac8e15d35ff8f5121266855bc34c1158c9a1.patch";
-      includes = [ "fastmcp/tools/function_tool.py" ];
-      stripLen = 1;
-      hash = "sha256-zAWIPAH7q9pIOmqWIup5DIDpVk1hOEDxdqQt7QuU8oI=";
-    })
-  ];
-
   build-system = [
     hatchling
     uv-dynamic-versioning
   ];
 
   dependencies = [
+    mcp-types
     platformdirs
     pydantic
     pydantic-settings
@@ -102,15 +93,17 @@ buildPythonPackage (finalAttrs: {
     ];
     mcp = [
       exceptiongroup
-      httpx
+      httpx2
       mcp
       opentelemetry-api
+      starlette
     ];
     openai = [ openai ];
     server = [
       authlib
       cyclopts
       griffelib
+      joserfc
       jsonref
       jsonschema-path
       openapi-pydantic
@@ -128,9 +121,6 @@ buildPythonPackage (finalAttrs: {
     ++ py-key-value-aio.optional-dependencies.filetree
     ++ py-key-value-aio.optional-dependencies.keyring
     ++ py-key-value-aio.optional-dependencies.memory;
-    tasks = [
-      pydocket
-    ];
   };
 
   pythonImportsCheck = [ "fastmcp" ];

--- a/pkgs/development/python-modules/fastmcp-tasks/default.nix
+++ b/pkgs/development/python-modules/fastmcp-tasks/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fastmcp,
+
+  # build-system
+  hatchling,
+  uv-dynamic-versioning,
+
+  # dependencies
+  cryptography,
+  fastmcp-slim,
+  pydocket,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fastmcp-tasks";
+  inherit (fastmcp) version src;
+  sourceRoot = "${finalAttrs.src.name}/fastmcp_tasks";
+  pyproject = true;
+
+  build-system = [
+    hatchling
+    uv-dynamic-versioning
+  ];
+
+  dependencies = [
+    cryptography
+    fastmcp-slim
+    pydocket
+  ]
+  ++ fastmcp-slim.optional-dependencies.server;
+
+  pythonImportsCheck = [ "fastmcp_tasks" ];
+
+  # upstream tests are done in fastmcp package
+  doCheck = false;
+
+  meta = {
+    description = "Background task execution for FastMCP servers via the MCP tasks extension";
+    changelog = "https://github.com/PrefectHQ/fastmcp/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/PrefectHQ/fastmcp/tree/main/fastmcp_tasks";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -11,6 +11,7 @@
 
   # dependencies
   fastmcp-slim,
+  fastmcp-tasks,
 
   # tests
   dirty-equals,
@@ -63,7 +64,7 @@ buildPythonPackage (finalAttrs: {
     code-mode = fastmcp-slim.optional-dependencies.code-mode;
     gemini = fastmcp-slim.optional-dependencies.gemini;
     openai = fastmcp-slim.optional-dependencies.openai;
-    # tasks = [ fastmcp-tasks ]; # unpackaged (split out of fastmcp-slim in 4.0)
+    tasks = [ fastmcp-tasks ];
   };
 
   pythonImportsCheck = [ "fastmcp" ];
@@ -89,6 +90,7 @@ buildPythonPackage (finalAttrs: {
   ++ finalAttrs.passthru.optional-dependencies.code-mode
   ++ finalAttrs.passthru.optional-dependencies.gemini
   ++ finalAttrs.passthru.optional-dependencies.openai
+  ++ finalAttrs.passthru.optional-dependencies.tasks
   ++ inline-snapshot.optional-dependencies.dirty-equals;
 
   disabledTests = [
@@ -115,6 +117,9 @@ buildPythonPackage (finalAttrs: {
 
     # AssertionError: assert 'INFO' == 'DEBUG'
     "test_temporary_settings"
+
+    # Upstream pins pydantic-monty==0.0.18; error propagation differs on 0.0.17
+    "test_code_mode_monty_call_tool_errors_are_catchable"
 
     # Subprocess-based multi-client tests fail in sandbox
     "test_multi_client"

--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   writableTmpDirAsHomeHook,
 
   # build-system
@@ -30,7 +29,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "fastmcp";
-  version = "3.4.7";
+  version = "4.0.2";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -38,18 +37,8 @@ buildPythonPackage (finalAttrs: {
     owner = "PrefectHQ";
     repo = "fastmcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EysVbtFbop5ENupc9T5EmtUSZ8osVtQSzpwa6rea/OQ=";
+    hash = "sha256-YW7cd7AkuZbYulaPOWi6GmM6tWeI+Wc1vt2G7nkj2ak=";
   };
-
-  patches = [
-    # Fix python 3.14 compatibility (https://github.com/PrefectHQ/fastmcp/pull/4796)
-    # TODO: remove when updating to the next release
-    (fetchpatch {
-      url = "https://github.com/PrefectHQ/fastmcp/commit/6be0ac8e15d35ff8f5121266855bc34c1158c9a1.patch";
-      includes = [ "fastmcp_slim/fastmcp/tools/function_tool.py" ];
-      hash = "sha256-7N86b5sslWLgoB2dS2Xh3JfZX3oTHeXfeSJOaWKI5b0=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
@@ -74,7 +63,7 @@ buildPythonPackage (finalAttrs: {
     code-mode = fastmcp-slim.optional-dependencies.code-mode;
     gemini = fastmcp-slim.optional-dependencies.gemini;
     openai = fastmcp-slim.optional-dependencies.openai;
-    tasks = fastmcp-slim.optional-dependencies.tasks;
+    # tasks = [ fastmcp-tasks ]; # unpackaged (split out of fastmcp-slim in 4.0)
   };
 
   pythonImportsCheck = [ "fastmcp" ];
@@ -100,7 +89,6 @@ buildPythonPackage (finalAttrs: {
   ++ finalAttrs.passthru.optional-dependencies.code-mode
   ++ finalAttrs.passthru.optional-dependencies.gemini
   ++ finalAttrs.passthru.optional-dependencies.openai
-  ++ finalAttrs.passthru.optional-dependencies.tasks
   ++ inline-snapshot.optional-dependencies.dirty-equals;
 
   disabledTests = [

--- a/pkgs/development/python-modules/ha-mcp/default.nix
+++ b/pkgs/development/python-modules/ha-mcp/default.nix
@@ -31,6 +31,16 @@ buildPythonPackage (finalAttrs: {
     setuptools
   ];
 
+  # Upstream pins fastmcp==3.4.7. The only API it uses that moved in
+  # FastMCP 4 is ToolResult, now exported from fastmcp.tools.base.
+  postPatch = ''
+    substituteInPlace \
+      src/ha_mcp/tools/tools_config_dashboards.py \
+      src/ha_mcp/tools/tools_dashboard_screenshot.py \
+      src/ha_mcp/visibility/enforcement.py \
+      --replace-fail "from fastmcp.tools.tool import" "from fastmcp.tools.base import"
+  '';
+
   pythonRelaxDeps = true;
 
   dependencies = [

--- a/pkgs/development/python-modules/mcp-types/default.nix
+++ b/pkgs/development/python-modules/mcp-types/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  mcp,
 
   # build-system
   hatchling,
@@ -14,19 +15,10 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mcp-types";
-  version = "2.1.1";
   pyproject = true;
   __structuredAttrs = true;
 
-  src = fetchFromGitHub {
-    owner = "modelcontextprotocol";
-    repo = "python-sdk";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-v3qS18hgOxLjm+IEa/knkfyh0Cz2QFtyqxXTZJepevU=";
-  };
-
-  # TODO: uncomment after bootstrap
-  # inherit (mcp) version src;
+  inherit (mcp) version src;
 
   sourceRoot = "${finalAttrs.src.name}/src/mcp-types";
 

--- a/pkgs/development/python-modules/mcp-types/default.nix
+++ b/pkgs/development/python-modules/mcp-types/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+  uv-dynamic-versioning,
+
+  # dependencies
+  pydantic,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mcp-types";
+  version = "2.1.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "python-sdk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-v3qS18hgOxLjm+IEa/knkfyh0Cz2QFtyqxXTZJepevU=";
+  };
+
+  # TODO: uncomment after bootstrap
+  # inherit (mcp) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/src/mcp-types";
+
+  build-system = [
+    hatchling
+    uv-dynamic-versioning
+  ];
+
+  dependencies = [
+    pydantic
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "mcp_types" ];
+
+  meta = {
+    changelog = "https://github.com/modelcontextprotocol/python-sdk/releases/tag/${finalAttrs.src.tag}";
+    description = "Model Context Protocol wire types";
+    homepage = "https://github.com/modelcontextprotocol/python-sdk";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      daniel-fahey
+    ];
+  };
+})

--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  python,
 
   # build-system
   hatchling,
@@ -10,15 +10,17 @@
 
   # dependencies
   anyio,
-  httpx,
-  httpx-sse,
+  httpx2,
   jsonschema,
+  mcp-types,
+  opentelemetry-api,
   pydantic,
-  pydantic-settings,
   pyjwt,
   python-multipart,
   sse-starlette,
   starlette,
+  typing-extensions,
+  typing-inspection,
   uvicorn,
 
   # optional-dependencies
@@ -27,22 +29,26 @@
   typer,
   # rich
   rich,
-  # ws
-  websockets,
 
   # tests
+  coverage,
   dirty-equals,
+  griffelib,
   inline-snapshot,
+  logfire,
   pytest-asyncio,
   pytest-examples,
   pytest-xdist,
   pytestCheckHook,
+  pyyaml,
   requests,
+  trio,
+  zensical,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "mcp";
-  version = "1.29.0";
+  version = "2.1.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -50,36 +56,27 @@ buildPythonPackage (finalAttrs: {
     owner = "modelcontextprotocol";
     repo = "python-sdk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lRlj5RT/R5zrYL5XpdQR2l9t99G94WTsubN0gSQekMc=";
+    hash = "sha256-v3qS18hgOxLjm+IEa/knkfyh0Cz2QFtyqxXTZJepevU=";
   };
-
-  # time.sleep(0.1) feels a bit optimistic and it has been flaky whilst
-  # testing this on macOS under load.
-  postPatch = lib.optionalString stdenv.buildPlatform.isDarwin ''
-    substituteInPlace tests/client/test_stdio.py \
-      --replace-fail "time.sleep(0.1)" "time.sleep(1)"
-  '';
 
   build-system = [
     hatchling
     uv-dynamic-versioning
   ];
 
-  pythonRelaxDeps = [
-    "pydantic-settings"
-  ];
-
   dependencies = [
     anyio
-    httpx
-    httpx-sse
+    httpx2
     jsonschema
+    mcp-types
+    opentelemetry-api
     pydantic
-    pydantic-settings
     pyjwt
     python-multipart
     sse-starlette
     starlette
+    typing-extensions
+    typing-inspection
     uvicorn
   ];
 
@@ -91,69 +88,49 @@ buildPythonPackage (finalAttrs: {
     rich = [
       rich
     ];
-    ws = [
-      websockets
-    ];
   };
 
   pythonImportsCheck = [ "mcp" ];
 
   nativeCheckInputs = [
+    coverage
     dirty-equals
+    griffelib
     inline-snapshot
+    logfire
+    (buildPythonPackage {
+      pname = "mcp-example-stories";
+      version = "0.0.0";
+      src = finalAttrs.src;
+      sourceRoot = "${finalAttrs.src.name}/examples";
+      pyproject = true;
+      build-system = [ hatchling ];
+      pythonRemoveDeps = [ "mcp" ];
+    })
     pytest-asyncio
     pytest-examples
     pytest-xdist
     pytestCheckHook
+    pyyaml
     requests
+    trio
+    zensical
   ]
   ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
-  pytestFlags = [
-    "-Wignore::pytest.PytestRemovedIn10Warning"
-  ];
-
-  disabledTests = [
-    # attempts to run the package manager uv
-    "test_command_execution"
-
-    # ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
-    "test_lifespan_cleanup_executed"
-
-    # AssertionError: Child process should be writing
-    "test_basic_child_process_cleanup"
-
-    # AssertionError: parent process should be writing
-    "test_nested_process_tree"
-
-    # AssertionError: Child should be writing
-    "test_early_parent_exit"
-
-    # pytest.PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO ...
-    "test_list_tools_returns_all_tools"
-
-    # AssertionError: Server startup marker not created
-    "test_stdin_close_triggers_cleanup"
-
-    # pytest.PytestUnraisableExceptionWarning: Exception ignored in: <function St..
-    "test_resource_template_client_interaction"
-
-    # Flaky: https://github.com/modelcontextprotocol/python-sdk/pull/1171
-    "test_notification_validation_error"
-
-    # Flaky: httpx.ConnectError: All connection attempts failed
-    "test_sse_security_"
-    "test_streamable_http_"
-    "test_streamablehttp_"
-
-    # This just feels a bit optimistic...
-    #     	assert duration < 3 * _sleep_time_seconds
-    # AssertionError: assert 0.0733884589999434 < (3 * 0.01)
-    "test_messages_are_executed_concurrently"
-
-    # ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
-    "test_tool_progress"
-  ];
+  # The stdio transport starts servers as subprocesses,
+  # with only a subset (allowlist) of environment variables.
+  # It doesn't include PYTHONPATH, so tests that spawn a child interpreter can't import mcp.
+  # In upstream CI uv sync installs mcp into the venv's site-packages.
+  # But it does include HOME,
+  # and every Python process adds $HOME's user site directory to sys.path.
+  # So we write the PYTHONPATH to a .pth file there and child interpreters will import mcp again.
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+    local site="$HOME/.local/lib/${python.libPrefix}/site-packages"
+    mkdir -p "$site"
+    tr ':' '\n' <<< "$PYTHONPATH" > "$site/nix-test-env.pth"
+  '';
 
   __darwinAllowLocalNetworking = true;
 
@@ -165,6 +142,7 @@ buildPythonPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       bryanhonof
       josh
+      daniel-fahey
     ];
   };
 })

--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   python,
@@ -131,6 +132,14 @@ buildPythonPackage (finalAttrs: {
     mkdir -p "$site"
     tr ':' '\n' <<< "$PYTHONPATH" > "$site/nix-test-env.pth"
   '';
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Relies on json.loads raising RecursionError for a 100k-deep body; on
+    # Darwin it parses and the server answers INVALID_REQUEST, not PARSE_ERROR.
+    "test_modern_post_with_deeply_nested_body_is_parse_error_not_a_crash"
+    # Timing-sensitive protocol-era probe; fails in the sandbox on Darwin.
+    "test_client_auto_mode_recovers_from_a_timed_out_probe_over_a_stream_loop"
+  ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/pylitterbot/default.nix
+++ b/pkgs/development/python-modules/pylitterbot/default.nix
@@ -5,7 +5,6 @@
   aioresponses,
   buildPythonPackage,
   deepdiff,
-  fastmcp,
   fetchFromGitHub,
   hatchling,
   pycognito,
@@ -41,10 +40,14 @@ buildPythonPackage (finalAttrs: {
     aiointercept
     aiohttp
     deepdiff
-    fastmcp
     pycognito
     pyjwt
   ];
+
+  # The optional `mcp` extra imports `mcp.server.fastmcp`, which mcp 2 removed
+  # (FastMCP moved to the fastmcp package). Drop it until pylitterbot migrates;
+  # the core library, which Home Assistant uses, does not import it.
+  # https://github.com/natekspencer/pylitterbot/blob/2025.6.4/pylitterbot/mcp/server.py
 
   nativeCheckInputs = [
     aioresponses
@@ -53,6 +56,11 @@ buildPythonPackage (finalAttrs: {
     pytest-freezegun
     pytest-timeout
     pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # exercise the mcp extra, see above
+    "tests/test_mcp_*.py"
   ];
 
   pythonImportsCheck = [ "pylitterbot" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10541,6 +10541,8 @@ self: super: with self; {
 
   mcp = callPackage ../development/python-modules/mcp { };
 
+  mcp-types = callPackage ../development/python-modules/mcp-types { };
+
   mcpadapt = callPackage ../development/python-modules/mcpadapt { };
 
   mcstatus = callPackage ../development/python-modules/mcstatus { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22971,6 +22971,8 @@ self: super: with self; {
 
   zenoh = callPackage ../development/python-modules/zenoh { };
 
+  zensical = toPythonModule (pkgs.zensical.override { python3Packages = self; });
+
   zephyr-python-api = callPackage ../development/python-modules/zephyr-python-api { };
 
   zephyr-test-management = callPackage ../development/python-modules/zephyr-test-management { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5944,6 +5944,8 @@ self: super: with self; {
 
   fastmcp-slim = callPackage ../development/python-modules/fastmcp-slim { };
 
+  fastmcp-tasks = callPackage ../development/python-modules/fastmcp-tasks { };
+
   fastmri = callPackage ../development/python-modules/fastmri { };
 
   fastnlo-toolkit = toPythonModule (


### PR DESCRIPTION
Updates the FastMCP stack to MCP protocol revision 2026-07-28 and bumps mcp-nixos to the release that requires it.

Stacked on #556839 (`python3Packages.mcp: 1.29.0 -> 2.1.1`, by @daniel-fahey): its three commits are included here unchanged, with authorship preserved, because FastMCP 4 needs MCP SDK 2 and `mcp-types`. I will rebase once that PR merges. On top of it:

- `python3Packages.mcp`: disable two tests that fail only on Darwin (`test_modern_post_with_deeply_nested_body_is_parse_error_not_a_crash` relies on `json.loads` raising `RecursionError` at 100k nesting, which does not happen on Darwin; the other is a timing-sensitive protocol-era probe). Both pass on x86_64-linux.
- `python3Packages.fastmcp`: 3.4.7 -> 4.0.2. Diff: https://github.com/PrefectHQ/fastmcp/compare/v3.4.7...v4.0.2, changelog: https://github.com/PrefectHQ/fastmcp/releases/tag/v4.0.2. fastmcp-slim now depends on `mcp-types` and, in the `mcp` extra, on `httpx2` and `starlette >= 1.0.1` (CVE-2026-48710) instead of `httpx`; the `server` extra gains `joserfc`; `pydocket` is no longer a direct dependency. The Python 3.14 patch is upstream in 4.0.2 and is dropped. `test_code_mode_monty_call_tool_errors_are_catchable` is disabled because upstream pins `pydantic-monty==0.0.18` and nixpkgs ships 0.0.17.
- `python3Packages.fastmcp-tasks`: init at 4.0.2. The background-task extension was split out of fastmcp-slim in 4.0 into its own distribution in the same source tree (built like fastmcp-slim). fastmcp's `tasks` extra and its test suite use it.
- `mcp-nixos`: 3.0.1 -> 3.1.0. Diff: https://github.com/utensils/mcp-nixos/compare/v3.0.1...v3.1.0, changelog: https://github.com/utensils/mcp-nixos/blob/v3.1.0/RELEASE_NOTES.md. 3.1.0 requires `fastmcp >= 4`; on the current fastmcp 3.4.7 it fails the runtime dependency check. I maintain mcp-nixos upstream.

### Reverse dependencies

fastmcp 3.4.7 pins `mcp<2.0`, so #556839 on its own breaks fastmcp and everything below it; this PR is its companion. All fastmcp dependents in nixpkgs were built on x86_64-linux against the new stack:

- `oterm`, `pdf-mcp`, `python3Packages.vulners`: build unchanged.
- `python3Packages.ha-mcp`: upstream still pins `fastmcp==3.4.7`; the only API it uses that moved is `ToolResult` (`fastmcp.tools.tool` -> `fastmcp.tools.base`), patched in `postPatch`.
- `python3Packages.pylitterbot`: its optional `mcp` extra imports `mcp.server.fastmcp`, which mcp 2 removed. nixpkgs had `fastmcp` as a hard dependency for it; it is dropped and the extra's tests are skipped. The core library, which Home Assistant uses, does not import it.
- `music-assistant`: the `fastmcp_server` provider pins fastmcp 3 upstream. `McpError` -> `MCPError` is patched so the provider imports, but elicitation semantics and the `MCPError` constructor changed, so `tests/providers/fastmcp_server` is skipped until upstream migrates. Everything else in its suite (3269 tests) passes.

### Builds

- x86_64-linux (all of the above, plus `python3Packages.mcp` with its full test suite and `python3Packages.fastmcp` with its full suite: 6987 passed).
- aarch64-darwin: `python3Packages.mcp` (5801 passed with the two Darwin-only tests disabled), `python3Packages.fastmcp` (6987 passed), `mcp-nixos` (430 passed).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
