### PR TITLE
kdePackages.aerothemeplasma: init at 6.7.0-unstable-2026-08-22; nixos/aerothemeplasma: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -32,6 +32,8 @@
 
 - [compsize](https://github.com/kilobyte/compsize), setcap wrapper for `compsize` package, a cli utility to to inspect compression type/ratio on BTRFS filesystems. Available as [programs.compsize](#opt-programs.compsize.enable)
 
+- [AeroThemePlasma](https://gitgud.io/aeroshell/atp/aerothemeplasma), an alternative shell for KDE Plasma that aims to replicate the look and feel of Windows 7. Available as [programs.aerothemeplasma](#opt-programs.aerothemeplasma.enable).
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [Cardwire](https://github.com/OpenGamingCollective/cardwire), a GPU manager for Linux that uses eBPF+LSM hooks to control GPUs. Available as [services.cardwired](#opt-services.cardwired.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -163,6 +163,7 @@
   ./misc/wordlist.nix
   ./programs/_1password-gui.nix
   ./programs/_1password.nix
+  ./programs/aerothemeplasma.nix
   ./programs/alvr.nix
   ./programs/amnezia-vpn.nix
   ./programs/appgate-sdp.nix

--- a/nixos/modules/programs/aerothemeplasma.nix
+++ b/nixos/modules/programs/aerothemeplasma.nix
@@ -1,0 +1,104 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.aerothemeplasma;
+
+  aeroKdePackages = pkgs.kdePackages.aerothemeplasmaPackages;
+in
+{
+  options.programs.aerothemeplasma = {
+    enable = lib.mkEnableOption null // {
+      description = ''
+        Whether to enable AeroThemePlasma.
+
+        This is a project which aims to recreate the look and feel of Windows 7
+        as much as possible on KDE Plasma, whilst adapting the design to fit in
+        with modern features provided by KDE Plasma and Linux.
+      '';
+    };
+
+    kwinComponents.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to install SMOD and the AeroShell KWin components.";
+    };
+
+    assets.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to install the unfree Windows 7 icon, cursor, and sound themes.";
+    };
+
+    uacAgent.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether AeroThemePlasma sessions use the UAC Polkit Agent.";
+    };
+
+    sddm.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to use AeroThemePlasma's Windows 7 SDDM theme.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.services.desktopManager.plasma6.enable;
+        message = "programs.aerothemeplasma requires services.desktopManager.plasma6.enable = true.";
+      }
+    ];
+
+    environment.systemPackages = [
+      aeroKdePackages.aerothemeplasma
+      pkgs.kdePackages.qtstyleplugin-kvantum
+    ]
+    ++ lib.optionals cfg.kwinComponents.enable [
+      pkgs.kdePackages.smod
+      pkgs.kdePackages.aeroshell-kwin-components
+    ]
+    ++ lib.optionals cfg.assets.enable [
+      pkgs.kdePackages.aerothemeplasma-icons
+      pkgs.kdePackages.aerothemeplasma-sounds
+    ];
+
+    services.displayManager = {
+      sessionPackages = [ aeroKdePackages.aerothemeplasma ];
+
+      sddm = {
+        theme = lib.mkIf cfg.sddm.enable (
+          lib.mkOverride 900 "${aeroKdePackages.aerothemeplasma}/share/sddm/themes/sddm-theme-mod"
+        );
+
+        # The SDDM theme imports QtMultimedia, so add it to the greeter environment
+        extraPackages = lib.mkIf cfg.sddm.enable [ pkgs.kdePackages.qtmultimedia ];
+      };
+    };
+
+    # Stock sessions need stock libplasma, so select plasmashell by session
+    systemd.user.services.plasma-plasmashell = {
+      overrideStrategy = "asDropin";
+      serviceConfig.ExecStart = [
+        ""
+        ''/bin/sh -c "if [ \"$PLASMA_DEFAULT_SHELL\" = ${aeroKdePackages.aerothemeplasma.shellId} ]; then exec ${lib.getBin aeroKdePackages.plasma-workspace}/bin/plasmashell --no-respawn; else exec ${lib.getBin pkgs.kdePackages.plasma-workspace}/bin/plasmashell --no-respawn; fi"''
+      ];
+    };
+
+    # Stock sessions need KDE's agent, so select the polkit agent by session
+    systemd.user.services.plasma-polkit-agent = lib.mkIf cfg.uacAgent.enable {
+      overrideStrategy = "asDropin";
+      serviceConfig.ExecStart = [
+        ""
+        ''/bin/sh -c "if [ -n \"$USE_UAC_AGENT\" ]; then exec ${pkgs.kdePackages.aeroshell-uac-polkit-agent}/libexec/uac-polkit-agent; else exec ${pkgs.kdePackages.polkit-kde-agent-1}/libexec/polkit-kde-authentication-agent-1; fi"''
+      ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ aaravrav ];
+}

