### PR TITLE
gocron: 0.9.14 -> 0.11.0

### DIFF
--- a/nixos/tests/gocron.nix
+++ b/nixos/tests/gocron.nix
@@ -34,10 +34,10 @@
       return status == 0 and int(output) == 1
 
     def start_job():
-      machine.succeed("curl -X POST http://localhost:8156/api/jobs/Test%20job")
+      machine.succeed("curl -X POST http://localhost:8156/api/jobs/test-job")
 
     def job_ran_successfully() -> bool:
-      output = machine.succeed("curl http://localhost:8156/api/runs/Test%20job | jq '.[0].status_id, .[0].logs.[2].message'")
+      output = machine.succeed("curl http://localhost:8156/api/runs/test-job | jq '.[0].status_id, .[0].logs.[2].message'")
       split_output = output.split('\n')
       ran_successfully = int(split_output[0]) == 3
       log_message_as_expected = "Job runs not successfully" in split_output[1]

--- a/pkgs/by-name/go/gocron/package.nix
+++ b/pkgs/by-name/go/gocron/package.nix
@@ -2,12 +2,8 @@
   lib,
   fetchFromGitHub,
   nodejs,
-  fetchYarnDeps,
-  yarnConfigHook,
-  yarnBuildHook,
-  yarnInstallHook,
-  stdenv,
-  buildGoModule,
+  buildNpmPackage,
+  buildGo127Module,
   makeWrapper,
   bash,
   versionCheckHook,
@@ -15,38 +11,30 @@
   nixosTests,
 }:
 
-buildGoModule (finalAttrs: {
+buildGo127Module (finalAttrs: {
 
   pname = "gocron";
-  version = "0.9.14";
+  version = "0.11.0";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "flohoss";
     repo = "gocron";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LKjK5V+WrzTJlWPytafy8Ypva41RW4/12aSGaJj572I=";
+    hash = "sha256-NyL//yrKqYiwwQBdJHwQcPvjKssX4o9XrymI/6Hvbhc=";
   };
 
-  gocron-web = stdenv.mkDerivation (finalAttrsWebassets: {
+  gocron-web = buildNpmPackage (finalAttrsWebassets: {
     pname = "${finalAttrs.pname}-web";
     src = "${finalAttrs.src}/web";
     inherit (finalAttrs) version;
 
-    yarnOfflineCache = fetchYarnDeps {
-      yarnLock = finalAttrsWebassets.src + "/yarn.lock";
-      hash = "sha256-f0xnF9gd3c0KPrORPVkApyWPy+DazyzHeQu32wWybiw=";
-    };
+    npmDepsHash = "sha256-LVazZ0O82sQGxqyu0Dh4G/SmM33ftLoGqpgKrHMFGks=";
 
-    nativeBuildInputs = [
-      yarnConfigHook
-      yarnBuildHook
-      yarnInstallHook
-      nodejs
-    ];
+    dontNpmInstall = true;
 
     preBuild = ''
-      yarn types
+      npm run types
     '';
 
     postBuild = ''
@@ -55,7 +43,7 @@ buildGoModule (finalAttrs: {
 
   });
 
-  vendorHash = "sha256-VbmS9Fh0pr/dUB+pZBqKbi4bu6Do/3TRr9uI3TmGsOM=";
+  vendorHash = "sha256-p45E84MWNTa0VvvGiOfOZ/ZEJ41m0Wu7g1nTEFYkU6c=";
 
   postPatch = ''
     substituteInPlace handlers/web.go \


### PR DESCRIPTION
gocron switched to npm for the webassets.

Also, go 1.27 is needed, which isn't covered by `buildGoModule`, which currently is on 1.26.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
