### PR TITLE
Vintage Story - Update to 1.22.7

### DIFF
--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -27,11 +27,11 @@ assert waylandSupport -> libxkbcommon != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vintagestory";
-  version = "1.22.3";
+  version = "1.22.7";
 
   src = fetchurl {
     url = "https://cdn.vintagestory.at/gamefiles/stable/vs_client_linux-x64_${finalAttrs.version}.tar.gz";
-    hash = "sha256-sa4Pj1DwT6W6LJCAYznmbyqPtMUTaLSNTkXS1imQp04=";
+    hash = "sha256-SDzGgnpQwIxcQczQJixvEiPBBOVMpxNcRmBSeNifXeE=";
   };
 
   __structuredAttrs = true;


### PR DESCRIPTION
literally just changed the version number and updated the hash for the new version. Tested locally.