### PR TITLE
yoinks: init at 0.3.1

### DIFF
--- a/pkgs/by-name/yo/yoinks/package.nix
+++ b/pkgs/by-name/yo/yoinks/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  ffmpeg-headless,
+  yt-dlp,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "yoinks";
+  version = "0.3.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "pablostanley";
+    repo = "yoinks";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CxijcAkRSddWo5hA7Wt0w6ouWFQZAxbLUh5gKJtr3P8=";
+  };
+
+  npmDepsHash = "sha256-PhzO6pKzSO+q1GHes3TQ74X0+sEYEhlbvT9MRHg98fg=";
+  nativeBuildInputs = [ ffmpeg-headless ];
+
+  postInstall = ''
+    ln -sf ${lib.getExe ffmpeg-headless} $out/lib/node_modules/yoinks/node_modules/ffmpeg-static/ffmpeg
+    wrapProgram $out/bin/yoinks \
+      --prefix PATH : ${lib.makeBinPath [ yt-dlp ]}
+  '';
+
+  env.FFMPEG_BIN = "${lib.getExe ffmpeg-headless}";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Yoink any video from YouTube, X, Instagram, Threads & 1800+ sites — right from your terminal.";
+    homepage = "https://github.com/pablostanley/yoinks";
+    license = lib.licenses.mit;
+    mainProgram = "yoinks";
+    maintainers = [ lib.maintainers.airone01 ];
+  };
+})


### PR DESCRIPTION
Packages [yoinks](https://github.com/pablostanley/yoinks), a yt-dlp TUI.

![yoinks main page](https://raw.githubusercontent.com/pablostanley/yoinks/refs/heads/main/assets/home.png)
(I'm a sucker for pretty TUIs)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
