### PR TITLE
check: enable strictDeps, enable structuredAttrs, add testMetaPkgConfig, use sri hash

### DIFF
--- a/pkgs/by-name/ch/check/package.nix
+++ b/pkgs/by-name/ch/check/package.nix
@@ -2,6 +2,7 @@
   fetchurl,
   lib,
   stdenv,
+  validatePkgConfig,
   testers,
 }:
 
@@ -14,12 +15,16 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-qN5OC6z7TXbdHGGN7SY1I7U7hdkqFG2INesaUpMvogo=";
   };
 
+  nativeBuildInputs = [
+    validatePkgConfig
+  ];
+
+  strictDeps = true;
+
   # fortify breaks the libcompat vsnprintf implementation
   hardeningDisable = lib.optionals (
     stdenv.hostPlatform.isMusl && (stdenv.hostPlatform != stdenv.buildPlatform)
   ) [ "fortify" ];
-
-  strictDeps = true;
 
   # Test can randomly fail: https://hydra.nixos.org/build/7243912
   doCheck = false;

--- a/pkgs/by-name/ch/check/package.nix
+++ b/pkgs/by-name/ch/check/package.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
   # Test can randomly fail: https://hydra.nixos.org/build/7243912
   doCheck = false;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Unit testing framework for C";
 

--- a/pkgs/by-name/ch/check/package.nix
+++ b/pkgs/by-name/ch/check/package.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation (finalAttrs: {
     stdenv.hostPlatform.isMusl && (stdenv.hostPlatform != stdenv.buildPlatform)
   ) [ "fortify" ];
 
+  strictDeps = true;
+
   # Test can randomly fail: https://hydra.nixos.org/build/7243912
   doCheck = false;
 

--- a/pkgs/by-name/ch/check/package.nix
+++ b/pkgs/by-name/ch/check/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/libcheck/check/releases/download/${finalAttrs.version}/check-${finalAttrs.version}.tar.gz";
-    sha256 = "02m25y9m46pb6n46s51av62kpd936lkfv3b13kfpckgvmh5lxpm8";
+    hash = "sha256-qN5OC6z7TXbdHGGN7SY1I7U7hdkqFG2INesaUpMvogo=";
   };
 
   # fortify breaks the libcompat vsnprintf implementation

--- a/pkgs/by-name/ch/check/package.nix
+++ b/pkgs/by-name/ch/check/package.nix
@@ -2,6 +2,7 @@
   fetchurl,
   lib,
   stdenv,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -25,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   __structuredAttrs = true;
 
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
   meta = {
     description = "Unit testing framework for C";
 
@@ -42,5 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl2Plus;
     mainProgram = "checkmk";
     platforms = lib.platforms.all;
+    pkgConfigModules = [ "check" ];
   };
 })


### PR DESCRIPTION
No change in CA hash for the output.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
