### PR TITLE
quickshell: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/by-name/qu/quickshell/package.nix
+++ b/pkgs/by-name/qu/quickshell/package.nix
@@ -25,7 +25,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "quickshell";
-  version = "0.3.0";
+  version = "0.3.1";
 
   # github mirror: https://github.com/quickshell-mirror/quickshell
   src = fetchFromGitea {
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "quickshell";
     repo = "quickshell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gU+VGpwGJ2vvg0mtYqVvj5u+2LteuHlpokH6JSAtueY=";
+    hash = "sha256-CLX2Zp5i5BuLbOxNOkwRd9YY84IOrACNxBV79o9/F9Y=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
 ## Description of changes

Bump quickshell to 0.3.1. Upstream changelog: https://git.outfoxxed.me/quickshell/quickshell/releases/tag/v0.3.1 — this release is mostly crash/UAF fixes (NetworkManager wireless-network list churn, ScriptModel handling, session-lock crashes on sleep/wake/DPMS).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Sandboxing enabled in `nix.conf`? `sandbox = true`
- Tested, as applicable:
  - [x] `nix build .#quickshell` succeeds
  - [ ] `nixpkgs-review rev HEAD`
  - [x] Ran `./result/bin/quickshell --version`, confirms `0.3.1`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)