### PR TITLE
piper-tts: 1.7.0 -> 1.8.0; enable tests

### DIFF
--- a/pkgs/by-name/pi/piper-tts/package.nix
+++ b/pkgs/by-name/pi/piper-tts/package.nix
@@ -30,14 +30,14 @@ in
 
 python3Packages.buildPythonApplication rec {
   pname = "piper-tts";
-  version = "1.7.0";
+  version = "1.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OHF-Voice";
     repo = "piper1-gpl";
     tag = "v${version}";
-    hash = "sha256-oQhDFhB2GXlAdxW1K7BM7RJkzihAwyoB6QbOpaMUVHM=";
+    hash = "sha256-rlox5n+EWJf/464L/0rwjEmSEkxo2XQQhubq7cbLvL8=";
   };
 
   patches = [

--- a/pkgs/by-name/pi/piper-tts/package.nix
+++ b/pkgs/by-name/pi/piper-tts/package.nix
@@ -127,6 +127,15 @@ python3Packages.buildPythonApplication rec {
     cp -Rv src/piper/train/vits $train/
   '';
 
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  disabledTests = [
+    # RuntimeError: cannot cache function '__o_fold': no locator available for file '/nix/store/byi2l9xb88xan6vf88xcx9vbklyvxha5-python3.14-librosa-1.0.0/lib/python3.14/site-packages/librosa/core/notation.py'
+    "test_training_phonemize_matches_inference_with_vowel_clusters"
+  ];
+
   pythonImportsCheck = [
     "piper"
     "piper.tashkeel"

--- a/pkgs/development/python-modules/pyopenjtalk-plus/default.nix
+++ b/pkgs/development/python-modules/pyopenjtalk-plus/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   replaceVars,
   buildPythonPackage,
   fetchFromGitHub,
@@ -79,6 +80,11 @@ buildPythonPackage (finalAttrs: {
     # however, the tests still need them, so we specify the original dictionary dir
     export OPEN_JTALK_DICT_DIR=_pyopenjtalk/dictionary
   '';
+
+  disabledTestPaths = lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+    # onnxruntime.capi.onnxruntime_pybind11_state.NotImplemented
+    "tests/test_tsqyomi_regression.py"
+  ];
 
   pythonImportsCheck = [ "pyopenjtalk" ];
 


### PR DESCRIPTION
https://github.com/OHF-Voice/piper1-gpl/releases/tag/v1.8.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
