### PR TITLE
treewide: sync gnome circle team packages with upstream

### DIFF
--- a/pkgs/by-name/ba/bazaar/package.nix
+++ b/pkgs/by-name/ba/bazaar/package.nix
@@ -119,5 +119,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     mainProgram = "bazaar";
     platforms = lib.platforms.linux;
+    teams = [ lib.teams.gnome-circle ];
   };
 })

--- a/pkgs/by-name/ca/cartridges/package.nix
+++ b/pkgs/by-name/ca/cartridges/package.nix
@@ -85,7 +85,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://apps.gnome.org/Cartridges/";
     changelog = "https://github.com/kra-mo/cartridges/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
-    teams = [ lib.teams.gnome-circle ];
     mainProgram = "cartridges";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/de/decibels/package.nix
+++ b/pkgs/by-name/de/decibels/package.nix
@@ -65,10 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.gnome.org/GNOME/decibels";
     changelog = "https://gitlab.gnome.org/GNOME/decibels/-/blob/${finalAttrs.version}/NEWS?ref_type=tags";
     license = lib.licenses.gpl3Only;
-    teams = [
-      lib.teams.gnome
-      lib.teams.gnome-circle
-    ];
+    teams = [ lib.teams.gnome ];
     mainProgram = "org.gnome.Decibels";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/gn/gnome-mahjongg/package.nix
+++ b/pkgs/by-name/gn/gnome-mahjongg/package.nix
@@ -58,7 +58,10 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.gnome.org/GNOME/gnome-mahjongg/-/blob/${finalAttrs.version}/NEWS?ref_type=tags";
     description = "Disassemble a pile of tiles by removing matching pairs";
     mainProgram = "gnome-mahjongg";
-    teams = [ lib.teams.gnome ];
+    teams = [
+      lib.teams.gnome
+      lib.teams.gnome-circle
+    ];
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/gr/gradia/package.nix
+++ b/pkgs/by-name/gr/gradia/package.nix
@@ -98,5 +98,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     ];
     mainProgram = "gradia";
     platforms = lib.platforms.linux;
+    teams = [ lib.teams.gnome-circle ];
   };
 })

--- a/pkgs/by-name/he/health/package.nix
+++ b/pkgs/by-name/he/health/package.nix
@@ -65,7 +65,6 @@ stdenv.mkDerivation rec {
     homepage = "https://apps.gnome.org/app/dev.Cogitri.Health";
     license = lib.licenses.gpl3Plus;
     mainProgram = "dev.Cogitri.Health";
-    teams = [ lib.teams.gnome-circle ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/le/letterpress/package.nix
+++ b/pkgs/by-name/le/letterpress/package.nix
@@ -74,7 +74,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     changelog = "https://gitlab.gnome.org/World/Letterpress/-/releases/${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
-    teams = [ lib.teams.gnome-circle ];
     platforms = lib.platforms.linux;
     mainProgram = "letterpress";
   };

--- a/pkgs/by-name/wo/wordbook/package.nix
+++ b/pkgs/by-name/wo/wordbook/package.nix
@@ -97,5 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ zendo ];
     mainProgram = "wordbook";
+    teams = [ lib.teams.gnome-circle ];
   };
 })


### PR DESCRIPTION
~~While cartridges has been removed with [`49decc5`](https://gitlab.gnome.org/Teams/Circle/-/commit/49decc59489d17bda290d578111827f278487a76), it's probably best to keep it under the `gnome-circle` team until we either drop it or it gets maintained again by another party.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
