### PR TITLE
libsoup_3: fix several CVEs

### DIFF
--- a/pkgs/by-name/li/libsoup_3/package.nix
+++ b/pkgs/by-name/li/libsoup_3/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  fetchpatch,
   glib,
   meson,
   ninja,
@@ -36,6 +37,84 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     hash = "sha256-Ue0K4G+dWkD0Af9Fni5fZS+aUQt3MOE1nuZtFNSHJ0A=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2026-1539.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/98c1285d9d78662c38bf14b4a128af01ccfdb446.patch";
+      hash = "sha256-gEqCeGx49/egPlMcvmOTslszJb/FlVlw+BhQznr5sv0=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-0719.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/1972635264f1d9ab1823c8b6becf921b4125b513.patch";
+      hash = "sha256-k7inbIk0HyijAtTWXFxJYfDTDBif/izWrsYQmdg7z4A=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-12478.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/303256edac53bd9321fb6ec61924ea82f04ed284.patch";
+      hash = "sha256-83teXanQTc6MC5/KBtfz0zgDjatSeiomIbmTFelc3d0=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-6324.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/96ac392b444d01bd5de1d1276b187c3ed49d048c.patch";
+      hash = "sha256-Y4MzqjroDnUFgDd9NRW/bHRRjWaSphB5dU5DnMdIG6I=";
+    })
+    (fetchpatch {
+      name = "Regression-fix-after-CVE-2026-6324-fix.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/538.patch";
+      hash = "sha256-v5xvd7XLHCROeec2bid/5V7Livd1uMHki39Oi+OokLg=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-5119.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/b0626fff8538e3dd4a52f148d91c8348d51d64d1.patch";
+      hash = "sha256-fLTmSp+Z8ZEVbqiaSOjG1iNhg16FS5ul8fP9y0uBeqY=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-4271.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/489affa74c8a229b8a4dd541710d4a5debedb7b4.patch";
+      hash = "sha256-XuFJMHtAiQiJ26KQ51JDQdJ/NdVkuccZCHQMOyzzdF0=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-2708.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/e032d3e9b0a27d10597398023532dd8f9b6654cf.patch";
+      hash = "sha256-r30VFpkOqJRiEhl63uavmKecbk8tpTuCvL9YbIozyZg=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-15711.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/60aa1ce2bdc7bb5da33be9062f50bcec7db67fca.patch";
+      hash = "sha256-13fU7zuzkb7wIH3BxylBaVyw6s/X6f4/ji9yYqYIcVg=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-12548.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/7334c38f1f6aa5e64207cb415cf2509838c52b37.patch";
+      hash = "sha256-eDsYtL6NHyouaVEHptZy2Gy/34guZJA7LUtj+YgWWQE=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-12549.patch"; # Also: CVE-2026-77014, CVE-2026-77680
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/550.patch";
+      hash = "sha256-Dpd1qyJlIqNp6MzqyCKQ6anQr887e4J3CAGXEyzQOYU=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-15713.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/24fb645fa949ece7d7e10363b77cf2d5fa2c2469.patch";
+      hash = "sha256-TdWCOo2QnCnTbV0dPk4iGnNuwZO+LKSH1YFp2XAenwY=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-15712.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/3a6fb56a0cba42d11f5fd1db6dedcc7c2e92757b.patch";
+      hash = "sha256-IPYr77720+LOi3fp+x2M4MTKOm62As0dh8lZ5hKsuTU=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-15714.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/79a52cadc490360e249cc2b23038d532b44dbf23.patch";
+      hash = "sha256-p5J1QlfU+/be5YVahVTKt2QsxlRttrf62AYOa1QrwEo=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-85534.patch";
+      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/5f656cd97b8a6f4a5b8b7a30efb7c2cc8ef498fb.patch";
+      hash = "sha256-DD5HO+ZCn9Q/lVWWG9WnTBSeOe37Y3GD4dvsP4YuCLI=";
+    })
+  ];
 
   depsBuildBuild = [
     pkg-config


### PR DESCRIPTION
This fixes 16 CVEs in `libsoup_3`.

I based this list of CVEs on previous work by @LordGrimmauld and @jtojnar (thanks!) and did a separate pass through the list of recent CVEs for libsoup. Applied all patches that made sense to apply. See also earlier discussion in https://github.com/NixOS/nixpkgs/pull/541570.

In the order of the applied patches:

CVE-2026-1539 (https://github.com/NixOS/nixpkgs/issues/488133)
CVE-2026-0719 (https://github.com/NixOS/nixpkgs/issues/487561)
CVE-2026-12478 — follow-up for CVE-2026-0716 (https://github.com/NixOS/nixpkgs/issues/480810)
CVE-2026-6324 — plus regression fix: https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/538
CVE-2026-5119 (https://github.com/NixOS/nixpkgs/issues/505297)
CVE-2026-4271
CVE-2026-2708
CVE-2026-15711 (https://github.com/NixOS/nixpkgs/issues/544163)
CVE-2026-12548
CVE-2026-12549 (https://github.com/NixOS/nixpkgs/issues/534494)
CVE-2026-77014
CVE-2026-77680
CVE-2026-15713 (https://github.com/NixOS/nixpkgs/issues/544161)
CVE-2026-15712
CVE-2026-15714 (https://github.com/NixOS/nixpkgs/issues/544167)
CVE-2026-85534 (https://github.com/NixOS/nixpkgs/issues/560179)

To verify that this does not cause any major breakage (all tested on `x86_64-linux`):

- Verified that all tests apart from HSTS tests still pass when setting `doCheck = true` (HSTS tests are currently expected to fail, see the comment above `doCheck`)
- Verified that the GNOME installer ISO builds (note: I've excluded firefox)
- Verified basic functionality of the GNOME DE and a couple of GNOME applications that depend on `libsoup_3` on a live system based on said GNOME installer ISO
- A second pair of eyes on the upstream changes would nonetheless be appreciated :)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
