### PR TITLE
audacious-plugins: 4.5.1 -> 4.6.1

### DIFF
--- a/pkgs/by-name/au/audacious-plugins/package.nix
+++ b/pkgs/by-name/au/audacious-plugins/package.nix
@@ -47,13 +47,13 @@
 
 stdenv.mkDerivation rec {
   pname = "audacious-plugins";
-  version = "4.5.1";
+  version = "4.6.1";
 
   src = fetchFromGitHub {
     owner = "audacious-media-player";
     repo = "audacious-plugins";
     rev = "${pname}-${version}";
-    hash = "sha256-HfO59DOIYsEpBzUyaLYh/gXfz+zvH8lIY2yBVCn3wks=";
+    hash = "sha256-Gglg7ncrdlMdy8b16+CXxVeQinWrPaz0EoBebY6A8pk=";
   };
 
   patches = [

--- a/pkgs/by-name/au/audacious-plugins/package.nix
+++ b/pkgs/by-name/au/audacious-plugins/package.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   alsa-lib,
   audacious-bare,
   curl,
@@ -58,18 +57,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001-Set-plugindir-to-PREFIX-lib-audacious.patch
-
-    # Remove when version >= 4.6
-    (fetchpatch {
-      name = "0001-audacious-plugins-sid-Use-new-sidplayfp-API.patch";
-      url = "https://github.com/audacious-media-player/audacious-plugins/commit/42c05763a136d6523d611473ff3701e2d9e30bec.patch";
-      hash = "sha256-bTC9nZFNwyo4PsGrLyDiQJDOrHTUDHUQaxEFe/wFPME=";
-    })
-    (fetchpatch {
-      name = "0002-audacious-plugins-sid-Support-version-3.0-of-libsidplayfp-version.patch";
-      url = "https://github.com/audacious-media-player/audacious-plugins/commit/2aaf45bd3840858e23b75d5863129a510299abd6.patch";
-      hash = "sha256-FbGLd3aiKeoJXKgTMIdI/oBEx5EzcqyhL0jWhG6Fyfw=";
-    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates audacious-plugins to version 4.6.1. The audacious-plugins no longer builds when #533251 is merged with master, because aa0d0cb777b3cc4cde2ec4fb151bd9280fb35f39 (from #517074) added patches that fail to apply on top of 4.6.1.

Changelog:
* https://github.com/audacious-media-player/audacious-plugins/releases/tag/audacious-plugins-4.6
* https://github.com/audacious-media-player/audacious-plugins/releases/tag/audacious-plugins-4.6.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] ~~Tested basic functionality of all binary files, usually in `./result/bin/`.~~ Tested several plugins through audacious 4.6.1 built with audacious-plugins 4.6.1.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
