### PR TITLE
nixos/plasma-login-manager: add extraPackages option and fix XDG_DATA_DIRS

### DIFF
--- a/nixos/modules/services/display-managers/plasma-login-manager.nix
+++ b/nixos/modules/services/display-managers/plasma-login-manager.nix
@@ -34,6 +34,8 @@ let
 
   defaultConfigFile = iniFmt.generate "00-nixos-defaults.conf" defaultConfig;
   userConfigFile = iniFmt.generate "99-user.conf" cfg.settings;
+
+  xdgDataDirs = lib.makeSearchPath "share" ([ dmcfg.sessionData.desktops ] ++ cfg.extraPackages);
 in
 {
   options.services.displayManager.plasma-login-manager = {
@@ -51,6 +53,16 @@ in
       };
       description = "Additional settings for Plasma Login Manager (see `man plasmalogin.conf`)";
     };
+
+    extraPackages = mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression "[ pkgs.kdePackages.breeze-icons ]";
+      description = ''
+        Extra packages to be made available to the Plasma Login Manager greeter environment.
+        Useful for custom icon themes, look-and-feel packages, cursors, and fonts.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -66,16 +78,12 @@ in
       path = [ cfg.package ];
       wantedBy = [ "graphical.target" ];
       restartIfChanged = false;
-      environment.XDG_DATA_DIRS = lib.mkIf (
-        dmcfg.sessionPackages != [ ]
-      ) "${dmcfg.sessionData.desktops}/share";
+      environment.XDG_DATA_DIRS = xdgDataDirs;
     };
 
     systemd.user.services.plasma-login = {
       overrideStrategy = "asDropin";
-      environment.XDG_DATA_DIRS = lib.mkIf (
-        dmcfg.sessionPackages != [ ]
-      ) "${dmcfg.sessionData.desktops}/share";
+      environment.XDG_DATA_DIRS = xdgDataDirs;
     };
 
     systemd.defaultUnit = "graphical.target";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

When using custom global themes or icon themes, plasmalogin fails to resolve icon assets because XDG_DATA_DIRS only contains session .desktop files. This PR should fix that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
