### PR TITLE
mac80211-hwsim-mgmt: init at unstable-2020-03-11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12627,6 +12627,11 @@
     githubId = 47289484;
     name = "Jack Avery";
   };
+  jacka10086 = {
+    github = "Jacka10086";
+    githubId = 111729221;
+    name = "Jacka";
+  };
   jackcres = {
     email = "crespomerchano@gmail.com";
     github = "omarcresp";

--- a/pkgs/by-name/ma/mac80211-hwsim-mgmt/package.nix
+++ b/pkgs/by-name/ma/mac80211-hwsim-mgmt/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libevent,
+  libnl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mac80211-hwsim-mgmt";
+  version = "unstable-2020-03-11";
+
+  # The upstream repository (patgrosse/mac80211_hwsim_mgmt) is unmaintained
+  # since 2017; Mininet-WiFi maintains this fork and vendors it in its
+  # installation script (util/install.sh).
+  src = fetchFromGitHub {
+    owner = "ramonfontes";
+    repo = "mac80211_hwsim_mgmt";
+    rev = "9d2cb2138bc41d1ee0227b4770aa8fc76f52fa13";
+    hash = "sha256-sbE7Oas24YKN7JJPSqVa7iizxAIMrCQsL30simVdy1E=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libevent
+    libnl
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 hwsim_mgmt/hwsim_mgmt $out/bin/hwsim_mgmt
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Management tool for the mac80211_hwsim kernel module";
+    homepage = "https://github.com/ramonfontes/mac80211_hwsim_mgmt";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jacka10086 ];
+    mainProgram = "hwsim_mgmt";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Introduces `mac80211-hwsim-mgmt` (`hwsim_mgmt`), the management tool for the `mac80211_hwsim` kernel module: create/delete virtual radios and set per-radio properties over netlink genl. It is a dependency of Mininet-WiFi wireless SDN setups.

Packages the [ramonfontes/mac80211_hwsim_mgmt](https://github.com/ramonfontes/mac80211_hwsim_mgmt) fork at the pinned commit `9d2cb21` (2020-03-11): the upstream repository (`patgrosse/mac80211_hwsim_mgmt`) is unmaintained since 2017, and the fork is the version Mininet-WiFi vendors in its installation script (`util/install.sh`). License MIT.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
