### PR TITLE
hypr-rdp: init at 0.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21658,6 +21658,12 @@
     githubId = 5969778;
     name = "Oliver Wilkins";
   };
+  olafkfreund = {
+    email = "olaf@freundcloud.com";
+    github = "olafkfreund";
+    githubId = 12804862;
+    name = "Olaf Krasicki-Freund";
+  };
   olcai = {
     email = "dev@timan.info";
     github = "olcai";

--- a/pkgs/by-name/hy/hypr-rdp/package.nix
+++ b/pkgs/by-name/hy/hypr-rdp/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  clang,
+  makeWrapper,
+  ffmpeg,
+  libdrm,
+  libgbm,
+  libva,
+  libxkbcommon,
+  mesa,
+  pipewire,
+  pulseaudio,
+  wayland,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hypr-rdp";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "MuNeNICK";
+    repo = "hypr-rdp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yrC8fITJofWJ2wpZMiaX06UVCMFI4GRg9pGyaTdosHg=";
+  };
+
+  cargoHash = "sha256-fx2SA0xXlxDIBI/2EtvzW9LGK1pbAZevK0y/dJAw2vg=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    clang
+    makeWrapper
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    ffmpeg
+    libdrm
+    libgbm
+    libva
+    libxkbcommon
+    mesa
+    pipewire
+    wayland
+  ];
+
+  # pulseaudio is a runtime lookup, not a link-time dependency: audio is
+  # forwarded by shelling out to PulseAudio tools, so it belongs in the
+  # wrapper rather than in buildInputs.
+  postInstall = ''
+    wrapProgram $out/bin/hypr-rdp \
+      --prefix PATH : ${lib.makeBinPath [ pulseaudio ]}
+  '';
+
+  # Upstream's own package.nix sets doCheck = false: the tests want a live
+  # Wayland compositor and a VAAPI device, neither of which exists in the
+  # build sandbox.
+  doCheck = false;
+
+  meta = {
+    description = "RDP server for Hyprland and other wlroots compositors";
+    homepage = "https://github.com/MuNeNICK/hypr-rdp";
+    changelog = "https://github.com/MuNeNICK/hypr-rdp/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "hypr-rdp";
+    maintainers = with lib.maintainers; [ olafkfreund ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
A native RDP server for Hyprland and other wlroots compositors.

There is currently no packaged way to serve a wlroots session over RDP. `services.xrdp` drives X11 sessions only, gnome-remote-desktop is a Mutter client, and KDE's krdp speaks Plasma's portal — so the wlroots answer has been wayvnc, i.e. VNC: no NLA, weaker Windows clients, no H.264. hypr-rdp captures through `wlr-screencopy-v1` / `ext-image-copy-capture-v1` and speaks RDP, which means `mstsc` on Windows connects to a Hyprland session without installing anything.

Upstream already ships `pkg/nix/package.nix`; this is that derivation adapted to a `by-name` entry: `src` from `fetchFromGitHub` with the version pinned literally instead of `lib.cleanSource` of the working tree, `meta.maintainers`/`platforms`/`changelog` added, and upstream's `doCheck = false` kept with the reason stated in a comment (the tests want a live compositor and a VAAPI device, neither of which exists in the sandbox). `pulseaudio` stays out of `buildInputs` deliberately — it is a runtime lookup via the wrapper, not a link-time dependency. The `cargoHash` was re-derived against the fetched `v0.1.5` tarball rather than copied from upstream's file (it matches upstream's value).

Disclosure, because it belongs in the review and not in a surprise later: first commit March 2026, `v0.1.5` August 2026, actively pushed to; ~220 commits, effectively one primary author plus one regular contributor; 66 stars. This is a pre-1.0 Rust network daemon that parses RDP from the wire, unaudited — a fair thing for a reviewer to weigh. It is a client of a running compositor, not a login service: if the session is not up there is nothing to connect to, so it is session sharing rather than remote login, and packaging it does not enable a listening service by default. No NixOS module is proposed here; this is the package only.

I use this daily on a Hyprland session (it is what [nixarchy](https://github.com/olafkfreund/nixarchy) ships as its remote-desktop option), connected from Windows `mstsc` and from FreeRDP.

Also adds my `maintainer-list.nix` entry in a preceding commit, per maintainers/README.md.

**Automation/AI disclosure (PR summary and commits):** prepared with Claude Code (model: Claude Fable 5) under my direction and review; commits carry `Assisted-by:` trailers per the policy. The build, `nixpkgs-review`, and runtime checks below were executed for real, not paraphrased.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. (`nixpkgs-review rev HEAD`: 1 package built: hypr-rdp)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (`hypr-rdp --help`, `hypr-rdp --version` → `hypr-rdp 0.1.5`; used daily as a running RDP server on Hyprland)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NnGySKyHzV4ToGz5gFR4y
