### PR TITLE
haskell.packages.ghc914.haskell-language-server: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -98,6 +98,17 @@ with haskellLib;
     )
   );
 
+  cabal-install_3_16_1_0 = lib.pipe super.cabal-install_3_16_1_0 [
+    unmarkBroken
+    doDistribute
+    (
+      pkg:
+      pkg.override {
+        cabal-install-solver = self.cabal-install-solver_3_16_1_0;
+      }
+    )
+  ];
+
   # cabal-install needs most recent versions of Cabal and Cabal-syntax,
   # so we need to put some extra work for non-latest GHCs
   inherit

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -104,6 +104,37 @@ with haskellLib;
   ormolu = doDistribute self.ormolu_0_9_0_0;
   fourmolu = doDistribute self.fourmolu_0_20_1_0;
 
+  inherit
+    (
+      let
+        hls_overlay = lself: lsuper: {
+          Cabal-syntax = lself.Cabal-syntax_3_16_1_0;
+          Cabal = lself.Cabal_3_16_1_0;
+          cabal-install = lself.cabal-install_3_16_1_0;
+          # hlint does not support GHC 3.14, yet:
+          # https://github.com/ndmitchell/hlint/issues/1672
+          apply-refact = null;
+          hlint = null;
+          refact = null;
+          # stylish-haskell does not support GHC 9.14, yet:
+          # https://github.com/haskell/haskell-language-server/blob/5ce2a847d255ce6f420da49771711a89eee78541/haskell-language-server.cabal#L1544-L1546
+          stylish-haskell = null;
+        };
+      in
+      lib.mapAttrs (_: pkg: doDistribute (pkg.overrideScope hls_overlay)) {
+        ghcide = super.ghcide;
+        haskell-language-server = lib.pipe super.haskell-language-server [
+          (disableCabalFlag "hlint")
+          (disableCabalFlag "stylishHaskell")
+        ];
+        hls-plugin-api = super.hls-plugin-api;
+      }
+    )
+    ghcide
+    haskell-language-server
+    hls-plugin-api
+    ;
+
   #
   # Jailbreaks
   #

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -142,6 +142,10 @@ with haskellLib;
   # https://github.com/jaspervdj/blaze-html/issues/151
   blaze-html = doJailbreak super.blaze-html;
 
+  # 2026-09-05: base <4.22
+  # https://github.com/mitchellwrosen/tasty-hspec/pull/38
+  tasty-hspec = doJailbreak super.tasty-hspec;
+
   #
   # Test suite issues
   #

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -146,6 +146,10 @@ with haskellLib;
   # https://github.com/mitchellwrosen/tasty-hspec/pull/38
   tasty-hspec = doJailbreak super.tasty-hspec;
 
+  # 2026-09-05: containers <0.8
+  # https://github.com/obsidiansystems/dependent-map/issues/59
+  dependent-map = doJailbreak super.dependent-map;
+
   #
   # Test suite issues
   #

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -74,7 +74,9 @@ extra-packages:
   - Cabal == 3.16.*                     # version required for cabal-install and other packages
   - cabal-add < 0.2.1                   # 2026-09-05: required for HLS with GHC <= 9.8
   - cabal-install == 3.14.*             # 2026-07-26: required to match Cabal used when building HLS
+  - cabal-install == 3.16.*             # 2026-09-05: required to match Cabal used when building HLS
   - cabal-install-solver == 3.14.*      # 2026-07-26: required to build cabal-install 3.14
+  - cabal-install-solver == 3.16.*      # 2026-09-05: required to build cabal-install 3.16
   - Cabal-syntax == 3.6.*               # required for the GHC 9.0.2 package set
   - Cabal-syntax == 3.10.*
   - Cabal-syntax == 3.12.*

--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -128480,6 +128480,161 @@ self: {
         Cabal-tree-diff = null;
       };
 
