### PR TITLE
prevail: 0.2.0 -> 0.2.6

### DIFF
--- a/pkgs/by-name/pr/prevail/package.nix
+++ b/pkgs/by-name/pr/prevail/package.nix
@@ -13,14 +13,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "prevail";
-  version = "0.2.0";
+  version = "0.2.6";
 
   src = fetchFromGitHub {
     owner = "vbpf";
     repo = "prevail";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-qlQSoz9GE2Z2rzmrPIj+HnIQmNxiBSgvR40FR9psuDc=";
+    hash = "sha256-c4km7WO9K0Hb0mTOkilXLwpFC8pJ8MEIqqlpBLJoC10=";
   };
 
   patches = [

--- a/pkgs/by-name/pr/prevail/remove-fetchcontent-usage.patch
+++ b/pkgs/by-name/pr/prevail/remove-fetchcontent-usage.patch
@@ -6,7 +6,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
  
  FetchContent_Declare(GSL
 -  GIT_REPOSITORY "https://github.com/microsoft/GSL"
--  GIT_TAG "v4.2.0"
+-  GIT_TAG "v4.2.2"
 -  GIT_SHALLOW ON
 +  SOURCE_DIR "@gslSrc@"
  )
@@ -17,7 +17,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
  if (prevail_ENABLE_TESTS)
    FetchContent_Declare(Catch2
 -    GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
--    GIT_TAG "v3.13.0"
+-    GIT_TAG "v3.15.3"
 -    GIT_SHALLOW ON
 +    SOURCE_DIR "@catch2Src@"
    )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes: #559475

Diff: https://github.com/vbpf/prevail/compare/v0.2.0...v0.2.6
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
