### PR TITLE
python3Packages.tonewinner-rs232: init at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/tonewinner-rs232/default.nix
+++ b/pkgs/development/python-modules/tonewinner-rs232/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest-asyncio,
+  pytest-timeout,
+  pytestCheckHook,
+  serialx,
+  uv-build,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "tonewinner-rs232";
+  version = "1.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "emma-sg";
+    repo = "tonewinner-rs232";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Zi7yjEv1GXBfETiHLs7RbQNk1z5jK35wHEs49/z/mjw=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [ serialx ] ++ serialx.optional-dependencies.esphome;
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "tonewinner_rs232" ];
+
+  meta = {
+    description = "Async Python library for Tonewinner AV processors over RS232 serial";
+    homepage = "https://github.com/emma-sg/tonewinner-rs232";
+    changelog = "https://github.com/emma-sg/tonewinner-rs232/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -7369,7 +7369,8 @@
         aiohasupervisor
         aiousbwatcher
         serialx
-      ]; # missing inputs: tonewinner-rs232
+        tonewinner-rs232
+      ];
     "toon" =
       ps: with ps; [
         aiohasupervisor
@@ -9334,6 +9335,7 @@
     "tolo"
     "tomato"
     "tomorrowio"
+    "tonewinner"
     "toon"
     "totalconnect"
     "touchline"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20808,6 +20808,8 @@ self: super: with self; {
 
   tomlrt = callPackage ../development/python-modules/tomlrt { };
 
+  tonewinner-rs232 = callPackage ../development/python-modules/tonewinner-rs232 { };
+
   toolz = callPackage ../development/python-modules/toolz { };
 
   toonapi = callPackage ../development/python-modules/toonapi { };


### PR DESCRIPTION
- https://pypi.org/project/tonewinner-rs232/
- https://github.com/emma-sg/tonewinner-rs232
- https://www.home-assistant.io/integrations/tonewinner/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
