### PR TITLE
immich-kiosk: 0.42.0 -> 0.43.1

### DIFF
--- a/pkgs/by-name/im/immich-kiosk/package.nix
+++ b/pkgs/by-name/im/immich-kiosk/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGoModule,
+  buildGoLatestModule, # upstream bumps go every release
   fetchFromGitHub,
   nodejs,
   fetchNpmDeps,
@@ -8,30 +8,30 @@
   go-task,
 }:
 
-buildGoModule rec {
+buildGoLatestModule rec {
   pname = "immich-kiosk";
-  version = "0.42.0";
+  version = "0.43.1";
 
   src = fetchFromGitHub {
     owner = "damongolding";
     repo = "immich-kiosk";
     tag = "v${version}";
-    hash = "sha256-NgNVTVU7WlOBiaLXviTUYAq3PSLQuCKICP3rO/2U61Y=";
+    hash = "sha256-6Z6tp+YGlh3Gk31ZvQQ+F/DLvnGx571cRXv54rrC0D4=";
   };
 
   postPatch = ''
     # Delete vendor directory to regenerate it consistently across platforms
     rm -rf vendor
     # immich-kiosk bumps go at a faster cadence than nixpkgs
-    sed -i -E 's/^go 1\.26\.[0-9]+$/go 1.26/' go.mod
+    sed -i -E 's/^go 1\.27\.[0-9]+$/go 1.27/' go.mod
   '';
-  vendorHash = "sha256-E+IS0/GxTpasiyKBj6oN9Jb3R4fzXZJ4v8bVkxlHWIk=";
+  vendorHash = "sha256-/kyQSoI398crsqX71IgaXepUAI2hEEwr8CRInF6zXeM=";
   proxyVendor = true;
 
   npmDeps = fetchNpmDeps {
     inherit src;
     sourceRoot = "${src.name}/frontend";
-    hash = "sha256-Tebhu7qdn7DHTwEBeN2htZJuhYfPE15NyUskIxrfqls=";
+    hash = "sha256-x4D+t0bfyJkp1i4SOwfZNw+jiz5gsb+RzQAQLH4XI4s=";
   };
   # Frontend is in a subdirectory
   npmRoot = "frontend";


### PR DESCRIPTION
https://github.com/damongolding/immich-kiosk/compare/v0.42.0...v0.43.1

Update bot [failed again](https://nixpkgs-update-logs.nix-community.org/immich-kiosk/2026-08-27.log) due to `go.mod requires go >= 1.27.0`. Switch to `buildGoLatestModule`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
