### PR TITLE
nixos/firefly-iii: serialize boolean settings for Laravel

### DIFF
--- a/nixos/modules/services/web-apps/firefly-iii-data-importer.nix
+++ b/nixos/modules/services/web-apps/firefly-iii-data-importer.nix
@@ -19,7 +19,9 @@ let
   env-file-values = lib.attrsets.mapAttrs' (
     n: v: lib.attrsets.nameValuePair (lib.strings.removeSuffix "_FILE" n) v
   ) (lib.attrsets.filterAttrs (n: v: lib.strings.hasSuffix "_FILE" n) cfg.settings);
-  env-nonfile-values = lib.attrsets.filterAttrs (n: v: !lib.strings.hasSuffix "_FILE" n) cfg.settings;
+  env-nonfile-values = lib.attrsets.mapAttrs (
+    _: v: if builtins.isBool v then lib.boolToString v else v
+  ) (lib.attrsets.filterAttrs (n: v: !lib.strings.hasSuffix "_FILE" n) cfg.settings);
 
   data-importer-maintenance = pkgs.writeShellScript "data-importer-maintenance.sh" ''
     set -a

--- a/nixos/modules/services/web-apps/firefly-iii.nix
+++ b/nixos/modules/services/web-apps/firefly-iii.nix
@@ -19,7 +19,9 @@ let
   env-file-values = lib.attrsets.mapAttrs' (
     n: v: lib.attrsets.nameValuePair (lib.strings.removeSuffix "_FILE" n) v
   ) (lib.attrsets.filterAttrs (n: v: lib.strings.hasSuffix "_FILE" n) cfg.settings);
-  env-nonfile-values = lib.attrsets.filterAttrs (n: v: !lib.strings.hasSuffix "_FILE" n) cfg.settings;
+  env-nonfile-values = lib.attrsets.mapAttrs (
+    _: v: if builtins.isBool v then lib.boolToString v else v
+  ) (lib.attrsets.filterAttrs (n: v: !lib.strings.hasSuffix "_FILE" n) cfg.settings);
 
   firefly-iii-maintenance = pkgs.writeShellScript "firefly-iii-maintenance.sh" ''
     set -a

--- a/nixos/tests/firefly-iii-data-importer.nix
+++ b/nixos/tests/firefly-iii-data-importer.nix
@@ -15,13 +15,27 @@
         settings = {
           LOG_CHANNEL = "stdout";
           USE_CACHE = true;
+          VERIFY_TLS_SECURITY = true;
+          IGNORE_DUPLICATE_ERRORS = false;
         };
       };
     };
 
-  testScript = ''
-    dataImporter.wait_for_unit("phpfpm-firefly-iii-data-importer.service")
-    dataImporter.wait_for_unit("nginx.service")
-    dataImporter.succeed("curl -fvvv -Ls http://localhost/token | grep 'Firefly III Data Import Tool'")
-  '';
+  testScript =
+    { nodes, ... }:
+    let
+      cfg = nodes.dataImporter.services.firefly-iii-data-importer;
+    in
+    ''
+      dataImporter.wait_for_unit("phpfpm-firefly-iii-data-importer.service")
+      dataImporter.wait_for_unit("nginx.service")
+      dataImporter.succeed("""
+        ${cfg.package.phpPackage}/bin/php -r '
+          $config = require "${cfg.dataDir}/cache/config.php";
+          exit($config["importer"]["connection"]["verify"] === true
+            && $config["importer"]["ignore_duplicate_errors"] === false ? 0 : 1);
+        '
+      """)
+      dataImporter.succeed("curl -fvvv -Ls http://localhost/token | grep 'Firefly III Data Import Tool'")
+    '';
 }

--- a/nixos/tests/firefly-iii.nix
+++ b/nixos/tests/firefly-iii.nix
@@ -24,6 +24,8 @@ in
           APP_KEY_FILE = "/etc/firefly-iii-appkey";
           LOG_CHANNEL = "stdout";
           SITE_OWNER = "mail@example.com";
+          APP_DEBUG = false;
+          SEND_ERROR_MESSAGE = true;
         };
       };
     };
@@ -100,21 +102,33 @@ in
       };
     };
 
-  testScript = ''
-    fireflySqlite.wait_for_unit("phpfpm-firefly-iii.service")
-    fireflySqlite.wait_for_unit("nginx.service")
-    fireflySqlite.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
-    fireflySqlite.succeed("curl -fvvv -Ls http://localhost/v1/js/app.js")
-    fireflySqlite.succeed("systemctl start firefly-iii-cron.service")
-    fireflyPostgresql.wait_for_unit("phpfpm-firefly-iii.service")
-    fireflyPostgresql.wait_for_unit("nginx.service")
-    fireflyPostgresql.wait_for_unit("postgresql.target")
-    fireflyPostgresql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
-    fireflyPostgresql.succeed("systemctl start firefly-iii-cron.service")
-    fireflyMysql.wait_for_unit("phpfpm-firefly-iii.service")
-    fireflyMysql.wait_for_unit("nginx.service")
-    fireflyMysql.wait_for_unit("mysql.service")
-    fireflyMysql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
-    fireflyMysql.succeed("systemctl start firefly-iii-cron.service")
-  '';
+  testScript =
+    { nodes, ... }:
+    let
+      cfg = nodes.fireflySqlite.services.firefly-iii;
+    in
+    ''
+      fireflySqlite.wait_for_unit("phpfpm-firefly-iii.service")
+      fireflySqlite.wait_for_unit("nginx.service")
+      fireflySqlite.succeed("""
+        ${cfg.package.phpPackage}/bin/php -r '
+          $config = require "${cfg.dataDir}/cache/config.php";
+          exit($config["app"]["debug"] === false
+            && $config["firefly"]["send_error_message"] === true ? 0 : 1);
+        '
+      """)
+      fireflySqlite.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
+      fireflySqlite.succeed("curl -fvvv -Ls http://localhost/v1/js/app.js")
+      fireflySqlite.succeed("systemctl start firefly-iii-cron.service")
+      fireflyPostgresql.wait_for_unit("phpfpm-firefly-iii.service")
+      fireflyPostgresql.wait_for_unit("nginx.service")
+      fireflyPostgresql.wait_for_unit("postgresql.target")
+      fireflyPostgresql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
+      fireflyPostgresql.succeed("systemctl start firefly-iii-cron.service")
+      fireflyMysql.wait_for_unit("phpfpm-firefly-iii.service")
+      fireflyMysql.wait_for_unit("nginx.service")
+      fireflyMysql.wait_for_unit("mysql.service")
+      fireflyMysql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
+      fireflyMysql.succeed("systemctl start firefly-iii-cron.service")
+    '';
 }


### PR DESCRIPTION
`VERIFY_TLS_SECURITY = true;` currently reaches the Firefly III importer as the string `1`, which Guzzle treats as a certificate path. Both the importer and main Firefly III module now serialize boolean settings as `true` and `false` so Laravel reads them as booleans.

Fixes #559385.

Both existing VM tests now check the types in Laravel's generated configuration. The importer regression check fails against the original module and passes with the fix. The importer and main application's SQLite, PostgreSQL, and MariaDB tests pass on x86_64-linux with sandboxing.

Assisted by GPT-6 Astra for the issue, fix and tests, and Codex for wording. Leaving this as a draft for my review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
