### PR TITLE
python3Packages.python-hotspring: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/python-hotspring/default.nix
+++ b/pkgs/development/python-modules/python-hotspring/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  aiohttp,
+  aresponses,
+  awesomeversion,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pyprojectVersionPatchHook,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytestCheckHook,
+  python-backoff,
+  yarl,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "python-hotspring";
+  version = "2.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Moustachauve";
+    repo = "python-hotspring";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TE/Gp2jXHjm3iSdh6aGg9ieT+OISype5CYTp17SdVxs=";
+  };
+
+  build-system = [ poetry-core ];
+
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
+
+  dependencies = [
+    aiohttp
+    awesomeversion
+    python-backoff
+    yarl
+  ];
+
+  nativeCheckInputs = [
+    aresponses
+    pytest-asyncio
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "hotspring" ];
+
+  meta = {
+    description = "Asynchronous Python client for Hot Spring Connected Spa Kit 2";
+    homepage = "https://github.com/Moustachauve/python-hotspring";
+    changelog = "https://github.com/Moustachauve/python-hotspring/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2923,7 +2923,8 @@
       ]; # missing inputs: aiohortos
     "hotspring" =
       ps: with ps; [
-      ]; # missing inputs: python-hotspring
+        python-hotspring
+      ];
     "hp_ilo" =
       ps: with ps; [
         python-hpilo
@@ -8738,6 +8739,7 @@
     "homeworks"
     "honeywell"
     "honeywell_string_lights"
+    "hotspring"
     "hr_energy_qube"
     "html5"
     "http"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16864,6 +16864,8 @@ self: super: with self; {
 
   python-hosts = callPackage ../development/python-modules/python-hosts { };
 
+  python-hotspring = callPackage ../development/python-modules/python-hotspring { };
+
   python-hpilo = callPackage ../development/python-modules/python-hpilo { };
 
   python-http-client = callPackage ../development/python-modules/python-http-client { };


### PR DESCRIPTION
- https://pypi.org/project/python-hotspring/
- https://github.com/Moustachauve/python-hotspring
- https://www.home-assistant.io/integrations/hotspring/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
