### PR TITLE
scs: 3.3.0 -> 3.3.1

### DIFF
--- a/pkgs/by-name/sc/scs/package.nix
+++ b/pkgs/by-name/sc/scs/package.nix
@@ -65,5 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/cvxgrp/scs/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+    ];
   };
 })

--- a/pkgs/by-name/sc/scs/package.nix
+++ b/pkgs/by-name/sc/scs/package.nix
@@ -14,7 +14,7 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scs";
-  version = "3.3.0";
+  version = "3.3.1";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "cvxgrp";
     repo = "scs";
     tag = finalAttrs.version;
-    hash = "sha256-5Mq/mi2pW9DHXjhUEjflBeZMjJN+aJZRenVlRlloBcw=";
+    hash = "sha256-vk9S4ZKuFg/MWNDlO/Wxmvqg9jrJy29YZcoDrL7gwDs=";
   };
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/python-modules/scs/default.nix
+++ b/pkgs/development/python-modules/scs/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage (finalAttrs: {
     repo = "scs-python";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-k6G336VZPnbYU1GfZrS+f0vEshMKhSJMWcH2dgD0CaY=";
+    hash = "sha256-bwES05yte1fKN1D2NATneBFYpPhurf3ighQMeRPsxr4=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/scs/default.nix
+++ b/pkgs/development/python-modules/scs/default.nix
@@ -69,6 +69,8 @@ buildPythonPackage (finalAttrs: {
     downloadPage = "https://github.com/bodono/scs-python";
     changelog = "https://github.com/bodono/scs-python/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+    ];
   };
 })


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/cvxgrp/scs/compare/3.3.0...3.3.1
Changelog: https://github.com/cvxgrp/scs/releases/tag/3.3.1

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test