--- a/nixos/tests/aerothemeplasma.nix
+++ b/nixos/tests/aerothemeplasma.nix
@@ -1,0 +1,216 @@
+# AeroThemePlasma "currently lacks full Wayland support", so test X11
+{ pkgs, ... }:
+
+let
+  evalModule =
+    {
+      enable,
+      plasma ? false,
+    }:
+    import ../lib/eval-config.nix {
+      system = null;
+      modules = [
+        {
+          boot.isContainer = true;
+          nixpkgs.config.allowUnfree = true;
+          nixpkgs.hostPlatform = "x86_64-linux";
+          system.stateVersion = "26.05";
+          programs.aerothemeplasma.enable = enable;
+          services.desktopManager.plasma6.enable = plasma;
+        }
+      ];
+    };
+
+  evaluates = args: (builtins.tryEval (evalModule args).config.system.build.toplevel.drvPath).success;
+
+  common =
+    { ... }:
+    {
+      imports = [ ./common/user-account.nix ];
+      nixpkgs.config.allowUnfree = true;
+      virtualisation.memorySize = 2047;
+      services.xserver.enable = true;
+      services.displayManager.sddm.enable = true;
+      services.desktopManager.plasma6.enable = true;
+      programs.aerothemeplasma.enable = true;
+    };
+
+  autoLogin = session: {
+    services.displayManager.defaultSession = session;
+    services.displayManager.autoLogin = {
+      enable = true;
+      user = "alice";
+    };
+  };
+in
+assert evaluates { enable = false; };
+assert !(evaluates { enable = true; });
+assert evaluates {
+  enable = true;
+  plasma = true;
+};
+{
+  name = "aerothemeplasma";
+  meta = {
+    maintainers = [ pkgs.lib.maintainers.aaravrav ];
+    # Hydra cannot build unfree assets, so disable this test there
+    hydraPlatforms = [ ];
+  };
+
+  enableOCR = true;
+
+  node.pkgsReadOnly = false;
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [
+        common
+        (autoLogin "aerothemeplasmax11")
+      ];
+      users.users.alice.extraGroups = [ "wheel" ];
+    };
+
+  nodes.stock =
+    { ... }:
+    {
+      imports = [
+        common
+        (autoLogin "plasmax11")
+      ];
+      programs.aerothemeplasma = {
+        assets.enable = false;
+        kwinComponents.enable = false;
+        sddm.enable = false;
+      };
+    };
+
+  # SDDM login automation is flaky, so test only the greeter
+  nodes.greeter =
+    { ... }:
+    {
+      imports = [ common ];
+      services.displayManager.defaultSession = "plasmax11";
+      programs.aerothemeplasma.uacAgent.enable = false;
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      aeroPackage = pkgs.kdePackages.aerothemeplasmaPackages.aerothemeplasma;
+      aeroTheme = "${aeroPackage}/share/sddm/themes/sddm-theme-mod";
+      mismatchedLibplasma = pkgs.kdePackages.aerothemeplasma-libplasma.override {
+        libplasma = pkgs.kdePackages.libplasma.overrideAttrs {
+          version = "0";
+          __intentionallyOverridingVersion = true;
+        };
+      };
+      forkLibplasma = pkgs.kdePackages.aerothemeplasma-libplasma;
+      uacAgent = pkgs.kdePackages.aeroshell-uac-polkit-agent;
+      user = nodes.machine.users.users.alice;
+    in
+    assert !forkLibplasma.meta.broken;
+    assert mismatchedLibplasma.meta.broken;
+    assert builtins.hasAttr "plasma-polkit-agent" nodes.stock.systemd.user.services;
+    assert !(builtins.hasAttr "plasma-polkit-agent" nodes.greeter.systemd.user.services);
+    ''
+      def wait_for_shell(m):
+          m.wait_for_file("/run/user/1000/xauth_*")
+          m.wait_until_succeeds("test -s /run/user/1000/xauth_*")
+          m.succeed("xauth merge /run/user/1000/xauth_*")
+          m.succeed("su - ${user.name} -c 'xauth merge /run/user/1000/xauth_*'")
+          m.wait_until_succeeds("pgrep plasmashell")
+          m.wait_for_window("^Desktop ")
+
+      start_all()
+
+      with subtest("Wait for the AeroThemePlasma session"):
+          wait_for_shell(machine)
+
+      with subtest("Check plasmashell started with the AeroThemePlasma shell"):
+          machine.succeed(
+              "grep -z PLASMA_DEFAULT_SHELL=io.gitgud.wackyideas.desktop /proc/$(pgrep -o plasmashell)/environ"
+          )
+
+      with subtest("Check plasmashell loaded the forked libplasma"):
+          machine.succeed(
+              "grep -qF '${forkLibplasma}' /proc/$(pgrep -o plasmashell)/maps"
+          )
+
+      with subtest("Check packaged components and assets"):
+          machine.succeed(
+              "test -x '${aeroPackage}/bin/startatp-wayland'",
+              "test -x '${aeroPackage}/bin/atpootb-autostart'",
+              "test -f '${aeroPackage}/share/wayland-sessions/aerothemeplasma.desktop'",
+              "test -f '${aeroPackage}/lib/qt-6/qml/aeroshell/utils/qmldir'",
+              "grep -qxF 'Exec=${aeroPackage}/bin/atpootb-autostart' '${aeroPackage}/etc/xdg/autostart/x-atpootb.desktop'",
+              "grep -qxF 'Theme=Windows 7 Aero' '${aeroPackage}/etc/xdg/aerothemeplasma/kdeglobals'",
+              "grep -qxF 'Theme=Windows 7' '${aeroPackage}/etc/xdg/aerothemeplasma/kdeglobals'",
+              "grep -qxF 'cursorTheme=aero-drop' '${aeroPackage}/etc/xdg/aerothemeplasma/kcminputrc'",
+              "test -f '/run/current-system/sw/share/icons/Windows 7 Aero/index.theme'",
+              "test -f /run/current-system/sw/share/icons/aero-drop/index.theme",
+              "test -f '/run/current-system/sw/share/sounds/Windows 7/index.theme'",
+              "test -f '${uacAgent}/share/systemd/user/plasma-polkit-agent.service.d/uac-polkit-agent.conf'",
+          )
+
+      with subtest("Check KWin components are installed"):
+          machine.succeed(
+              "test -f /run/current-system/sw/lib/qt-6/plugins/org.kde.kdecoration3/org.smod.smod.so",
+              "test -f /run/current-system/sw/lib/qt-6/plugins/kwin/effects/plugins/aeroglassblur.so",
+              "test -f /run/current-system/sw/lib/plugins/kwin-x11/effects/plugins/aeroglassblur.so",
+          )
+
+      with subtest("Check the start menu and taskbar plasmoids loaded"):
+          machine.fail(
+              "journalctl -b | grep -E 'error loading (SevenStart|SevenTasks)|MenuRepresentation unavailable|Cannot assign to non-existent property'"
+          )
+
+      with subtest("Check the UAC agent registered as the session's polkit agent"):
+          machine.wait_until_succeeds("pgrep -f uac-polkit-agent")
+          machine.wait_until_succeeds(
+              "journalctl -b | grep -F 'uac-polkit-agent' | grep -q 'Listener online'"
+          )
+
+      with subtest("Check the AeroThemePlasma lock screen loads"):
+          machine.succeed(
+              "sudo -u alice env XDG_RUNTIME_DIR=/run/user/1000 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus busctl --user call org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver Lock"
+          )
+          machine.wait_until_succeeds("pgrep -f kscreenlocker_greet")
+          machine.fail(
+              "journalctl -b | grep -F 'module \"aeroshell.utils\" is not installed'"
+          )
+
+      with subtest("Check the configured SDDM greeter renders"):
+          greeter.wait_until_succeeds("pgrep -f sddm-greeter")
+          greeter.succeed(
+              "grep -qxF 'Current=${aeroTheme}' /etc/sddm.conf.d/00-nixos.conf"
+          )
+          greeter.wait_for_text(r"(Password|alice|Alice)")
+          greeter.fail(
+              "journalctl -b | grep -iE 'could not load theme|module \"QtMultimedia\" is not installed'"
+          )
+
+      with subtest("Check the disabled options and stock session fallback"):
+          wait_for_shell(stock)
+          stock.fail(
+              "grep -qF '${forkLibplasma}' /proc/$(pgrep -o plasmashell)/maps"
+          )
+          stock.fail(
+              "grep -qxF 'Current=${aeroTheme}' /etc/sddm.conf.d/00-nixos.conf"
+          )
+          stock.fail(
+              "test -e /run/current-system/sw/lib/qt-6/plugins/org.kde.kdecoration3/org.smod.smod.so"
+          )
+          stock.fail(
+              "test -e /run/current-system/sw/lib/qt-6/plugins/kwin/effects/plugins/aeroglassblur.so"
+          )
+          stock.fail(
+              "test -e '/run/current-system/sw/share/icons/Windows 7 Aero/index.theme'"
+          )
+          stock.fail(
+              "test -e '/run/current-system/sw/share/sounds/Windows 7/index.theme'"
+          )
+          stock.wait_until_succeeds("pgrep -f polkit-kde-authentication-agent-1")
+          stock.fail("pgrep -f uac-polkit-agent")
+    '';
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -203,6 +203,7 @@ in
   activation-var = runTest ./activation/var.nix;
   actual = runTest ./actual.nix;
   adguardhome = runTest ./adguardhome.nix;
+  aerothemeplasma = runTestOn [ "x86_64-linux" ] ./aerothemeplasma.nix;
   aesmd = runTestOn [ "x86_64-linux" ] ./aesmd.nix;
   agate = runTest ./web-servers/agate.nix;
   agda = import ./agda {

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -97,6 +97,15 @@ let
         aerothemeplasma-icons = self.callPackage ./third-party/aerothemeplasma-icons { };
         aerothemeplasma-libplasma = self.callPackage ./third-party/aerothemeplasma-libplasma { };
         aerothemeplasma-sounds = self.callPackage ./third-party/aerothemeplasma-sounds { };
+
+        # Evaluators otherwise recurse through a second KDE package set, so hide the forked scope
+        aerothemeplasmaPackages = lib.dontRecurseIntoAttrs (
+          self.overrideScope (
+            _: _: {
+              libplasma = self.aerothemeplasma-libplasma;
+            }
+          )
+        );
         applet-window-buttons6 = self.callPackage ./third-party/applet-window-buttons6 { };
         dynamic-workspaces = self.callPackage ./third-party/dynamic-workspaces { };
         karousel = self.callPackage ./third-party/karousel { };
@@ -107,8 +116,12 @@ let
         wallpaper-engine-plugin = self.callPackage ./third-party/wallpaper-engine-plugin { };
       }
     );
