### PR TITLE
beamPackages.ex_doc: 0.40.3 -> 0.40.4

### DIFF
--- a/pkgs/development/beam-modules/ex_doc/default.nix
+++ b/pkgs/development/beam-modules/ex_doc/default.nix
@@ -4,52 +4,35 @@
   fetchMixDeps,
   mixRelease,
   nix-update-script,
-
-  # for tests
-  beam27Packages,
-  beam28Packages,
 }:
-# Based on ../elixir-ls/default.nix
 
-let
+mixRelease (finalAttrs: {
   pname = "ex_doc";
-  version = "0.40.3";
+  version = "0.40.4";
   src = fetchFromGitHub {
     owner = "elixir-lang";
-    repo = "${pname}";
-    rev = "v${version}";
-    hash = "sha256-xGZCBnjYr+0x6JNcf0XZVdaKaUB8V72GuZI3lEunzic=";
+    repo = "${finalAttrs.pname}";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-wDdBjq62TX8m50LeszMx4f8nlUeMgElpKZ3imHNq7Hs=";
   };
-in
-mixRelease {
-  inherit
-    pname
-    version
-    src
-    ;
 
   escriptBinName = "ex_doc";
 
   stripDebug = true;
 
   mixFodDeps = fetchMixDeps {
-    pname = "mix-deps-${pname}";
-    inherit src version;
-    hash = "sha256-FSLAQhFk7NCUXRMfNr6E9XvndrviapjcKZDisHbB87Y=";
+    pname = "mix-deps-${finalAttrs.pname}";
+    inherit (finalAttrs) src version;
+    hash = "sha256-gjvvNG8LUFG5YouwFygbXeWUzlxpESAPZWzqXyS6vBw=";
   };
 
   passthru = {
-    tests = {
-      # ex_doc is the doc generation for OTP 27+, so let's make sure they build
-      erlang_27 = beam27Packages.erlang;
-      erlang_28 = beam28Packages.erlang;
-    };
-
     updateScript = nix-update-script { };
   };
 
   meta = {
     homepage = "https://github.com/elixir-lang/ex_doc";
+    changelog = "https://github.com/elixir-lang/ex_doc/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = ''
       ExDoc produces HTML and EPUB documentation for Elixir projects
     '';
@@ -58,4 +41,4 @@ mixRelease {
     mainProgram = "ex_doc";
     maintainers = with lib.maintainers; [ chiroptical ];
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/elixir-lang/ex_doc/blob/v0.40.4/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
