### PR TITLE
peazip: provide application-relative 7z executable

### DIFF
--- a/pkgs/by-name/pe/peazip/package.nix
+++ b/pkgs/by-name/pe/peazip/package.nix
@@ -84,7 +84,8 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper $out/lib/peazip/pea $out/bin/pea \
       ''${qtWrapperArgs[@]} # putting this here as to not have double wrapping
 
-    mkdir -p $out/share/peazip $out/lib/peazip/res
+    mkdir -p $out/share/peazip $out/lib/peazip/res/bin/7z
+    ln -s ${_7z}/bin/7z $out/lib/peazip/res/bin/7z/7z
     ln -s $out/share/peazip $out/lib/peazip/res/share
     cp -r res/share/{icons,lang,themes,presets} $out/share/peazip/
     # Install desktop entries


### PR DESCRIPTION
PeaZip can still fall back to `res/bin/7z/7z` when opening archives despite the `HSYSBIN` patch, but the package does not provide that path. It now has the [application-relative link recommended by upstream](https://github.com/peazip/PeaZip/blob/11.2.0/peazip-sources/readme.txt), pointing to the existing system 7z wrapper.

Fixes #554615.

Built on x86_64-linux with sandboxing. I reproduced the missing-executable dialog with `conf.txt` truncated before `[use system 7z]`; a fresh configuration worked before the fix. With the link, the same ZIP opens and lists its contents under Xvfb, and an execution trace confirms it uses that backend.

Assisted by GPT-6 Astra for the issue, fix and tests, and Codex for wording. Leaving this as a draft for my review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