+  scope = makeScopeWithSplicing' {
+    otherSplices = generateSplicesForMkScope "kdePackages";
+    f = allPackages;
+  };
 in
-makeScopeWithSplicing' {
-  otherSplices = generateSplicesForMkScope "kdePackages";
-  f = allPackages;
+scope
+// {
+  aerothemeplasma = scope.aerothemeplasmaPackages.aerothemeplasma;
 }

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -91,6 +91,7 @@ let
         polkit-qt-1 = self.callPackage ./misc/polkit-qt-1 { };
         pulseaudio-qt = self.callPackage ./misc/pulseaudio-qt { };
 
+        aerothemeplasma = self.callPackage ./third-party/aerothemeplasma { };
         applet-window-buttons6 = self.callPackage ./third-party/applet-window-buttons6 { };
         dynamic-workspaces = self.callPackage ./third-party/dynamic-workspaces { };
         karousel = self.callPackage ./third-party/karousel { };

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -95,6 +95,7 @@ let
         aeroshell-uac-polkit-agent = self.callPackage ./third-party/aeroshell-uac-polkit-agent { };
         aerothemeplasma = self.callPackage ./third-party/aerothemeplasma { };
         aerothemeplasma-icons = self.callPackage ./third-party/aerothemeplasma-icons { };
