### PR TITLE
notion-electron: 2.2.3 -> 2.4.0

### DIFF
--- a/pkgs/by-name/no/notion-electron/package.nix
+++ b/pkgs/by-name/no/notion-electron/package.nix
@@ -4,21 +4,22 @@
   buildNpmPackage,
   makeWrapper,
   desktop-file-utils,
-  electron,
+  electron_42,
+  nix-update-script,
 }:
 
 buildNpmPackage (finalAttrs: {
   pname = "notion-electron";
-  version = "2.2.3";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "anechunaev";
     repo = "notion-electron";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Or0Dd9ZfKfyi6DbDHOgCK1zz+PUHeONCfb53C1dIqS8=";
+    hash = "sha256-9p5GjTxXKkmUbE7uGeM/LUiZNygoZDlAWV4xpY8BPlg=";
   };
 
-  npmDepsHash = "sha256-39zUDddZVK5XwKJeBfmVDNHPkcLJgRcXJX9c3RYftlA";
+  npmDepsHash = "sha256-cCS2DTt3H3+eLd+cv7AeaVEryXmaF74VFqsf2px0exs=";
 
   __structuredAttrs = true;
 
@@ -40,15 +41,19 @@ buildNpmPackage (finalAttrs: {
 
     cp assets/icons/desktop.png $out/share/icons/hicolor/256x256/apps/notion-electron.png
 
+    cp -r assets $out/lib/node_modules/notion-electron/
+
     desktop-file-edit \
       --set-key="Exec" --set-value="notion-electron %U" \
       $out/share/applications/notion-electron.desktop
 
     # Disable update functionality as it will be handled via nixpkgs
-    makeWrapper ${electron}/bin/electron $out/bin/notion-electron \
+    makeWrapper ${electron_42}/bin/electron $out/bin/notion-electron \
               --add-flags '--disable-update-functionality' \
               --add-flags $out/lib/node_modules/notion-electron
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Enhanced Notion Desktop client for Linux";


### PR DESCRIPTION
Updated notion-electron from `v2.2.3` to `v2.4.0` and added the nix-update-script to the package.

Release inclusive changelog: https://github.com/anechunaev/notion-electron/releases/tag/v2.4.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
