### PR TITLE
tuple: install CLI on Darwin

### DIFF
--- a/pkgs/by-name/tu/tuple/package.nix
+++ b/pkgs/by-name/tu/tuple/package.nix
@@ -5,6 +5,7 @@
   cacert,
   fetchurl,
   fetchzip,
+  installShellFiles,
   makeWrapper,
 }:
 
@@ -26,9 +27,15 @@ tupleStdenv.mkDerivation {
 
   dontUnpack = !isDarwin;
 
-  nativeBuildInputs = lib.optionals (!isDarwin) [
-    makeWrapper
-  ];
+  nativeBuildInputs =
+    if isDarwin then
+      [
+        installShellFiles
+      ]
+    else
+      [
+        makeWrapper
+      ];
 
   installPhase =
     if isDarwin then
@@ -36,6 +43,15 @@ tupleStdenv.mkDerivation {
         runHook preInstall
         mkdir -p $out/Applications
         cp -a $src $out/Applications/Tuple.app
+        mkdir -p $out/bin
+        ln -s ../Applications/Tuple.app/Contents/SharedSupport/bin/tuple $out/bin/tuple
+        # Generate completions from the source path: running the app after
+        # copying it into $out makes macOS lock the bundle (App Management),
+        # after which any chmod inside it fails with EPERM (fixupPhase).
+        $src/Contents/SharedSupport/bin/tuple completion bash >tuple.bash
+        $src/Contents/SharedSupport/bin/tuple completion fish >tuple.fish
+        $src/Contents/SharedSupport/bin/tuple completion zsh >tuple.zsh
+        installShellCompletion tuple.{bash,fish,zsh}
         runHook postInstall
       ''
     else


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> The `tuple` CLI is a command-line tool that controls a running Tuple desktop app. You can use it to start and join calls, manage contacts, capture the shared screen, stream the transcript of a captured call, search past calls, post notifications into a call, and run an MCP server so AI coding agents can drive Tuple on your behalf.
>
> The CLI talks to the desktop app over a local socket - **there’s no network call to Tuple’s servers**. The app must be running and signed in for commands to work.

https://docs.tuple.app/cli/overview

<details>
<summary>nix run</summary>

```console
$ NIXPKGS_ALLOW_UNFREE=1 nix run --impure .#tuple -- --help
Tuple CLI for managing contacts, calls, and application state.

Usage:
  tuple [command]

Available Commands:
  call          Call lifecycle
  completion    Generate the autocompletion script for the specified shell
  connect       Connect an AI agent to your Tuple session
  contacts      People and availability
  help          Help about any command
  mcp           Start MCP server over stdin/stdout
  notifications External call notifications
  reaction      Send a sound reaction
  rooms         Rooms and persistent spaces
  screen        Screen operations
  state         Show current application state
  transcription Manage call transcriptions
  whoami        Print the authenticated user's identity

Flags:
      --env string      Tuple environment: "prod", "staging", or "dev" (env TUPLE_ENV; otherwise defaults from the binary name, e.g. tuple-dev)
      --format string   output format: "default", "json", or "table" (default "default")
  -h, --help            help for tuple
  -H, --host string     daemon socket to connect to (env TUPLE_HOST, default "/tmp/tuple.sock")

Use "tuple [command] --help" for more information about a command.
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
