### PR TITLE
yarr: 2.6 → 2.8

### DIFF
--- a/pkgs/by-name/ya/yarr/package.nix
+++ b/pkgs/by-name/ya/yarr/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildGoModule,
+  buildNpmPackage,
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
@@ -10,14 +11,29 @@
 
 buildGoModule (finalAttrs: {
   pname = "yarr";
-  version = "2.6";
+  version = "2.8";
 
   src = fetchFromGitHub {
     owner = "nkanaev";
     repo = "yarr";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-D/049qH6CFNL7MY5e54guA9i84pbAwGf2UPHnVQWCkU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9JzwuDaU/dV9SXBL5cAiDl0lehfFZMnClYS94dlUh88=";
   };
+
+  assets = buildNpmPackage {
+    pname = "${finalAttrs.pname}-assets";
+    inherit (finalAttrs) version src;
+    npmDepsHash = "sha256-1WUzvlllmQhtJ2k2rw+SzBu5ktwIFaATMSNZWq9EU0k=";
+    installPhase = ''
+      runHook preInstall
+      cp -r src/assets/static "$out"
+      runHook postInstall
+    '';
+  };
+
+  postPatch = ''
+    cp ${finalAttrs.assets}/bundle.{css,js} src/assets/static
+  '';
 
   vendorHash = null;
 
@@ -31,15 +47,20 @@ buildGoModule (finalAttrs: {
   tags = [
     "sqlite_foreign_keys"
     "sqlite_json"
+    "sqlite_fts5"
   ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
+  checkFlags = [ "-short" ]; # skip docker tests
+
   passthru = {
     updateScript = nix-update-script { };
     tests = lib.optionalAttrs stdenv.hostPlatform.isLinux nixosTests.yarr;
   };
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Yet another rss reader";


### PR DESCRIPTION
https://github.com/nkanaev/yarr/releases/tag/v2.8
https://github.com/nkanaev/yarr/releases/tag/v2.7

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
