### PR TITLE
python3Packages.pymap3d: init at 3.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13305,7 +13305,7 @@
   };
   jfr = {
     name = "Joseph Fox-Rabinovitz";
-    github = " joe-saronic";
+    github = "joe-saronic";
     githubId = 156837150;
   };
   jfroche = {

--- a/pkgs/development/python-modules/pymap3d/default.nix
+++ b/pkgs/development/python-modules/pymap3d/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # optional-dependencies
+  # core:
+  numpy,
+  python-dateutil,
+  # full:
+  astropy,
+  xarray,
+  # proj:
+  pyproj,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pymap3d";
+  version = "3.2.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "geospace-code";
+    repo = "pymap3d";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5H2gPt986lfP5/rB4222vAqbvfsQQdQ736N+GBaDM90=";
+  };
+
+  build-system = [ setuptools ];
+
+  optional-dependencies = {
+    core = [
+      numpy
+      python-dateutil
+    ];
+    full = [
+      astropy
+      xarray
+    ];
+    proj = [ pyproj ];
+  };
+
+  # tests missing an optional dependency skip themselves
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.core;
+
+  pythonImportsCheck = [ "pymap3d" ];
+
+  passthru.tests = {
+    # the full suite minus the matlab-engine tests
+    full = finalAttrs.finalPackage.overrideAttrs (old: {
+      nativeInstallCheckInputs =
+        old.nativeInstallCheckInputs
+        ++ finalAttrs.passthru.optional-dependencies.full
+        ++ finalAttrs.passthru.optional-dependencies.proj;
+    });
+  };
+
+  meta = {
+    description = "Pure Python 3-D coordinate conversions for geodesy and astrometry";
+    homepage = "https://github.com/geospace-code/pymap3d";
+    changelog = "https://github.com/geospace-code/pymap3d/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ jfr ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15357,6 +15357,8 @@ self: super: with self; {
 
   pymanopt = callPackage ../development/python-modules/pymanopt { };
 
+  pymap3d = callPackage ../development/python-modules/pymap3d { };
+
   pymarshal = callPackage ../development/python-modules/pymarshal { };
 
   pymata-express = callPackage ../development/python-modules/pymata-express { };


### PR DESCRIPTION
Added `pymap3d`, which I use pretty often for stuff. Since some of the tests have heavy dependencies, I added them to passthru only. The core tests only rely on numpy and dateutil. I figured the former is ubiquitous enough and the latter small enough to justify adding them.

First commit fixes a random space in my handle. Didn't seem worth waiting for a separate PR to fix that.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
