### PR TITLE
nixos/xrdp: enable FUSE for drive redirection

### DIFF
--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -149,6 +149,8 @@ in
 
     (mkIf cfg.enable {
 
+      programs.fuse.enable = true;
+
       networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
 
       # xrdp can run X11 program even if "services.xserver.enable = false"

--- a/nixos/tests/xrdp.nix
+++ b/nixos/tests/xrdp.nix
@@ -45,14 +45,16 @@
 
       client.execute("xterm >&2 &")
       client.sleep(1)
-      client.send_chars("xfreerdp /cert-tofu /w:640 /h:480 /v:127.0.0.1 /u:${user.name} /p:${user.password}\n")
+      client.send_chars("xfreerdp /cert:tofu /w:640 /h:480 /v:127.0.0.1 /u:${user.name} /p:${user.password}\n")
       client.sleep(5)
       client.screenshot("localrdp")
 
+      client.succeed("mkdir -p /tmp/shared", "echo hello > /tmp/shared/marker")
       client.execute("xterm >&2 &")
       client.sleep(1)
-      client.send_chars("xfreerdp /cert-tofu /w:640 /h:480 /v:server /u:${user.name} /p:${user.password}\n")
+      client.send_chars("xfreerdp /cert:tofu /w:640 /h:480 /v:server /u:${user.name} /p:${user.password} /drive:shared,/tmp/shared\n")
       client.sleep(5)
       client.screenshot("remoterdp")
+      server.wait_until_succeeds("runuser -u ${user.name} -- grep -Fx hello ${user.home}/thinclient_drives/shared/marker")
     '';
 }


### PR DESCRIPTION
XRDP drive redirection needs the privileged `fusermount3` helper. Enabling XRDP now also enables `programs.fuse`, so redirected drives can mount for the logged-in user.

Fixes #544807.

The existing VM test now shares a client directory and reads a file from it as the server user. Both FreeRDP commands also use the supported `/cert:tofu` option; the old spelling prevented connections from opening. The test passes on x86_64-linux with sandboxing.

Assisted by GPT-6 Astra for the issue, fix and tests, and Codex for wording. Leaving this as a draft for my review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
