### PR TITLE
python3Packages.samsung-exlink: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/samsung-exlink/default.nix
+++ b/pkgs/development/python-modules/samsung-exlink/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pyprojectVersionPatchHook,
+  pytest-asyncio,
+  pytest-timeout,
+  pytestCheckHook,
+  serialx,
+  uv-build,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "samsung-exlink";
+  version = "1.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = "samsung-exlink";
+    tag = finalAttrs.version;
+    hash = "sha256-JnuHinva05/nG93qNYojIe6c/UkjrN2y16Cwi1BnQQM=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.8.4,<0.9.0" "uv_build"
+  '';
+
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
+
+  build-system = [ uv-build ];
+
+  dependencies = [ serialx ] ++ serialx.optional-dependencies.esphome;
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "samsung_exlink" ];
+
+  meta = {
+    description = "Async library to control Samsung consumer TVs over RS232";
+    homepage = "https://github.com/home-assistant-libs/samsung-exlink";
+    changelog = "https://github.com/home-assistant-libs/samsung-exlink/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -6208,8 +6208,9 @@
       ps: with ps; [
         aiohasupervisor
         aiousbwatcher
+        samsung-exlink
         serialx
-      ]; # missing inputs: samsung-exlink
+      ];
     "samsung_infrared" =
       ps: with ps; [
         infrared-protocols
@@ -9177,6 +9178,7 @@
     "rympro"
     "sabnzbd"
     "saj"
+    "samsung_exlink"
     "samsung_infrared"
     "samsungtv"
     "sanix"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18431,6 +18431,8 @@ self: super: with self; {
     inherit (pkgs) libsamplerate;
   };
 
+  samsung-exlink = callPackage ../development/python-modules/samsung-exlink { };
+
   samsungctl = callPackage ../development/python-modules/samsungctl { };
 
   samsungtvws = callPackage ../development/python-modules/samsungtvws { };


### PR DESCRIPTION
- https://pypi.org/project/samsung-exlink/
- https://github.com/home-assistant-libs/samsung-exlink
- https://www.home-assistant.io/integrations/samsung_exlink/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
