### PR TITLE
nixos/mjolnir: add support for using native encryption

### DIFF
--- a/nixos/modules/services/matrix/mjolnir.nix
+++ b/nixos/modules/services/matrix/mjolnir.nix
@@ -20,10 +20,15 @@ let
     rawHomeserverUrl = cfg.homeserverUrl;
 
     pantalaimon = {
-      inherit (cfg.pantalaimon) username;
-
       use = cfg.pantalaimon.enable;
+    }
+    // lib.optionalAttrs cfg.pantalaimon.enable {
+      inherit (cfg.pantalaimon) username;
       password = "@PANTALAIMON_PASSWORD@"; # will be replaced in "generateConfig"
+    };
+    encryption = {
+      inherit (cfg.settings.encryption) username;
+      password = "@ENCRYPTION_PASSWORD@"; # will be replaced in "generateConfig"
     };
   };
 
@@ -72,6 +77,9 @@ let
       ${lib.optionalString (cfg.pantalaimon.passwordFile != null) ''
         ${pkgs.replace-secret}/bin/replace-secret '@PANTALAIMON_PASSWORD@' '${cfg.pantalaimon.passwordFile}' ${cfg.dataPath}/config/default.yaml
       ''}
+      ${lib.optionalString (cfg.encryption.passwordFile != null) ''
+        ${pkgs.replace-secret}/bin/replace-secret '@ENCRYPTION_PASSWORD@' '${cfg.encryption.passwordFile}' ${cfg.dataPath}/config/default.yaml
+      ''}
     ''
   );
 in
@@ -95,6 +103,14 @@ in
       default = null;
       description = ''
         File containing the matrix access token for the `mjolnir` user.
+      '';
+    };
+
+    encryption.passwordFile = lib.mkOption {
+      type = with lib.types; nullOr path;
+      default = null;
+      description = ''
+        File containing the matrix password for the `mjolnir` user.
       '';
     };
 
@@ -187,16 +203,21 @@ in
   config = lib.mkIf config.services.mjolnir.enable {
     assertions = [
       {
+        assertion = !(cfg.settings.encryption.use && cfg.encryption.passwordFile == null);
+        message = "encryption.passwordFile must be specified when native encryption is used.";
+      }
+      {
         assertion = !(cfg.pantalaimon.enable && cfg.pantalaimon.passwordFile == null);
-        message = "Specify pantalaimon.passwordFile";
+        message = "pantalaimon.passwordFile must be specified when pantalaimon is enabled.";
       }
       {
-        assertion = !(cfg.pantalaimon.enable && cfg.accessTokenFile != null);
-        message = "Do not specify accessTokenFile when using pantalaimon";
+        assertion = cfg.accessTokenFile == null -> cfg.pantalaimon.enable || cfg.settings.encryption.use;
+        message = "Do not specify accessTokenFile when using native encryption or pantalaimon";
       }
       {
-        assertion = !(!cfg.pantalaimon.enable && cfg.accessTokenFile == null);
-        message = "Specify accessTokenFile when not using pantalaimon";
+        assertion =
+          !(!cfg.pantalaimon.enable && !cfg.settings.encryption.use && cfg.accessTokenFile == null);
+        message = "Specify accessTokenFile when not using pantalaimon or native encryption.";
       }
     ];
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
