### PR TITLE
fastcrw: compile tests in debug mode

### DIFF
--- a/pkgs/by-name/fa/fastcrw/package.nix
+++ b/pkgs/by-name/fa/fastcrw/package.nix
@@ -36,6 +36,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoTestFlags = [ "--no-fail-fast" ];
 
+  # Optimizing test binaries with fat LTO takes over 100 minutes on Hydra,
+  # while the tests themselves finish in about two minutes.
+  checkType = "debug";
+
   checkFlags = [
     # Dials a blackhole address to assert the error is a connect-phase timeout;
     # the sandbox has no route at all, so it fails fast as "network unreachable".


### PR DESCRIPTION
Test binaries should not be compiled in release mode. Set `checkType = "debug"`. Release package remains fat LTO.

On an 8-core machine: before: 37m02.778s, after: 14m27.260s (-22m35.518s -61.0%).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
