### PR TITLE
buildRustCrate: do not add the lib output to the RPATH

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -639,6 +639,12 @@ lib.makeOverridable
             ];
         outputDev = if buildTests then [ "out" ] else [ "lib" ];
 
+        # The multiple-outputs hook adds `-rpath $lib/lib` to each binary in `$out`.
+        # The `lib` output refers to `out`. The two references make a cycle and the
+        # build fails. No binary loads a file from `$lib/lib`. `patchelf --shrink-rpath`
+        # removes the entry, but the setup hook ignores a patchelf failure.
+        NIX_NO_SELF_RPATH = true;
+
         meta = {
           mainProgram = crateName;
           badPlatforms = [

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -916,6 +916,36 @@ rec {
     tests
     // {
 
+      # A binary must not have an RPATH entry for the `lib` output of its crate.
+      # Such an entry makes a reference cycle and the build fails. The patchelf
+      # hook removes the entry and hides the problem. This test disables the hook.
+      noSelfRpath =
+        let
+          crate =
+            (mkHostCrate {
+              crateName = "nixtestcrate-self-rpath";
+              libPath = "src/lib.rs";
+              crateBin = [
+                {
+                  name = "test_self_rpath";
+                  path = "src/main.rs";
+                }
+              ];
+              src = symlinkJoin {
+                name = "buildRustCrateSelfRpathCase";
+                paths = [
+                  (mkLib "src/lib.rs")
+                  (mkBin "src/main.rs")
+                ];
+              };
+            }).overrideAttrs
+              { dontPatchELF = true; };
+        in
+        runCommand "run-buildRustCrate-no-self-rpath-test" { } ''
+          test -x ${crate}/bin/test_self_rpath
+          touch $out
+        '';
+
       crateBinWithPathOutputs = assertOutputs {
         name = "crateBinWithPath";
         crateArgs = {


### PR DESCRIPTION

buildRustCrate has `outputs = [ "out" "lib" ]` and `outputDev = [ "lib" ]`. The multiple-outputs hook adds `-rpath $lib/lib` to each binary in `$out`. The hook also writes `$out` into `$lib/nix-support/propagated-build-inputs`. The two outputs refer to each other.

No binary loads a file from `$lib/lib`. `patchelf --shrink-rpath` removes the entry in the fixup phase. But the patchelf hook ignores a patchelf failure. After such a failure the entry stays, and the build fails:

    error: cycle detected in build of '...' in the references of output
    'lib' from output 'out'

Each crate that has a library and binaries can show this failure.

`NIX_NO_SELF_RPATH` prevents the entry. The new test builds such a crate with `dontPatchELF`. The test fails without this change.

Also worth noting, `pkgs/stdenv/generic/default.nix` already exports `NIX_NO_SELF_RPATH=1` for Darwin and for non-ELF platforms, so `buildRustCrate` never gets the self-rpath there and this bug is ELF-only.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
