### PR TITLE
libtorrent-rasterbar: 2_0_x -> 2_1_x

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -2,7 +2,7 @@
   lib,
   fetchurl,
   intltool,
-  libtorrent-rasterbar,
+  libtorrent-rasterbar-2_0_x,
   python3Packages,
   gtk3,
   libappindicator,

--- a/pkgs/by-name/li/libtorrent-rasterbar-2_1_x/package.nix
+++ b/pkgs/by-name/li/libtorrent-rasterbar-2_1_x/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   patches = [
     ./python-destdir.patch

--- a/pkgs/by-name/li/libtorrent-rasterbar-2_1_x/package.nix
+++ b/pkgs/by-name/li/libtorrent-rasterbar-2_1_x/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  boost,
+  fetchFromGitHub,
+  cmake,
+  openssl,
+  python3,
+}:
+
+let
+  # Make sure we override python, so the correct version is chosen
+  boostPython = boost.override {
+    enablePython = true;
+    python = python3;
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libtorrent-rasterbar";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "arvidn";
+    repo = "libtorrent";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-hQdwzGhDt9V0pJHRPSSCUshX80sWnIpPnuiO0zkb8Cg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  buildInputs = [
+    boostPython
+    openssl
+  ];
+
+  strictDeps = true;
+
+  patches = [
+    ./python-destdir.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace cmake/Modules/GeneratePkgConfig/target-compile-settings.cmake.in \
+      --replace-fail \
+        'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")' \
+        'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")
+         set(_INSTALL_FULL_LIBDIR "@CMAKE_INSTALL_FULL_LIBDIR@")' \
+      --replace-fail \
+        'set(_INSTALL_INCLUDEDIR "@CMAKE_INSTALL_INCLUDEDIR@")' \
+        'set(_INSTALL_INCLUDEDIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")'
+
+    substituteInPlace cmake/Modules/GeneratePkgConfig/pkg-config.cmake.in \
+      --replace-fail '$'{prefix}/@_INSTALL_LIBDIR@ @_INSTALL_FULL_LIBDIR@
+  '';
+
+  postInstall = ''
+    moveToOutput "include" "$dev"
+    moveToOutput "lib/${python3.libPrefix}" "$python"
+
+    pc="$(find "$out" -type f -name 'libtorrent-rasterbar.pc' -print -quit)"
+
+    substituteInPlace "$pc" \
+      --replace-fail "$out/$dev" "$dev"
+
+    mkdir -p "$dev/lib/pkgconfig"
+    mv "$pc" "$dev/lib/pkgconfig/libtorrent-rasterbar.pc"
+  '';
+
+  postFixup = ''
+    substituteInPlace "$dev/lib/cmake/LibtorrentRasterbar/LibtorrentRasterbarTargets-release.cmake" \
+      --replace-fail "\''${_IMPORT_PREFIX}/lib" "$out/lib"
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+    "python"
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "python-bindings" true)
+  ];
+
+  meta = {
+    homepage = "https://libtorrent.org/";
+    description = "Efficient feature complete C++ bittorrent implementation";
+    changelog = "https://github.com/arvidn/libtorrent/blob/${finalAttrs.src.tag}/ChangeLog";
+    license = lib.licenses.bsd3;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libtorrent-rasterbar-2_1_x/python-destdir.patch
+++ b/pkgs/by-name/li/libtorrent-rasterbar-2_1_x/python-destdir.patch
@@ -1,0 +1,13 @@
+diff --git a/bindings/python/CMakeLists.txt b/bindings/python/CMakeLists.txt
+index 4e8ee816b..ff1981d84 100644
+--- a/bindings/python/CMakeLists.txt
++++ b/bindings/python/CMakeLists.txt
+@@ -106,7 +106,7 @@ endif()
+ message(STATUS "Python 3 site packages: ${_PYTHON3_SITE_ARCH}")
+ message(STATUS "Python 3 extension suffix: ${Python3_SOABI}")
+ 
+-install(TARGETS python-libtorrent DESTINATION "${_PYTHON3_SITE_ARCH}")
++install(TARGETS python-libtorrent DESTINATION "\$ENV{DESTDIR}${_PYTHON3_SITE_ARCH}")
+ 
+ if (python-egg-info)
+ 	set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmake.in")

--- a/pkgs/by-name/qb/qbittorrent/package.nix
+++ b/pkgs/by-name/qb/qbittorrent/package.nix
@@ -3,6 +3,7 @@
   cmake,
   dbus,
   fetchFromGitHub,
+  fetchpatch,
   guiSupport ? true,
   lib,
   libtorrent-rasterbar,
@@ -29,6 +30,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "release-${finalAttrs.version}";
     hash = "sha256-K6YnqKHVo+notbjKxnzcN1DEcpAa2KMge4Ov30poEQY=";
   };
+
+  # Remove with the release of version 5.3.0
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/qbittorrent/qBittorrent/commit/e154c1a811021ab0bd6e6f9595c2b3c6518aaea3.patch";
+      hash = "sha256-W7lgokw2R0tcjUngGrvZBAKfwSxwb8yp6bVqfguATnQ=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6050,7 +6050,7 @@ with pkgs;
 
   libsigcxx30 = callPackage ../development/libraries/libsigcxx/3.0.nix { };
 
-  libtorrent-rasterbar = libtorrent-rasterbar-2_0_x;
+  libtorrent-rasterbar = libtorrent-rasterbar-2_1_x;
 
   libubox-nossl = libubox.override { with_ustream_ssl = false; };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Resolves https://github.com/NixOS/nixpkgs/issues/551573

Assisted-by: ChatGPT-6

Differences to 2_0_x:
```patch
@@ -17,14 +17,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "libtorrent-rasterbar";
-  version = "2.0.13";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "arvidn";
     repo = "libtorrent";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-0L7C3IY/XA+/vLJjZr47aFdYypevhMn1tzZNvDtOjbw=";
+    hash = "sha256-hQdwzGhDt9V0pJHRPSSCUshX80sWnIpPnuiO0zkb8Cg=";
   };
 
   nativeBuildInputs = [
@@ -43,18 +43,16 @@ stdenv.mkDerivation (finalAttrs: {
     ./python-destdir.patch
   ];
 
-  # https://github.com/arvidn/libtorrent/issues/6865
   postPatch = ''
     substituteInPlace cmake/Modules/GeneratePkgConfig/target-compile-settings.cmake.in \
       --replace-fail \
         'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")' \
         'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")
-         set(_INSTALL_FULL_LIBDIR "@CMAKE_INSTALL_FULL_LIBDIR@")'
-  ''
-  # a: libdir=''${prefix}//nix/store/...
-  # b: libdir=/nix/store/...
-  # https://github.com/NixOS/nixpkgs/issues/144170
-  + ''
+         set(_INSTALL_FULL_LIBDIR "@CMAKE_INSTALL_FULL_LIBDIR@")' \
+      --replace-fail \
+        'set(_INSTALL_INCLUDEDIR "@CMAKE_INSTALL_INCLUDEDIR@")' \
+        'set(_INSTALL_INCLUDEDIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")'
+
     substituteInPlace cmake/Modules/GeneratePkgConfig/pkg-config.cmake.in \
       --replace-fail '$'{prefix}/@_INSTALL_LIBDIR@ @_INSTALL_FULL_LIBDIR@
   '';
@@ -62,17 +60,19 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     moveToOutput "include" "$dev"
     moveToOutput "lib/${python3.libPrefix}" "$python"
+
+    pc="$(find "$out" -type f -name 'libtorrent-rasterbar.pc' -print -quit)"
+
+    substituteInPlace "$pc" \
+      --replace-fail "$out/$dev" "$dev"
+
+    mkdir -p "$dev/lib/pkgconfig"
+    mv "$pc" "$dev/lib/pkgconfig/libtorrent-rasterbar.pc"
   '';
 
   postFixup = ''
     substituteInPlace "$dev/lib/cmake/LibtorrentRasterbar/LibtorrentRasterbarTargets-release.cmake" \
       --replace-fail "\''${_IMPORT_PREFIX}/lib" "$out/lib"
-  ''
-  # a: Cflags: ... -I/nix/store/x//nix/store/x-dev/include ...
-  # b: Cflags: ... -I/nix/store/x-dev/include ...
-  + ''
-    substituteInPlace $dev/lib/pkgconfig/libtorrent-rasterbar.pc \
-      --replace-fail "$out/$dev" "$dev"
   '';
 
   outputs = [

```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
