### PR TITLE
cmake: fix Darwin build

### DIFF
--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -8,6 +8,7 @@
   bzip2,
   curlMinimal,
   expat,
+  iconv,
   libarchive,
   libuv,
   ncurses,
@@ -125,7 +126,11 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional useOpenSSL openssl
   ++ lib.optional cursesUI ncurses
-  ++ lib.optional qt5UI qtbase;
+  ++ lib.optional qt5UI qtbase
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    iconv
+    iconv.dev
+  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/540343#issuecomment-5552268426

The first cmake in the bootstrap now succeeds on aarch64-darwin; still building the others.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
