### PR TITLE
blinderkitten: init at 1.0.1b97

### DIFF
--- a/pkgs/by-name/bl/blinderkitten/package.nix
+++ b/pkgs/by-name/bl/blinderkitten/package.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  curl,
+  freetype,
+  libx11,
+  libxinerama,
+  libxrandr,
+  libxcursor,
+  libxcomposite,
+  mesa,
+  alsa-lib,
+  freeglut,
+  jack2,
+  bluez,
+  gtk3,
+  webkitgtk_4_1,
+  sdl3,
+  fuse2,
+  libusb1,
+  hidapi,
+  ladspa-header,
+  openssl,
+  avahi,
+  nix-update-script,
+}:
+
+let
+  juce = fetchFromGitHub {
+    owner = "norbertrostaing";
+    repo = "JUCE";
+    rev = "develop-local";
+    hash = "sha256-Dk66pXlJ/B9ezsDVqV0cxSNkqPVb2fqo4YGoCrCCHOE=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "blinderkitten";
+  version = "1.0.1b97";
+
+  src = fetchFromGitHub {
+    owner = "norbertrostaing";
+    repo = "BlinderKitten";
+    tag = finalAttrs.version;
+    hash = "sha256-8OT4tZXR01IOndVuCWJgSGLeyq5rxuFRcc1ZBWQKaZE=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  makeFlags = [
+    "-j2"
+    "CONFIG=Release"
+  ];
+
+  # https://github.com/norbertrostaing/BlinderKitten/blob/295380b51208f66756c5eda758c76284ac036c29/.github/workflows/build.yml#L199
+  buildInputs = [
+    curl
+    freetype
+    libx11
+    libxinerama
+    libxrandr
+    libxcursor
+    libxcomposite
+    mesa
+    alsa-lib
+    freeglut
+    jack2
+    bluez
+    gtk3
+    webkitgtk_4_1
+    sdl3
+    fuse2
+    libusb1
+    hidapi
+    ladspa-header
+    openssl
+    avahi
+  ];
+
+  # Patch nixpkgs webkitgtk version
+  # Patch avahi pkg-config; Fixing a missing lib during linking
+  postPatch = ''
+    ln -s ${juce} JUCE
+    substituteInPlace ./Builds/LinuxMakefile/Makefile \
+      --replace-fail "webkit2gtk-4.0" "webkit2gtk-4.1" \
+      --replace-fail "shell \$(PKG_CONFIG) --libs" "shell \$(PKG_CONFIG) --libs avahi-client"
+  '';
+
+  # Move into build directory
+  preBuild = ''
+    cd ./Builds/LinuxMakefile/
+  '';
+
+  # Install files
+  # Move binary
+  # Move desktop item
+  installPhase = ''
+    mkdir $out
+    cp -rvL BlinderKitten.AppDir/usr/* $out
+    mkdir $out/share/applications
+    cp -v build/BlinderKitten $out/bin
+    cp -v BlinderKitten.AppDir/blinderkitten.desktop $out/share/applications
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A free lighting software without restriction";
+    homepage = "https://blinderkitten.lighting/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ tgi74 ];
+    platforms = lib.platforms.linux;
+    mainProgram = "BlinderKitten";
+  };
+})


### PR DESCRIPTION
Hello hello!

[BlinderKitten](https://blinderkitten.lighting/) is a popular lighting software for interfacing with DMX/Art-net/MIDI et al.

It was quite straightforward to package, and improves installation as you don't have to rely on the AppImage.

The build process described here is based on the package's [github action build workflow](https://github.com/norbertrostaing/BlinderKitten/blob/main/.github/workflows/build.yml) used for release. I tried using the native projucer hook from `juce` in nixpkgs, but ultimately gave up as the project uses its own forked version on projucer (and upgrading in the build phase wouldn't be ideal).

(also yes, I'm working on a derivation for Chataigne as well, be patient c:)

## Things done

Init at latest version; Complete with binary & desktop item.

Tested to work on Linux x64 (my setup uses DMX over ArtNet & Midi).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
