### PR TITLE
nixos/olivetin: fix listen address option casing

### DIFF
--- a/nixos/modules/services/web-apps/olivetin.nix
+++ b/nixos/modules/services/web-apps/olivetin.nix
@@ -9,6 +9,9 @@ let
   cfg = config.services.olivetin;
 
   settingsFormat = pkgs.formats.yaml { };
+  configFile = settingsFormat.generate "olivetin-config.yaml" (
+    removeAttrs cfg.settings [ "ListenAddressSingleHTTPFrontend" ]
+  );
 in
 
 {
@@ -65,8 +68,15 @@ in
       type = lib.types.submodule {
         freeformType = settingsFormat.type;
 
+        imports = [
+          (lib.mkRenamedOptionModule
+            [ "ListenAddressSingleHTTPFrontend" ]
+            [ "listenAddressSingleHTTPFrontend" ]
+          )
+        ];
+
         options = {
-          ListenAddressSingleHTTPFrontend = lib.mkOption {
+          listenAddressSingleHTTPFrontend = lib.mkOption {
             type = lib.types.str;
             description = ''
               The address to listen on for the internal "microproxy" frontend.
@@ -116,7 +126,7 @@ in
 
         tmp="$(mktemp)"
         ${lib.getExe pkgs.yq-go} eval-all '. as $item ireduce ({}; . *+ $item)' \
-          ${settingsFormat.generate "olivetin-config.yaml" cfg.settings} \
+          ${configFile} \
           $CREDENTIALS_DIRECTORY/config-*.yaml > "$tmp"
         chmod -w "$tmp"
 

--- a/nixos/tests/olivetin.nix
+++ b/nixos/tests/olivetin.nix
@@ -8,6 +8,8 @@
     services.olivetin = {
       enable = true;
       settings = {
+        # Keep the old spelling working.
+        ListenAddressSingleHTTPFrontend = "127.0.0.1:8001";
         actions = [
           {
             id = "hello_world";
@@ -28,13 +30,13 @@
   };
 
   interactive.nodes.machine = {
-    services.olivetin.settings.ListenAddressSingleHTTPFrontend = "0.0.0.0:8000";
-    networking.firewall.allowedTCPPorts = [ 8000 ];
+    services.olivetin.settings.listenAddressSingleHTTPFrontend = lib.mkForce "0.0.0.0:8001";
+    networking.firewall.allowedTCPPorts = [ 8001 ];
     virtualisation.forwardPorts = [
       {
         from = "host";
-        host.port = 8000;
-        guest.port = 8000;
+        host.port = 8001;
+        guest.port = 8001;
       }
     ];
   };
@@ -44,14 +46,14 @@
     import shlex
 
     machine.wait_for_unit("olivetin.service")
-    machine.wait_for_open_port(8000)
+    machine.wait_for_open_port(8001)
 
     def start_action(action):
       if "${config.nodes.machine.services.olivetin.package.releaseSeries}" == "2k":
-        cmd = f"curl http://localhost:8000/api/StartActionByGetAndWait/{action}"
+        cmd = f"curl http://localhost:8001/api/StartActionByGetAndWait/{action}"
       else:
         req = {"actionId": action}
-        cmd = f"curl -H 'Content-Type: application/json' http://localhost:8000/api/olivetin.api.v1.OliveTinApiService/StartActionAndWait -d {shlex.quote(json.dumps(req))}"
+        cmd = f"curl -H 'Content-Type: application/json' http://localhost:8001/api/olivetin.api.v1.OliveTinApiService/StartActionAndWait -d {shlex.quote(json.dumps(req))}"
 
       return json.loads(machine.succeed(cmd))
 


### PR DESCRIPTION
OliveTin 3k ignores `ListenAddressSingleHTTPFrontend` because it expects `listenAddressSingleHTTPFrontend`. The generated YAML now uses the correct name, while the old option name keeps working for existing configurations.

Fixes #553745.

The existing VM test now sets a nondefault port through the old option name. `nix-build -A nixosTests.olivetin` passes on x86_64-linux with sandboxing. The default and both option spellings also produce the expected YAML.

I tried the legacy OliveTin VM test too, but its build fails on the existing `olivetin-gen-2025.11.25` hash mismatch before reaching the test.

Assisted by GPT-6 Astra for the issue, fix and tests, and Codex for wording. Leaving this as a draft for my review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
