### PR TITLE
ryl: init at 0.21.0

### DIFF
--- a/pkgs/by-name/ry/ryl/package.nix
+++ b/pkgs/by-name/ry/ryl/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  yamllint,
+  versionCheckHook,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ryl";
+  version = "0.21.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "owenlamont";
+    repo = "ryl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CfTohleyvbFU1WB5MzqZv3ZtZeWZdnmFcjqpVY4ON5M=";
+  };
+
+  cargoHash = "sha256-EzMlaTvVwOohwyEjeRFkiw+LTrIDA11gYCCxBoWzzAQ=";
+
+  nativeCheckInputs = [
+    yamllint # Needed for tests "*_yamllint"
+  ];
+
+  checkFlags = [
+    # Runs `uv run ./scripts/print_ryl_schemastore_schema.py` which makes uv
+    # try to download a cpython distribution using HTTP which is blocked by the network sandbox.
+    "--skip=schemastore_toml_schema_exposes_known_rule_properties"
+    "--skip=schemastore_toml_schema_sets_expected_metadata"
+    "--skip=schemastore_toml_schema_uses_readable_rule_wrapper_names"
+    "--skip=schemastore_toml_schema_validates_repo_fixtures"
+
+    # > thread 'indentation_matches_yamllint' (38984) panicked at tests/yamllint_compat_indentation.rs:130:13:
+    # > assertion `left == right` failed: diagnostics mismatch multi-line (auto-standard)
+    # >   left: "/build/.tmpd4bvjL/multi-bad.yaml\n  3:6       error    wrong indentation: expected 4 but found 5  (indentation)\n\n"
+    # >  right: "/build/.tmpd4bvjL/multi-bad.yaml\n  3:6       error    wrong indentation: expected 4but found 5  (indentation)\n\n"
+    "--skip=indentation_matches_yamllint"
+    # > thread 'quoted_strings_rule_matches_yamllint' (43249) panicked at tests/yamllint_compat_quoted_strings.rs:171:13:
+    # > assertion `left == right` failed: yamllint exit mismatch consistent (auto-standard)
+    # >   left: 255
+    # >  right: 1
+    "skip=quoted_strings_rule_matches_yamllint"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast YAML linter written in Rust (drop in replacement for yamllint - but with additional rules and features)";
+    homepage = "https://ryl-docs.pages.dev/";
+    downloadPage = "https://github.com/owenlamont/ryl";
+    changelog = "https://github.com/owenlamont/ryl/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.kpbaks ];
+    mainProgram = "ryl";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Considered a draft. The skip of tests `quoted_strings_rule_matches_yamllint` and `indentation_matches_yamllint` is done due to the logic of the tests being wrong. I think this should be fixed in the package source, as maintaining these edge cases is flakey.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
