### PR TITLE
python3Packages.nexblue-api: init at 0.1.3

### DIFF
--- a/pkgs/development/python-modules/nexblue-api/default.nix
+++ b/pkgs/development/python-modules/nexblue-api/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
+  pythonOlder,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "nexblue-api";
+  version = "0.1.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.13";
+
+  src = fetchFromGitHub {
+    owner = "NexBlue-AB";
+    repo = "nexblue-api";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-y9GDSI98n79Kob/Wpxihdi6EK9/bd1wqbpHPYV0vVzA=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "nexblue_api" ];
+
+  meta = {
+    description = "Async client for the NexBlue OpenAPI";
+    homepage = "https://github.com/NexBlue-AB/nexblue-api";
+    changelog = "https://github.com/NexBlue-AB/nexblue-api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4813,7 +4813,8 @@
       ];
     "nexblue" =
       ps: with ps; [
-      ]; # missing inputs: nexblue-api
+        nexblue-api
+      ];
     "nexen" =
       ps: with ps; [
       ];
@@ -8981,6 +8982,7 @@
     "netgear_lte"
     "netio"
     "network"
+    "nexblue"
     "nexia"
     "nextbus"
     "nextcloud"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11946,6 +11946,8 @@ self: super: with self; {
 
   newversion = callPackage ../development/python-modules/newversion { };
 
+  nexblue-api = callPackage ../development/python-modules/nexblue-api { };
+
   nexia = callPackage ../development/python-modules/nexia { };
 
   nextcloudmonitor = callPackage ../development/python-modules/nextcloudmonitor { };


### PR DESCRIPTION
- https://pypi.org/project/nexblue-api/
- https://github.com/NexBlue-AB/nexblue-api
- https://www.home-assistant.io/integrations/nexblue/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