+        aerothemeplasma-libplasma = self.callPackage ./third-party/aerothemeplasma-libplasma { };
         aerothemeplasma-sounds = self.callPackage ./third-party/aerothemeplasma-sounds { };
         applet-window-buttons6 = self.callPackage ./third-party/applet-window-buttons6 { };
         dynamic-workspaces = self.callPackage ./third-party/dynamic-workspaces { };

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -92,6 +92,7 @@ let
         pulseaudio-qt = self.callPackage ./misc/pulseaudio-qt { };
 
         aeroshell-kwin-components = self.callPackage ./third-party/aeroshell-kwin-components { };
+        aeroshell-uac-polkit-agent = self.callPackage ./third-party/aeroshell-uac-polkit-agent { };
         aerothemeplasma = self.callPackage ./third-party/aerothemeplasma { };
         aerothemeplasma-icons = self.callPackage ./third-party/aerothemeplasma-icons { };
         aerothemeplasma-sounds = self.callPackage ./third-party/aerothemeplasma-sounds { };

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -98,6 +98,7 @@ let
         koi = self.callPackage ./third-party/koi { };
         krohnkite = self.callPackage ./third-party/krohnkite { };
         kzones = self.callPackage ./third-party/kzones { };
+        smod = self.callPackage ./third-party/smod { };
         wallpaper-engine-plugin = self.callPackage ./third-party/wallpaper-engine-plugin { };
       }
     );

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -91,6 +91,7 @@ let
         polkit-qt-1 = self.callPackage ./misc/polkit-qt-1 { };
         pulseaudio-qt = self.callPackage ./misc/pulseaudio-qt { };
 
+        aeroshell-kwin-components = self.callPackage ./third-party/aeroshell-kwin-components { };
         aerothemeplasma = self.callPackage ./third-party/aerothemeplasma { };
         applet-window-buttons6 = self.callPackage ./third-party/applet-window-buttons6 { };
         dynamic-workspaces = self.callPackage ./third-party/dynamic-workspaces { };

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -93,6 +93,7 @@ let
 
         aeroshell-kwin-components = self.callPackage ./third-party/aeroshell-kwin-components { };
         aerothemeplasma = self.callPackage ./third-party/aerothemeplasma { };
+        aerothemeplasma-icons = self.callPackage ./third-party/aerothemeplasma-icons { };
         applet-window-buttons6 = self.callPackage ./third-party/applet-window-buttons6 { };
         dynamic-workspaces = self.callPackage ./third-party/dynamic-workspaces { };
         karousel = self.callPackage ./third-party/karousel { };

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -94,6 +94,7 @@ let
         aeroshell-kwin-components = self.callPackage ./third-party/aeroshell-kwin-components { };
         aerothemeplasma = self.callPackage ./third-party/aerothemeplasma { };
         aerothemeplasma-icons = self.callPackage ./third-party/aerothemeplasma-icons { };
+        aerothemeplasma-sounds = self.callPackage ./third-party/aerothemeplasma-sounds { };
         applet-window-buttons6 = self.callPackage ./third-party/applet-window-buttons6 { };
         dynamic-workspaces = self.callPackage ./third-party/dynamic-workspaces { };
         karousel = self.callPackage ./third-party/karousel { };

