### PR TITLE
kdl-lsp: init at 6.7.1

### DIFF
--- a/pkgs/by-name/kd/kdl-lsp/package.nix
+++ b/pkgs/by-name/kd/kdl-lsp/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kdl-lsp";
+  version = "6.7.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kdl-org";
+    repo = "kdl-rs";
+    tag = "kdl-lsp-v${finalAttrs.version}";
+    hash = "sha256-LqKYhJ0puOaqgIfSdw4b8ctWfiRYZmvL8AK3C2v0sSE=";
+  };
+
+  cargoHash = "sha256-+5XdCrlnxtdlhj07G2VFL1ICb0Ji+dqxfwJLpZlthmA=";
+
+  cargoBuildFlags = "--package kdl-lsp";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=kdl-lsp-v([\\d.]+)" ];
+  };
+
+  meta = {
+    description = "LSP server for kdl document language";
+    homepage = "https://github.com/kdl-org/kdl-rs";
+    changelog = "https://github.com/kdl-org/kdl-rs/blob/kdl-lsp-v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.kpbaks ];
+    mainProgram = "kdl-lsp";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
