### PR TITLE
haskellPackages.lzma-conduit: pick upstream patch to fix flaky failures

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -909,9 +909,14 @@ with haskellLib;
   # 2022-01-29: Tests require package to be in ghc-db.
   aeson-schemas = dontCheck super.aeson-schemas;
 
-  # Too strict bounds on transformers and resourcet
-  # https://github.com/alphaHeavy/lzma-conduit/issues/23 krank:ignore-line
-  lzma-conduit = doJailbreak super.lzma-conduit;
+  lzma-conduit = lib.pipe super.lzma-conduit [
+    # Too strict bounds on transformers and resourcet
+    # https://github.com/alphaHeavy/lzma-conduit/issues/23 krank:ignore-line
+    doJailbreak
+    # Forbid small inputs in test suite which fail an assertion
+    # https://github.com/alphaHeavy/lzma-conduit/issues/25 krank:ignore-line
+    (appendPatch ./patches/lzma-conduit-prevent-flaky-failures.patch)
+  ];
 
   # 2020-06-05: HACK: does not pass own build suite - `dontCheck`
   # 2024-01-15: too strict bound on free < 5.2

--- a/pkgs/development/haskell-modules/patches/lzma-conduit-prevent-flaky-failures.patch
+++ b/pkgs/development/haskell-modules/patches/lzma-conduit-prevent-flaky-failures.patch
@@ -1,0 +1,20 @@
+From f5a907574e3d77e1eb4768f4cc9807efcc753071 Mon Sep 17 00:00:00 2001
+From: "copilot-swe-agent[bot]" <198982749+Copilot@users.noreply.github.com>
+Date: Thu, 2 Oct 2025 04:02:54 +0000
+Subject: [PATCH] Fix test failure for small inputs by adding precondition
+
+Co-authored-by: NathanHowell <170829+NathanHowell@users.noreply.github.com>
+---
+
+diff --git a/tests/Main.hs b/tests/Main.hs
+index 140c942..7a69a72 100644
+--- a/tests/Main.hs
++++ b/tests/Main.hs
+@@ -52,6 +52,7 @@ prop_compressAndDiscard = monadicIO . forAllM someBigString $ \ str -> do
+ 
+ prop_compressAndCheckLength :: Property
+ prop_compressAndCheckLength = monadicIO . forAllM someBigString $ \ str -> do
++  pre $ B.length str > 64
+   len <- run . runResourceT $ Cl.sourceList [str] C.$$ compress Nothing C.=$= Cl.fold (\ acc el -> acc + B.length el) 0
+   -- random strings don't compress very well
+   assert (len > B.length str `div` 2)


### PR DESCRIPTION
Had to manually trim down the patch because filterdiff couldn't manage filtering out just the changes in tests/…


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
