### PR TITLE
uiua: 0.18.1 -> 0.19.1; uiua-unstable: 0.19.0-rc.1 -> 0.19.1

### DIFF
--- a/pkgs/by-name/ui/uiua/stable.nix
+++ b/pkgs/by-name/ui/uiua/stable.nix
@@ -1,8 +1,8 @@
 rec {
-  version = "0.18.1";
+  version = "0.19.1";
   tag = version;
-  hash = "sha256-HB6YjWi4DEbLTwMhqtcF0IufK8YEmE4w/7n/nsL8VEw=";
-  cargoHash = "sha256-B2eDBf5ycFpXBk9XIzkltdr6eDs/CHHufHtjoOAvg2E=";
+  hash = "sha256-wDMOFbwATIp0+wwlGxm5yEqnw7EtNc/savQy3RI2a/8=";
+  cargoHash = "sha256-eKfqPipGrrKQZLVKyHPYyeGHl8xQEIm4X5I1lfEwdxA=";
   updateScript = ./update-stable.sh;
-  patches = [ ];
+  patches = [ ./0001-no-network-test.patch ];
 }

--- a/pkgs/by-name/ui/uiua/unstable.nix
+++ b/pkgs/by-name/ui/uiua/unstable.nix
@@ -1,8 +1,8 @@
 rec {
-  version = "0.19.0-rc.1";
+  version = "0.19.1";
   tag = version;
-  hash = "sha256-xN154QH0CxPaoAN8oa5jj3G/wBRQgdBmYYnv0qMjShs=";
-  cargoHash = "sha256-lC3hm6cdd7IyjjsGvXX39JAqVfA6SEkV0kEnXL83sC4=";
+  hash = "sha256-wDMOFbwATIp0+wwlGxm5yEqnw7EtNc/savQy3RI2a/8=";
+  cargoHash = "sha256-eKfqPipGrrKQZLVKyHPYyeGHl8xQEIm4X5I1lfEwdxA=";
   updateScript = ./update-unstable.sh;
   patches = [ ./0001-no-network-test.patch ];
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
