### PR TITLE
pcsclite: fix pcsc-spy interpreter

### DIFF
--- a/pkgs/by-name/pc/pcsclite/package.nix
+++ b/pkgs/by-name/pc/pcsclite/package.nix
@@ -21,6 +21,7 @@
   pname ? "pcsclite",
   polkitSupport ? false,
   nixosTests,
+  runCommand,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -86,6 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     # pcsc-spy is a debugging utility and it drags python into the closure
     moveToOutput bin/pcsc-spy "$dev"
+    patchShebangs --host "$dev/bin/pcsc-spy"
   '';
 
   __structuredAttrs = true;
@@ -117,6 +119,13 @@ stdenv.mkDerivation (finalAttrs: {
         package = finalAttrs.finalPackage;
         command = "pcscd --version";
       };
+      pcsc-spy = runCommand "pcsc-spy-test" { } ''
+        status=0
+        ${finalAttrs.finalPackage.dev}/bin/pcsc-spy --help > help.txt 2>&1 || status=$?
+        test "$status" -eq 1
+        grep -F "Usage: pcsc-spy" help.txt
+        touch "$out"
+      '';
     };
     updateScript = nix-update-script { };
   };


### PR DESCRIPTION
`pcsc-spy` still has `/usr/bin/python3` as its interpreter after installation, so it cannot run on NixOS. Its shebang is now patched with the host Python path after the script moves to the development output.

Fixes #557676.

Added a small test that runs `pcsc-spy --help` and checks its output. The new test and the existing version and pkg-config tests pass. I also reproduced the original failure and checked that Python stays out of the main and library outputs.

Built with sandboxing on x86_64-linux using the package recipe with master's cached dependencies. Staging evaluation passes too; a full staging build would rebuild the toolchain. Targeting staging because pcsclite has many dependents.

Assisted by GPT-6 Astra for the issue, fix and tests, and Codex for wording. Leaving this as a draft for my review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