+  cabal-install_3_16_1_0 =
+    callPackage
+      (
+        {
+          mkDerivation,
+          array,
+          async,
+          base,
+          base16-bytestring,
+          binary,
+          bytestring,
+          Cabal,
+          Cabal-described,
+          cabal-install-solver,
+          Cabal-QuickCheck,
+          Cabal-syntax,
+          Cabal-tests,
+          Cabal-tree-diff,
+          containers,
+          cryptohash-sha256,
+          directory,
+          echo,
+          edit-distance,
+          exceptions,
+          filepath,
+          hackage-security,
+          HTTP,
+          mtl,
+          network-uri,
+          open-browser,
+          parsec,
+          pretty,
+          pretty-show,
+          process,
+          QuickCheck,
+          random,
+          regex-base,
+          regex-posix,
+          resolv,
+          safe-exceptions,
+          semaphore-compat,
+          silently,
+          stm,
+          tagged,
+          tar,
+          tasty,
+          tasty-expected-failure,
+          tasty-golden,
+          tasty-hunit,
+          tasty-quickcheck,
+          text,
+          time,
+          tree-diff,
+          unix,
+          zlib,
+        }:
+        mkDerivation {
+          pname = "cabal-install";
+          version = "3.16.1.0";
+          sha256 = "082ix6d443yqyirsjimzj5lg3znqlb06mfkvd9436fczk0ibq9wx";
+          revision = "3";
+          editedCabalFile = "0492j5bkrjwfflxgf1siw4xz61gj7q6cb0m55k092ldhbnd7wh1j";
+          isLibrary = true;
+          isExecutable = true;
+          libraryHaskellDepends = [
+            array
+            async
+            base
+            base16-bytestring
+            binary
+            bytestring
+            Cabal
+            cabal-install-solver
+            Cabal-syntax
+            containers
+            cryptohash-sha256
+            directory
+            echo
+            edit-distance
+            exceptions
+            filepath
+            hackage-security
+            HTTP
+            mtl
+            network-uri
+            open-browser
+            parsec
+            pretty
+            process
+            random
+            regex-base
+            regex-posix
+            resolv
+            safe-exceptions
+            semaphore-compat
+            stm
+            tar
+            text
+            time
+            unix
+            zlib
+          ];
+          executableHaskellDepends = [ base ];
+          testHaskellDepends = [
+            array
+            base
+            bytestring
+            Cabal
+            Cabal-described
+            cabal-install-solver
+            Cabal-QuickCheck
+            Cabal-syntax
+            Cabal-tests
+            Cabal-tree-diff
+            containers
+            directory
+            filepath
+            mtl
+            network-uri
+            pretty-show
+            process
+            QuickCheck
+            random
+            silently
+            tagged
+            tar
+            tasty
+            tasty-expected-failure
+            tasty-golden
+            tasty-hunit
+            tasty-quickcheck
+            time
+            tree-diff
+            zlib
+          ];
+          doCheck = false;
+          postInstall = ''
+            mkdir -p $out/share/bash-completion
+            mv bash-completion $out/share/bash-completion/completions
+          '';
+          description = "The command-line interface for Cabal and Hackage";
+          license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+          hydraPlatforms = lib.platforms.none;
+          mainProgram = "cabal";
+          maintainers = [ lib.maintainers.sternenseemann ];
+          broken = true;
+        }
+      )
+      {
+        Cabal-QuickCheck = null;
+        Cabal-described = null;
+        Cabal-tests = null;
+        Cabal-tree-diff = null;
+      };
+
   cabal-install =
     callPackage
       (
@@ -128894,6 +129049,62 @@ self: {
       sha256 = "0551cvrkbnjfqjd3byq7pczlwjdb0n1jrfsrb0j8axagylbif7g1";
       revision = "1";
       editedCabalFile = "14jrs9q52vp9slb5pm66a9xrjdgkjypwssnnjc5pamlykakrjqa1";
+      libraryHaskellDepends = [
+        array
+        base
+        bytestring
+        Cabal
+        Cabal-syntax
+        containers
+        directory
+        edit-distance
+        filepath
+        mtl
+        network-uri
+        pretty
+        text
+        transformers
+      ];
+      testHaskellDepends = [
+        base
+        Cabal-syntax
+        tasty
+        tasty-hunit
+        tasty-quickcheck
+      ];
+      description = "The solver component of cabal-install";
+      license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+      hydraPlatforms = lib.platforms.none;
+    }
+  ) { };
+
+  cabal-install-solver_3_16_1_0 = callPackage (
+    {
+      mkDerivation,
+      array,
+      base,
+      bytestring,
+      Cabal,
+      Cabal-syntax,
+      containers,
+      directory,
+      edit-distance,
+      filepath,
+      mtl,
+      network-uri,
+      pretty,
+      tasty,
+      tasty-hunit,
+      tasty-quickcheck,
+      text,
+      transformers,
+    }:
+    mkDerivation {
+      pname = "cabal-install-solver";
+      version = "3.16.1.0";
+      sha256 = "0a546gpwi8j9ijzqfgm15pajs1myrs6h94bfypgrjygajig2pz5d";
+      revision = "1";
+      editedCabalFile = "0s003vpqfchy967zwgp51q3vczhmldaa10bkckch4dfpyb5qjbw8";
       libraryHaskellDepends = [
         array
         base


### PR DESCRIPTION
Fixes the build for HLS on GHC 9.14 without support for hlint or stylish-haskell, because these two don't support ghc-lib-parser 9.14.x, yet.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
