### PR TITLE
siril: add Python to the runtime PATH

### DIFF
--- a/pkgs/by-name/si/siril/package.nix
+++ b/pkgs/by-name/si/siril/package.nix
@@ -91,6 +91,10 @@ stdenv.mkDerivation (finalAttrs: {
   # Necessary because project uses default build dir for flatpaks/snaps
   mesonBuildDir = "nixbld";
 
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ python3 ]})
+  '';
+
   nativeInstallCheckInputs = [
     versionCheckHook
   ];


### PR DESCRIPTION
Siril searches `PATH` for `python3` when creating its Python environment. The GTK wrappers now include Python, so launching Siril no longer requires a global Python installation.

Fixes #555759.

The sandboxed x86_64-linux build and existing version check pass. With Python absent from the caller's `PATH`, the original GUI reports the missing-Python error; the fixed GUI creates a virtual environment with a working Python and pip. This startup check ran under Xvfb with networking disabled and covers interpreter discovery and environment creation, before Siril's later pip downloads.

Assisted by GPT-6 Astra for the issue, fix and tests, and Codex for wording. Leaving this as a draft for my review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
