### PR TITLE
various: adopt packages by freedesktop team

### DIFF
--- a/pkgs/by-name/fo/font-util/package.nix
+++ b/pkgs/by-name/fo/font-util/package.nix
@@ -47,8 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
       # or its an older version that the one on spdx
       unicodeTOU
     ];
-    maintainers = [ ];
     pkgConfigModules = [ "fontutil" ];
     platforms = lib.platforms.unix;
+    teams = [ lib.teams.freedesktop ];
   };
 })

--- a/pkgs/by-name/fp/fprintd/package.nix
+++ b/pkgs/by-name/fp/fprintd/package.nix
@@ -119,6 +119,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "D-Bus daemon that offers libfprint functionality over the D-Bus interprocess communication bus";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    teams = [ lib.teams.freedesktop ];
   };
 })

--- a/pkgs/by-name/li/libfprint/package.nix
+++ b/pkgs/by-name/li/libfprint/package.nix
@@ -95,6 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library designed to make it easy to add support for consumer fingerprint readers";
     license = lib.licenses.lgpl21Only;
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    teams = [ lib.teams.freedesktop ];
   };
 })

--- a/pkgs/by-name/li/libglvnd/package.nix
+++ b/pkgs/by-name/li/libglvnd/package.nix
@@ -112,6 +112,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     # https://gitlab.freedesktop.org/glvnd/libglvnd/-/issues/212
     badPlatforms = [ lib.systems.inspect.platformPatterns.isStatic ];
-    maintainers = [ ];
+    teams = [ lib.teams.freedesktop ];
   };
 })

--- a/pkgs/by-name/li/libslirp/package.nix
+++ b/pkgs/by-name/li/libslirp/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "General purpose TCP-IP emulator";
     homepage = "https://gitlab.freedesktop.org/slirp/libslirp";
     license = lib.licenses.bsd3;
-    maintainers = [ ];
     platforms = lib.platforms.unix;
+    teams = [ lib.teams.freedesktop ];
   };
 })

--- a/pkgs/by-name/us/usbredir/package.nix
+++ b/pkgs/by-name/us/usbredir/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     mainProgram = "usbredirect";
     homepage = "https://www.spice-space.org/usbredir.html";
     license = lib.licenses.lgpl21Plus;
-    maintainers = [ ];
     platforms = lib.platforms.unix;
+    teams = [ lib.teams.freedesktop ];
   };
 }

--- a/pkgs/by-name/vi/virglrenderer/package.nix
+++ b/pkgs/by-name/vi/virglrenderer/package.nix
@@ -94,8 +94,8 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Virtual 3D GPU for use inside QEMU virtual machines";
     homepage = "https://docs.mesa3d.org/drivers/virgl";
     license = lib.licenses.mit;
-    maintainers = [ ];
     mainProgram = "virgl_test_server";
     platforms = lib.platforms.unix;
+    teams = [ lib.teams.freedesktop ];
   };
 })

--- a/pkgs/by-name/xd/xdg-utils/package.nix
+++ b/pkgs/by-name/xd/xdg-utils/package.nix
@@ -367,7 +367,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.freedesktop.org/wiki/Software/xdg-utils/";
     description = "Set of command line tools that assist applications with a variety of desktop integration tasks";
     license = lib.licenses.mit;
-    maintainers = [ ];
     platforms = lib.platforms.all;
+    teams = [ lib.teams.freedesktop ];
   };
 })


### PR DESCRIPTION
Adopt some packages without maintainer by the freedesktop team so they can have a new home.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
