### PR TITLE
nixos/proxychains: fix random chain configuration

### DIFF
--- a/nixos/modules/programs/proxychains.nix
+++ b/nixos/modules/programs/proxychains.nix
@@ -10,7 +10,7 @@ let
 
   configFile = ''
     ${cfg.chain.type}_chain
-    ${lib.optionalString (cfg.chain.type == "random") "chain_len = ${toString cfg.chain.length}"}
+    ${lib.optionalString (cfg.chain.length != null) "chain_len = ${toString cfg.chain.length}"}
     ${lib.optionalString cfg.proxyDNS "proxy_dns"}
     ${lib.optionalString cfg.quietMode "quiet_mode"}
     remote_dns_subnet ${toString cfg.remoteDNSSubnet}
@@ -163,7 +163,7 @@ in
   config = lib.mkIf cfg.enable {
 
     assertions = lib.singleton {
-      assertion = cfg.chain.type != "random" && cfg.chain.length == null;
+      assertion = cfg.chain.type == "random" || cfg.chain.length == null;
       message = ''
         Option `programs.proxychains.chain.length`
         only makes sense with `programs.proxychains.chain.type` = "random".


### PR DESCRIPTION
Setting `chain.type = "random"` currently fails the assertion, even without a chain length. This lets random mode work and keeps the check against setting a length for strict or dynamic chains. It also leaves out `chain_len` when no length is set.

Fixes #557400.

Checked all six mode/length combinations with Nix. Both random cases fail before the fix and pass after it. The four valid configs also load with proxychains 4.4.0 and proxychains-ng 4.17. Formatting checks pass.

Assisted by GPT-6 Astra, including finding the issue and testing the fix. Leaving this as a draft for my review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
