### PR TITLE
hivex: fix hivexget runtime dependencies

### DIFF
--- a/pkgs/by-name/hi/hivex/package.nix
+++ b/pkgs/by-name/hi/hivex/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   autoreconfHook,
   makeWrapper,
+  bash,
   perlPackages,
   ocamlPackages,
   libxml2,
@@ -39,6 +40,7 @@ stdenv.mkDerivation rec {
     findlib
   ]);
   buildInputs = [
+    bash
     libxml2
   ]
   ++ (with perlPackages; [
@@ -50,12 +52,25 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postInstall = ''
+    wrapProgram $out/bin/hivexget \
+        --prefix "PATH" : "$out/bin"
+
     wrapProgram $out/bin/hivexregedit \
         --set PERL5LIB "$out/${perlPackages.perl.libPrefix}" \
         --prefix "PATH" : "$out/bin"
 
     wrapProgram $out/bin/hivexml \
         --prefix "PATH" : "$out/bin"
+  '';
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    test "$(PATH=/nonexistent "$out/bin/hivexget" images/special '\abcd_äöüß' 'abcd_äöüß')" = 0
+
+    runHook postInstallCheck
   '';
 
   meta = {


### PR DESCRIPTION
`hivexget` keeps its `/bin/bash` shebang because Bash is missing from the host inputs under `strictDeps`. Bash is now a host input so fixup can patch the interpreter, and `hivexget` has a wrapper so it can find its companion `hivexsh`.

Fixes #426907.

The sandboxed x86_64-linux build passes. A new install check reads a DWORD from upstream's real registry fixture with an empty caller `PATH`. The original executable fails to launch; the fixed one also prints its usage message correctly.

Assisted by GPT-6 Astra for the issue, fix and tests, and Codex for wording. Leaving this as a draft for my review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
