### PR TITLE
nixos/i2pd: add option for tunnel type

### DIFF
--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -263,6 +263,14 @@ in
           types.submodule {
             inherit freeformType;
             options = {
+              type = lib.mkOption {
+                type = types.str;
+                default = "server";
+                description = ''
+                  Type of server tunnel.
+                  See <https://docs.i2pd.website/en/latest/user-guide/tunnels/#tunnel-types>.
+                '';
+              };
               host = lib.mkOption {
                 type = types.either types.str credType;
                 description = "IP address of server (on this address i2pd will send data from I2P)";
@@ -289,6 +297,14 @@ in
           types.submodule {
             inherit freeformType;
             options = {
+              type = lib.mkOption {
+                type = types.str;
+                default = "client";
+                description = ''
+                  Type of client tunnel.
+                  See <https://docs.i2pd.website/en/latest/user-guide/tunnels/#tunnel-types>.
+                '';
+              };
               port = lib.mkOption {
                 type = types.port;
                 description = "Port of client tunnel (on this port i2pd will receive data)";
@@ -401,10 +417,8 @@ in
       gen = attr: settings: {
         conf = genConfig "i2pd.conf" (credSubstituteRec attr settings);
         tunconf = genTunnels "i2pd-tunnels.conf" (
-          lib.mapAttrs' (k: v: lib.nameValuePair "client-${k}" (v // { "type" = "client"; })) (
-            credSubstituteRec attr cfg.clientTunnels
-          )
-          // lib.mapAttrs' (k: v: lib.nameValuePair "server-${k}" (v // { "type" = "server"; })) (
+          lib.mapAttrs' (k: v: lib.nameValuePair "client-${k}" v) (credSubstituteRec attr cfg.clientTunnels)
+          // lib.mapAttrs' (k: v: lib.nameValuePair "server-${k}" v) (
             credSubstituteRec attr cfg.serverTunnels
           )
         );


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The module incorrectly assumed tunnel `type` is only `client` or `server`, overwriting the other possible  [types](https://docs.i2pd.website/en/latest/user-guide/tunnels/#tunnel-types).

Fixes: [#225601](https://github.com/NixOS/nixpkgs/pull/225601#discussion_r3938954167)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
