### PR TITLE
cheat-engine: init at 7.7.1

### DIFF
--- a/pkgs/by-name/ch/cheat-engine/package.nix
+++ b/pkgs/by-name/ch/cheat-engine/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+  autoPatchelfHook,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeWrapper,
+  wrapGAppsHook3,
+  qt6Packages,
+  libGL,
+  gtk3,
+  libx11,
+  zlib,
+}:
+let
+  runtimeLibs = [
+    libGL
+  ];
+
+  # The zip ships no app icon, so use the official logo from the
+  # cheat-engine repo, pinned to a commit for reproducibility.
+  icon = fetchurl {
+    url = "https://raw.githubusercontent.com/cheat-engine/cheat-engine/ec45d5f47f92a239ba0bf51ec5d04a7509c3fd37/Cheat%20Engine/images/celogo.png";
+    sha256 = "sha256-MNq3cEvgjE7Jl5isoajMTt2CutdjuvwKidZdM0aYFuo=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "cheat-engine";
+  version = "7.7.1";
+
+  src = fetchurl {
+    url = "https://cheatengine.org/download/CheatEngineLinux771.zip";
+    hash = "sha256-D7DZBDroVqzeA7W4caLzYn689nSurNBF+G1W2RoH8Xc=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    unzip
+    autoPatchelfHook
+    copyDesktopItems
+    makeWrapper
+
+    wrapGAppsHook3
+    qt6Packages.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    qt6Packages.qtbase
+    qt6Packages.libqtpas
+    libx11
+    libGL
+    zlib
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "cheat-engine";
+      exec = "cheat-engine";
+      icon = "cheat-engine";
+      desktopName = "Cheat Engine";
+      comment = "Memory scanner/debugger for games";
+      categories = [
+        "Game"
+        "Utility"
+      ];
+    })
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontWrapGApps = true;
+  dontWrapQtApps = true;
+
+  unpackPhase = ''
+    unzip -q "$src"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/cheat-engine $out/bin
+    cp -r ./* $out/share/cheat-engine/
+    install -Dm644 ${icon} $out/share/icons/hicolor/128x128/apps/cheat-engine.png
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    makeWrapper \
+      $out/share/cheat-engine/cheatengine-x86_64 \
+      $out/bin/cheat-engine \
+      "''${gappsWrapperArgs[@]}" \
+      "''${qtWrapperArgs[@]}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}" \
+      --chdir $out/share/cheat-engine
+  '';
+
+  # No GitHub/GitLab/etc. release source nix-update can check, so this ships
+  # a custom script that reads the version off the downloads page.
+  passthru.updateScript = [ ./update.sh ];
+
+  meta = {
+    description = "Memory scanner/debugger for games, used for educational purposes";
+    homepage = "https://cheatengine.org/";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = lib.platforms.linux;
+    mainProgram = "cheat-engine";
+    maintainers = [ lib.maintainers.mschuwalow ];
+  };
+}

--- a/pkgs/by-name/ch/cheat-engine/update.sh
+++ b/pkgs/by-name/ch/cheat-engine/update.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl nix perl git
+# shellcheck shell=bash
+
+# Cheat Engine ships no GitHub/GitLab releases page that nix-update
+# understands, but its downloads page is the canonical source of the
+# latest Linux zip. Version "7.7.1" is encoded in the URL as "771".
+
+set -euo pipefail
+
+attr="${UPDATE_NIX_ATTR_PATH:-cheat-engine}"
+downloads_url="https://cheatengine.org/downloads.php"
+base_url="https://cheatengine.org/download/"
+
+repo_root="$(git rev-parse --show-toplevel)"
+system="$(nix eval --impure --raw --expr 'builtins.currentSystem')"
+
+result="$(nix --extra-experimental-features 'nix-command flakes' eval --impure --raw --expr "
+  let
+    flake = builtins.getFlake \"$repo_root\";
+    pkg = flake.legacyPackages.\"$system\".\"$attr\";
+    pos = builtins.unsafeGetAttrPos \"version\" pkg;
+    outPath = toString flake.outPath;
+    relFile = builtins.substring (builtins.stringLength outPath) (-1) pos.file;
+  in
+  relFile + \"\n\" + pkg.version + \"\n\" + pkg.src.url + \"\n\" + pkg.src.outputHash
+")"
+
+deriv_file="$repo_root$(printf '%s' "$result" | sed -n 1p)"
+old_version="$(printf '%s' "$result" | sed -n 2p)"
+old_url="$(printf '%s' "$result" | sed -n 3p)"
+old_hash="$(printf '%s' "$result" | sed -n 4p)"
+
+page="$(curl -sSL --compressed "$downloads_url")"
+
+# The downloads page names the version explicitly ("Download Cheat Engine
+# 7.7.1 For Linux"), which handles multi-digit major/minor/patch correctly
+# instead of reverse-parsing the dot-stripped URL suffix.
+new_version="$(printf '%s' "$page" | grep -oE 'Download Cheat Engine [0-9.]+ For Linux' | grep -oE '[0-9.]+' | head -n1)"
+if [[ -z "$new_version" ]]; then
+  echo "$attr: failed to find the Linux version on $downloads_url" >&2
+  exit 1
+fi
+
+# The download URL is the version with dots stripped (7.7.1 -> 771). Cross-check
+# the full expected link against the page so a site-side naming change is caught.
+url_suffix="${new_version//./}"
+new_url="${base_url}CheatEngineLinux${url_suffix}.zip"
+if ! printf '%s' "$page" | grep -qF "$new_url"; then
+  echo "$attr: expected $new_url on $downloads_url but did not find it" >&2
+  exit 1
+fi
+
+if [[ "$new_version" == "$old_version" ]]; then
+  echo "$attr: already up to date ($old_version)"
+  exit 0
+fi
+
+raw_new_hash="$(nix-prefetch-url --type sha256 "$new_url" 2>/dev/null)"
+new_hash="$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$raw_new_hash")"
+
+# Replace literally with perl: \Q..\E quotes the search string so the SRI hash
+# and URL (which contain '+', '/', etc.) are matched verbatim, unlike sed -E.
+replace_lit() {
+  local old="$1" new="$2" file="$3"
+  OLD="$old" NEW="$new" perl -i -pe 's/\Q$ENV{OLD}\E/$ENV{NEW}/' "$file"
+}
+
+replace_lit "version = \"$old_version\"" "version = \"$new_version\"" "$deriv_file"
+replace_lit "url = \"$old_url\"" "url = \"$new_url\"" "$deriv_file"
+replace_lit "hash = \"$old_hash\"" "hash = \"$new_hash\"" "$deriv_file"
+
+echo "$attr: $old_version -> $new_version"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [cheat-engine](https://www.cheatengine.org/) to nixpkgs, as they now ship a native linux build.

I'm not sure whether this kind of package is welcome in nixpkgs, feel free to just close the pr if it is not a good fit.

update script was tested with `nix-shell maintainers/scripts/update.nix --argstr package cheat-engine`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