--- a/pkgs/kde/third-party/aeroshell-kwin-components/default.nix
+++ b/pkgs/kde/third-party/aeroshell-kwin-components/default.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  extra-cmake-modules,
+  kcmutils,
+  kcolorscheme,
+  kconfig,
+  kconfigwidgets,
+  kcoreaddons,
+  kcrash,
+  kdecoration,
+  kguiaddons,
+  ki18n,
+  kiconthemes,
+  kio,
+  kirigami,
+  knotifications,
+  kservice,
+  ksvg,
+  kwidgetsaddons,
+  kwin,
+  kwin-x11,
+  kwindowsystem,
+  libepoxy,
+  libx11,
+  libxcb,
+  nix-update-script,
+  pkg-config,
+  qtbase,
+  qtdeclarative,
+  qttools,
+  qtwayland,
+  vulkan-headers,
+  vulkan-loader,
+  wayland-protocols,
+  wrapQtAppsHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "aeroshell-kwin-components";
+  version = "6.7.0-unstable-2026-08-08";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "gitgud.io";
+    owner = "aeroshell";
+    repo = "aeroshell-kwin-components";
+    rev = "ba5b59a4b5270a71a17768e0e7a22dc1be926833";
+    hash = "sha256-w+C0bNbf23GIyDcAtjqfDsRXI1dTx2KqU7x+6/cG4rE=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kcmutils
+    kcolorscheme
+    kconfig
+    kconfigwidgets
+    kcoreaddons
+    kcrash
+    kdecoration
+    kguiaddons
+    ki18n
+    kiconthemes
+    kio
+    kirigami
+    knotifications
+    kservice
+    ksvg
+    kwidgetsaddons
+    kwin
+    kwin-x11
+    kwindowsystem
+    libepoxy
+    libx11
+    libxcb
+    qtbase
+    qtdeclarative
+    qttools
+    qtwayland
+    vulkan-headers
+    vulkan-loader
+    wayland-protocols
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTING" false)
+    (lib.cmakeBool "KWIN_BUILD_WAYLAND" true)
+  ];
+
+  postInstall = ''
+    # The Wayland build already installs shared data, rules, and translations, so omit them from the X11 build
+    cmake -S .. -B build-x11 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$out -DBUILD_TESTING=OFF \
+      -DKWIN_BUILD_WAYLAND=OFF -DKWIN_INSTALL_MISC=OFF
+    cmake --build build-x11 -j$NIX_BUILD_CORES
+    cmake --install build-x11
+
+    ln -s kwin $out/share/kwin-x11
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch=Plasma/${lib.versions.majorMinor finalAttrs.version}" ];
+  };
+
+  meta = {
+    description = "AeroShell components related to KWin";
+    homepage = "https://gitgud.io/aeroshell/aeroshell-kwin-components";
+    license = with lib.licenses; [
+      agpl3Only
+      cc0
+      gpl2Only
+      gpl2Plus
+      gpl3Only
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ aaravrav ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/kde/third-party/aeroshell-uac-polkit-agent/default.nix
+++ b/pkgs/kde/third-party/aeroshell-uac-polkit-agent/default.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  extra-cmake-modules,
+  kconfig,
+  kcoreaddons,
+  kcrash,
+  kdbusaddons,
+  ki18n,
+  kirigami,
+  kirigami-addons,
+  knotifications,
+  ksvg,
+  kwindowsystem,
+  nix-update-script,
+  polkit-kde-agent-1,
+  polkit-qt-1,
+  qtbase,
+  qtdeclarative,
+  qtmultimedia,
+  wrapQtAppsHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "aeroshell-uac-polkit-agent";
+  version = "6.7.0-unstable-2026-06-20";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "gitgud.io";
+    owner = "aeroshell";
+    repo = "uac-polkit-agent";
+    rev = "d8c2262f5a12fe1a53560e70414b9312b91d84bb";
+    hash = "sha256-SltZEKT8CvCWirx00b3ZjCWv8Smc/AEppTuXhXVKQts=";
+  };
+
+  postPatch = ''
+    substituteInPlace uac-polkit-agent.conf.in \
+      --replace-fail "@KDE_INSTALL_FULL_LIBEXECDIR@/polkit-kde-authentication-agent-1" \
+        "${polkit-kde-agent-1}/libexec/polkit-kde-authentication-agent-1"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kconfig
+    kcoreaddons
+    kcrash
+    kdbusaddons
+    ki18n
+    kirigami
+    kirigami-addons
+    knotifications
+    ksvg
+    kwindowsystem
+    polkit-qt-1
+    qtbase
+    qtdeclarative
+    qtmultimedia
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/systemd/user
+    mv $out/etc/systemd/user/plasma-polkit-agent.service.d $out/share/systemd/user/
+    rmdir $out/etc/systemd/user $out/etc/systemd
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch=Plasma/${lib.versions.majorMinor finalAttrs.version}" ];
+  };
+
+  meta = {
+    description = "UAC Polkit Agent is an alternative frontend designed to look like the User Account Control dialog on Windows Vista and 7";
+    homepage = "https://gitgud.io/aeroshell/uac-polkit-agent";
+    license = with lib.licenses; [
+      cc0
+      gpl2Plus
+    ];
+    maintainers = with lib.maintainers; [ aaravrav ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/kde/third-party/aerothemeplasma-icons/default.nix
+++ b/pkgs/kde/third-party/aerothemeplasma-icons/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation {
+  pname = "aerothemeplasma-icons";
+  version = "6.6.1-unstable-2026-06-20";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "gitgud.io";
+    group = "aeroshell";
+    owner = "atp";
+    repo = "aerothemeplasma-icons";
+    rev = "96950b8028a5d960cb683280fe5f1d9e33e6b8a2";
+    hash = "sha256-7dfoGD3LQiBQ7/JeM1CwAZ+NNMaAJyAN/SaYIHZl1xg=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Windows 7 Icon Theme for AeroThemePlasma";
+    homepage = "https://gitgud.io/aeroshell/atp/aerothemeplasma-icons";
+    license = with lib.licenses; [ unfree ];
+    maintainers = with lib.maintainers; [ aaravrav ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/kde/third-party/aerothemeplasma-libplasma/default.nix
+++ b/pkgs/kde/third-party/aerothemeplasma-libplasma/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitLab,
+  libplasma,
+  nix-update-script,
+}:
+
+let
+  version = "6.7.4-unstable-2026-08-07";
+in
+(libplasma.overrideAttrs (old: {
+  pname = "aerothemeplasma-libplasma";
+  inherit version;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "gitgud.io";
+    owner = "aeroshell";
+    repo = "libplasma";
+    rev = "da45ff7247e42afec0fa84e32ca851bc8773378b";
+    hash = "sha256-ci/z9YaQxoYG70FUG9fCYi2zeepGMgHWO5AumdIE8Ck=";
+  };
+
+  # Stock release patches do not apply to the fork, so drop them
+  patches = [ ];
+
+  passthru = (old.passthru or { }) // {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch=Plasma/${lib.versions.majorMinor version}" ];
+    };
+  };
+
+  meta = old.meta // {
+    description = "Foundational libraries, components, and tools of the Plasma workspaces";
+    homepage = "https://gitgud.io/aeroshell/libplasma";
+    maintainers = with lib.maintainers; [ aaravrav ];
+    teams = [ ];
+    broken = lib.versions.majorMinor version != lib.versions.majorMinor libplasma.version;
+  };
+}))

