### PR TITLE
nixos/pihole-ftl: handle addresses in webserver firewall ports

### DIFF
--- a/nixos/modules/services/networking/pihole-ftl.nix
+++ b/nixos/modules/services/networking/pihole-ftl.nix
@@ -471,6 +471,8 @@ in
           (map (
             port:
             lib.pipe port [
+              (lib.splitString ":")
+              lib.last
               (builtins.split "[[:alpha:]]+")
               builtins.head
               lib.toInt

--- a/nixos/tests/pihole-ftl/dnsmasq.nix
+++ b/nixos/tests/pihole-ftl/dnsmasq.nix
@@ -8,13 +8,19 @@ in
     services.pihole-ftl = {
       enable = true;
       useDnsmasqConfig = true;
-      settings.webserver.port = port;
+      openFirewallWebserver = true;
+      settings.webserver.port = "${port},[::]:${port}";
     };
   };
 
   testScript = ''
+    import json
+
     start_all()
     machine.wait_for_unit("pihole-ftl.service")
-    machine.wait_for_open_port(${port})
+    machine.wait_for_open_port(${port}, addr="127.0.0.1")
+    machine.wait_for_open_port(${port}, addr="::1")
+    response = machine.succeed("curl --silent --show-error --globoff http://[::1]:${port}/api/auth")
+    assert "session" in json.loads(response)
   '';
 }


### PR DESCRIPTION
`openFirewallWebserver` fails to evaluate when a port includes an address, such as `[::]:80r`. The module now removes the address before the existing suffix and number conversion. Bare ports keep working as before.

Fixes #553000.

The existing dnsmasq VM test now enables the firewall option with IPv4 and IPv6 listeners and checks an IPv6 API response. It passes on x86_64-linux with sandboxing. I also checked seven port configurations, including the reported example, IPv4, IPv6, IPv4-mapped IPv6, and hostnames. The address-prefixed cases fail before the fix and pass after it.

Assisted by GPT-6 Astra for the issue, fix and tests, and Codex for wording. Leaving this as a draft for my review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
