### PR TITLE
llama-cpp-{cuda,rocm,vulkan}: add nixpkgs-update: no auto update

### DIFF
--- a/pkgs/by-name/ll/llama-cpp-cuda/package.nix
+++ b/pkgs/by-name/ll/llama-cpp-cuda/package.nix
@@ -1,3 +1,4 @@
 { llama-cpp }:
 
+# nixpkgs-update: no auto update
 llama-cpp.override { cudaSupport = true; }

--- a/pkgs/by-name/ll/llama-cpp-rocm/package.nix
+++ b/pkgs/by-name/ll/llama-cpp-rocm/package.nix
@@ -1,3 +1,4 @@
 { llama-cpp }:
 
+# nixpkgs-update: no auto update
 llama-cpp.override { rocmSupport = true; }

--- a/pkgs/by-name/ll/llama-cpp-vulkan/package.nix
+++ b/pkgs/by-name/ll/llama-cpp-vulkan/package.nix
@@ -1,3 +1,4 @@
 { llama-cpp }:
 
+# nixpkgs-update: no auto update
 llama-cpp.override { vulkanSupport = true; }


### PR DESCRIPTION
Just `llama-cpp` itself should be updated instead.

Prevents PRs like:
https://github.com/NixOS/nixpkgs/pull/560287
https://github.com/NixOS/nixpkgs/pull/560286
https://github.com/NixOS/nixpkgs/pull/560291


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