--- a/pkgs/kde/third-party/aerothemeplasma-sounds/default.nix
+++ b/pkgs/kde/third-party/aerothemeplasma-sounds/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation {
+  pname = "aerothemeplasma-sounds";
+  version = "6.6.1-unstable-2026-02-27";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "gitgud.io";
+    group = "aeroshell";
+    owner = "atp";
+    repo = "aerothemeplasma-sounds";
+    rev = "55d2f5fd15f53cccbbb13388941b930442db1159";
+    hash = "sha256-z73owMl2+mAQJKGgjuJAmPIYOYuoVug0nWZ3WqWY0DY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Windows 7 Sound Theme Collection for AeroThemePlasma";
+    homepage = "https://gitgud.io/aeroshell/atp/aerothemeplasma-sounds";
+    license = with lib.licenses; [ unfree ];
+    maintainers = with lib.maintainers; [ aaravrav ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/kde/third-party/aerothemeplasma/default.nix
+++ b/pkgs/kde/third-party/aerothemeplasma/default.nix
@@ -1,0 +1,265 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  attica,
+  breeze-icons,
+  cmake,
+  extra-cmake-modules,
+  kauth,
+  kcmutils,
+  kconfig,
+  kcoreaddons,
+  kcrash,
+  kdbusaddons,
+  kglobalaccel,
+  kguiaddons,
+  ki18n,
+  kiconthemes,
+  kio,
+  kirigami,
+  kirigami-addons,
+  kitemmodels,
+  knewstuff,
+  knotifications,
+  knotifyconfig,
+  kpackage,
+  krunner,
+  kstatusnotifieritem,
+  ksvg,
+  kwidgetsaddons,
+  kwin,
+  kwindowsystem,
+  kxmlgui,
+  libksysguard,
+  libplasma,
+  pkg-config,
+  plasma-activities,
+  plasma-activities-stats,
+  plasma-desktop,
+  plasma-integration,
+  plasma-nm,
+  plasma-pa,
+  plasma-wayland-protocols,
+  plasma-workspace,
+  plasma5support,
+  qqc2-desktop-style,
+  qt5compat,
+  qtbase,
+  qtdeclarative,
+  qtmultimedia,
+  qtstyleplugin-kvantum,
+  qtsvg,
+  qtvirtualkeyboard,
+  qtwayland,
+  sonnet,
+  wayland,
+  wrapQtAppsHook,
+}:
+
+stdenv.mkDerivation {
+  __structuredAttrs = true;
+
+  pname = "aerothemeplasma";
+  version = "6.7.0-unstable-2026-08-22";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "aeroshell-desktop";
+      repo = "aerothemeplasma";
+      rev = "afaaa49dad2a9fc894e44e05caf2d5be75f85061";
+      hash = "sha256-l4QaCvka8LzKnx8y4/BFbNZnPKd2LVzaTIIKe1qZpFY=";
+      name = "aerothemeplasma";
+    })
+    # The plasmoids import aeroshell-workspace's QML modules, so package both sources
+    (fetchFromGitHub {
+      owner = "aeroshell-desktop";
+      repo = "aeroshell-workspace";
+      rev = "00a39ba08f3b9441b0883f1b82fc4e7e9e6a44b7";
+      hash = "sha256-UGT+MaFwSgLzacdwZTLhaxW5qhaSVa6ZFE6F4XCaHbE=";
+      name = "aeroshell-workspace";
+    })
+  ];
+  sourceRoot = "aerothemeplasma";
+
+  # NixOS owns /usr/share/icons/default, so disable the helper that writes there
+  patches = [ ./disable-system-cursor-helper.patch ];
+
+  postPatch = ''
+    substituteInPlace plasma/sddm/login-sessions/startatp.cmake plasma/sddm/login-sessions/startatp-wayland.cmake \
+      --replace-fail "/etc/xdg/aerothemeplasma" "$out/etc/xdg/aerothemeplasma"
+    substituteInPlace plasma/sddm/login-sessions/startatp.cmake plasma/sddm/login-sessions/startatp-wayland.cmake \
+      --replace-fail "kreadconfig6" "${lib.getExe' kconfig "kreadconfig6"}"
+    substituteInPlace plasma/sddm/login-sessions/startatp.cmake \
+      --replace-fail "startplasma-x11" "${lib.getBin plasma-workspace}/bin/startplasma-x11"
+    substituteInPlace plasma/sddm/login-sessions/startatp-wayland.cmake \
+      --replace-fail '@CMAKE_INSTALL_FULL_LIBEXECDIR@/plasma-dbus-run-session-if-needed' \
+        "${plasma-workspace}/libexec/plasma-dbus-run-session-if-needed" \
+      --replace-fail "\''${CMAKE_INSTALL_FULL_BINDIR}/startplasma-wayland" \
+        "${lib.getBin plasma-workspace}/bin/startplasma-wayland"
+    substituteInPlace misc/xdg/autostart/x-atpootb.desktop \
+      --replace-fail "/usr/bin/atpootb" "$out/bin/atpootb-autostart"
+    substituteInPlace plasma/atpootb/src/app.h \
+      --replace-fail "/usr/share/aerothemeplasma" "$out/share/aerothemeplasma"
+    substituteInPlace plasma/atpootb/src/app.cpp \
+      --replace-fail '"plasma-apply-lookandfeel"' \
+        '"${lib.getExe' plasma-workspace "plasma-apply-lookandfeel"}"' \
+      --replace-fail '"plasma-apply-cursortheme"' \
+        '"${lib.getExe' plasma-workspace "plasma-apply-cursortheme"}"' \
+      --replace-fail '"kvantummanager"' \
+        '"${lib.getExe' qtstyleplugin-kvantum "kvantummanager"}"'
+    substituteInPlace plasma/atpootb/src/CMakeLists.txt \
+      --replace-fail "\''${CMAKE_INSTALL_PREFIX}/share/dbus-1/interfaces/org.kde.kwin.Effects.xml" \
+        "${kwin}/share/dbus-1/interfaces/org.kde.kwin.Effects.xml"
+    substituteInPlace plasma/shells/io.gitgud.wackyideas.desktop/contents/views/DesktopEditMode.qml \
+      --replace-fail "/usr/share/sddm/themes/sddm-theme-mod" "$out/share/sddm/themes/sddm-theme-mod"
+    substituteInPlace misc/xdg/kscreenlockerrc \
+      --replace-fail "/usr/share/sddm/themes/sddm-theme-mod/bgtexture.jpg" \
+        "$out/share/sddm/themes/sddm-theme-mod/background"
+    substituteInPlace misc/xdg/kcm-about-distrorc \
+      --replace-fail "/usr/share/aerothemeplasma/branding/kcminfo.png" \
+        "$out/share/aerothemeplasma/branding/kcminfo.png"
+    sed -i \
+      -e 's/^        PlasmaQuick$/        Plasma::PlasmaQuick/' \
+      -e 's/^        Plasma$/        Plasma::Plasma/' \
+      plasma/plasmoids/src/sevenstart_src/src/CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    attica
+    kauth
+    kcmutils
+    kconfig
+    kcoreaddons
+    kcrash
+    kdbusaddons
+    kglobalaccel
+    kguiaddons
+    ki18n
+    kiconthemes
+    kio
+    kirigami
+    kirigami-addons
+    kitemmodels
+    knewstuff
+    knotifications
+    knotifyconfig
+    kpackage
+    krunner
+    kstatusnotifieritem
+    ksvg
+    kwidgetsaddons
+    kwin
+    kwindowsystem
+    kxmlgui
+    libksysguard
+    libplasma
+    plasma-activities
+    plasma-activities-stats
+    plasma-desktop
+    plasma-nm
+    plasma-pa
+    plasma-wayland-protocols
+    plasma-workspace
+    plasma5support
+    qqc2-desktop-style
+    qt5compat
+    qtbase
+    qtdeclarative
+    qtmultimedia
+    qtstyleplugin-kvantum
+    qtsvg
+    qtvirtualkeyboard
+    qtwayland
+    sonnet
+    wayland
+  ];
+
+  doCheck = true;
+
+  env.QT_QPA_PLATFORM = "offscreen";
+
+  nativeCheckInputs = [
+    breeze-icons
+    plasma-integration
+  ];
+
+  preCheck = ''
+    export HOME="$TMPDIR"
+    export QT_PLUGIN_PATH="${plasma-integration}/${qtbase.qtPluginPrefix}''${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
+    export QT_QPA_PLATFORMTHEME=kde
+    export QT_QPA_SYSTEM_ICON_THEME=breeze
+    export XDG_DATA_DIRS="${breeze-icons}/share''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+  '';
+
+  postInstall = ''
+    # INSTALL_X11_COMPONENTS omits the main package, so add only its session files
+    install -Dm755 ../plasma/sddm/login-sessions/startatp.cmake $out/bin/startatp
+    mkdir -p $out/share/xsessions
+    substitute ../plasma/sddm/login-sessions/aerothemeplasmax11.desktop.cmake \
+      $out/share/xsessions/aerothemeplasmax11.desktop \
+      --replace-fail "\''${CMAKE_INSTALL_FULL_BINDIR}" "$out/bin"
+
+    # XDG autostart is shared by all sessions, so run setup only in AeroThemePlasma
+    cat > $out/bin/atpootb-autostart <<EOF
+    #!${stdenv.shell}
+    [ "\$PLASMA_DEFAULT_SHELL" = "io.gitgud.wackyideas.desktop" ] || exit 0
+    exec "$out/bin/atpootb" "\$@"
+    EOF
+    chmod +x $out/bin/atpootb-autostart
+
+    cmake -S ../../aeroshell-workspace -B build-workspace \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=$out \
+      -DKDE_INSTALL_SYSCONFDIR=$out/etc \
+      -DKDE_INSTALL_QMLDIR=$out/${qtbase.qtQmlPrefix} \
+      -DBUILD_TESTING=OFF
+    cmake --build build-workspace -j$NIX_BUILD_CORES
+    cmake --install build-workspace
+  '';
+
+  postFixup = ''
+    wrapQtApp "$out/bin/startatp"
+    wrapQtApp "$out/bin/startatp-wayland"
+  '';
+
+  passthru = {
+    providedSessions = [
+      "aerothemeplasma"
+      "aerothemeplasmax11"
+    ];
+    shellId = "io.gitgud.wackyideas.desktop";
+  };
+
+  meta = {
+    description = "An alternative shell for KDE Plasma that aims to replicate the look and feel of Windows 7";
+    longDescription = ''
+      This is a project which aims to recreate the look and feel of Windows 7
+      as much as possible on KDE Plasma, whilst adapting the design to fit in
+      with modern features provided by KDE Plasma and Linux.
+    '';
+    homepage = "https://gitgud.io/aeroshell/atp/aerothemeplasma";
+    license = with lib.licenses; [
+      agpl3Only
+      bsd2
+      bsd3
+      gpl2Only
+      gpl2Plus
+      gpl3Only
+      lgpl2Plus
+      lgpl21Only
+      lgpl21Plus
+      lgpl3Only
+      mit
+    ];
+    maintainers = with lib.maintainers; [ aaravrav ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/kde/third-party/aerothemeplasma/disable-system-cursor-helper.patch
+++ b/pkgs/kde/third-party/aerothemeplasma/disable-system-cursor-helper.patch
@@ -1,0 +1,32 @@
+diff --git a/plasma/atpootb/CMakeLists.txt b/plasma/atpootb/CMakeLists.txt
+index 12c8397..ab89682 100644
+--- a/plasma/atpootb/CMakeLists.txt
++++ b/plasma/atpootb/CMakeLists.txt
+@@ -53,11 +53,3 @@ qt_policy(SET QTP0001 NEW)
+ ecm_find_qmlmodule(org.kde.kirigamiaddons.formcard 1.0)
+-
+-kauth_install_actions(io.gitgud.wackyideas.ootb kauth.actions)
+-
+-add_executable(ootbcursor_authhelper src/ootbauthhelper.cpp src/ootbauthhelper.h)
+-target_link_libraries(ootbcursor_authhelper KF6::AuthCore KF6::ConfigCore KF6::I18n Qt6::DBus Qt6::Core)
+-
+-install(TARGETS ootbcursor_authhelper DESTINATION ${KAUTH_HELPER_INSTALL_DIR})
+-kauth_install_helper_files(ootbcursor_authhelper io.gitgud.wackyideas.ootb root)
+-
++
+ add_subdirectory(src)
+diff --git a/plasma/atpootb/src/contents/ui/Main.qml b/plasma/atpootb/src/contents/ui/Main.qml
+index 30a94b5..b7b6abf 100644
+--- a/plasma/atpootb/src/contents/ui/Main.qml
++++ b/plasma/atpootb/src/contents/ui/Main.qml
+@@ -301,9 +301,9 @@ Rectangle {
+             }
+         }
+         Component.onCompleted: {
++            cursorAction.parent = null;
+             if(!KAUTH_ACTIONS_QML) {
+                 sddmAction.parent = null;
+-                cursorAction.parent = null;
+             }
+         }
+     }

