### PR TITLE
oklch-color-picker: add X11 runtime dependencies

### DIFF
--- a/pkgs/by-name/ok/oklch-color-picker/package.nix
+++ b/pkgs/by-name/ok/oklch-color-picker/package.nix
@@ -7,6 +7,11 @@
   autoPatchelfHook,
   wayland,
   libxkbcommon,
+  libx11,
+  libxcursor,
+  libxi,
+  libxrandr,
+  libxcb,
   libGL,
   stdenv,
   makeDesktopItem,
@@ -37,6 +42,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     wayland
     libxkbcommon
+    libx11
+    libxcursor
+    libxi
+    libxrandr
+    libxcb
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
The picker links X11 libraries dynamically and panics on startup in an X11 session because only the Wayland runtime libraries were declared. Adds libx11, libxcursor, libxi, libxrandr and libxcb to `runtimeDependencies` on Linux.

Context: I'm the upstream author and I'm working on making `vimPlugins.oklch-color-picker-nvim` work on NixOS by having it use this package instead of downloading binaries at runtime. That override will be a separate PR. Testing it is what surfaced this missing dependency.

Verified with a NixOS VM test on X11 and Wayland, run from the plugin repository. The tested Nixpkgs branch contains this change plus the upcoming plugin override:
- Nixpkgs branch: https://github.com/eero-lehtinen/nixpkgs/tree/oklch-color-picker-nvim-test
- Test: https://github.com/eero-lehtinen/oklch-color-picker.nvim/tree/nixos-test-fork/tests/nixos
- Run: https://github.com/eero-lehtinen/oklch-color-picker.nvim/actions/runs/33994704591

This PR was written with Claude Code (Claude Fable 5.1); I reviewed the change and the test results.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the automation/AI policy.