### PR TITLE
fastcrw: 0.32.0 -> 0.33.0

### DIFF
--- a/pkgs/by-name/fa/fastcrw/package.nix
+++ b/pkgs/by-name/fa/fastcrw/package.nix
@@ -10,17 +10,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fastcrw";
-  version = "0.32.0";
+  version = "0.33.0";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "us";
     repo = "crw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zk8xjKPPifNiHqx/B01ZG3r9xgoG1p1D1M7LhQoHD5Y=";
+    hash = "sha256-ltZoCLgIR7jBBsyggLwZspwqCNspH4+jqpadyQ2HS/0=";
   };
 
-  cargoHash = "sha256-yVh3B9Xl5yB9YWG0+lDOudnD1qi2VpAWBnItFZiRr3c=";
+  cargoHash = "sha256-G4N82svyVX9MXRHLH9nrPXVl6PQWxVwzr8eRKYwezic=";
 
   # aws-lc-sys drives its C build through cmake and generates its bindings.
   nativeBuildInputs = [
@@ -37,9 +37,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoTestFlags = [ "--no-fail-fast" ];
 
   checkFlags = [
-    # Dials a blackhole address to assert the error is a connect-phase timeout;
+    # Dial a blackhole address to assert the error is a connect-phase timeout;
     # the sandbox has no route at all, so it fails fast as "network unreachable".
     "--skip=http_only::tests::connection_failure_catches_connect_timeout"
+    "--skip=http_only::tests::is_retriable_error_false_for_connect_timeout"
 
     # The SSRF guard resolves the destination before a request is accepted, so
     # in the sandbox these get "DNS resolution failed" instead of the response


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