--- a/pkgs/kde/third-party/smod/default.nix
+++ b/pkgs/kde/third-party/smod/default.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  extra-cmake-modules,
+  kcmutils,
+  kcolorscheme,
+  kconfig,
+  kconfigwidgets,
+  kcoreaddons,
+  kcrash,
+  kdecoration,
+  kguiaddons,
+  ki18n,
+  kiconthemes,
+  kio,
+  kirigami,
+  knotifications,
+  kservice,
+  ksvg,
+  kwidgetsaddons,
+  kwin,
+  kwin-x11,
+  kwindowsystem,
+  libepoxy,
+  libx11,
+  libxcb,
+  nix-update-script,
+  pkg-config,
+  qtbase,
+  qtdeclarative,
+  qttools,
+  qtwayland,
+  vulkan-headers,
+  vulkan-loader,
+  wayland-protocols,
+  wrapQtAppsHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "smod";
+  version = "6.7.4-unstable-2026-08-23";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "gitgud.io";
+    owner = "aeroshell";
+    repo = "smod";
+    rev = "44bbe37c8680df37779d157ac119a5f28f4fca78";
+    hash = "sha256-Ha2K+BwptTH3YEHQRZt2Rdav68h6qKYWcTB8NA3ocoA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kcmutils
+    kcolorscheme
+    kconfig
+    kconfigwidgets
+    kcoreaddons
+    kcrash
+    kdecoration
+    kguiaddons
+    ki18n
+    kiconthemes
+    kio
+    kirigami
+    knotifications
+    kservice
+    ksvg
+    kwidgetsaddons
+    kwin
+    kwin-x11
+    kwindowsystem
+    libepoxy
+    libx11
+    libxcb
+    qtbase
+    qtdeclarative
+    qttools
+    qtwayland
+    vulkan-headers
+    vulkan-loader
+    wayland-protocols
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTING" false)
+  ];
+
+  postInstall = ''
+    export PKG_CONFIG_PATH=$out/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
+
+    cmake -S .. -B build-smodglow-x11 \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=$out \
+      -DCMAKE_INSTALL_LIBDIR=$out/lib \
+      -DBUILD_DECORATION=OFF \
+      -DBUILD_EFFECT=OFF \
+      -DBUILD_EFFECTX11=ON \
+      -DBUILD_TESTING=OFF \
+      -DKDE_INSTALL_PLUGINDIR=$out/${qtbase.qtPluginPrefix}
+    cmake --build build-smodglow-x11 -j$NIX_BUILD_CORES
+    cmake --install build-smodglow-x11
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch=Plasma/${lib.versions.majorMinor finalAttrs.version}" ];
+  };
+
+  meta = {
+    description = "AeroShell SMOD KDecoration3 engine";
+    homepage = "https://gitgud.io/aeroshell/smod";
+    license = with lib.licenses; [
+      agpl3Only
+      bsd3
+      gpl2Only
+      gpl2Plus
+      gpl3Only
+      mit
+    ];
+    maintainers = with lib.maintainers; [ aaravrav ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds AeroThemePlasma (https://gitgud.io/aeroshell/atp/aerothemeplasma), an alternative KDE Plasma shell that aims to replicate the look and feel of Windows 7.

1) Packages AeroThemePlasma and its supporting projects:
  - SMOD (https://gitgud.io/aeroshell/smod), the AeroShell KDecoration3 engine
  - AeroShell KWin Components (https://gitgud.io/aeroshell/aeroshell-kwin-components)
  - UAC Polkit Agent (https://gitgud.io/aeroshell/uac-polkit-agent)
  - AeroShell's libplasma fork (https://gitgud.io/aeroshell/libplasma)
  - Windows 7 icon and cursor themes (https://gitgud.io/aeroshell/atp/aerothemeplasma-icons)
  - Windows 7 sound themes (https://gitgud.io/aeroshell/atp/aerothemeplasma-sounds)

2) Adds a NixOS module for AeroThemePlasma,which installs its desktop sessions and provides options for the KWin components, UAC agent, SDDM theme, and asset packages. AeroThemePlasma sessions use a scoped libplasma fork, while regular Plasma sessions continue using stock libplasma.

## Things done

- Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] aarch64-darwin
- Tested, as applicable:
    - [x] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at passthru.tests.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran nixpkgs-review on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
    - [x] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
