### PR TITLE
python3Packages.{mcap,mcap-protobuf-support}: init

### DIFF
--- a/pkgs/development/python-modules/mcap-protobuf-support/default.nix
+++ b/pkgs/development/python-modules/mcap-protobuf-support/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  mcap,
+  protobuf,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mcap-protobuf-support";
+  version = "0.5.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "foxglove";
+    repo = "mcap";
+    tag = "releases/python/mcap-protobuf-support/v${finalAttrs.version}";
+    hash = "sha256-BBS1M9LDBas7B0h9GB/r4fBrRcF1WAcXhWlX1J9+wmA=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python/mcap-protobuf-support";
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    mcap
+    protobuf
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "mcap_protobuf" ];
+
+  meta = {
+    description = "Protobuf support for the Python MCAP library";
+    homepage = "https://github.com/foxglove/mcap";
+    changelog = "https://github.com/foxglove/mcap/releases/tag/releases%2Fpython%2Fmcap-protobuf-support%2Fv${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jfr ];
+  };
+})

--- a/pkgs/development/python-modules/mcap/default.nix
+++ b/pkgs/development/python-modules/mcap/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  fetchurl,
+  lz4,
+  pytestCheckHook,
+  setuptools,
+  zstandard,
+}:
+
+let
+  version = "1.4.0";
+  fixturesRef = "refs/tags/releases/python/mcap/v${version}";
+  # test fixtures are absent from sdist, but present in the monorepo under git-lfs
+  demo-mcap = fetchurl {
+    url = "https://media.githubusercontent.com/media/foxglove/mcap/${fixturesRef}/testdata/mcap/demo.mcap";
+    hash = "sha256-uQoK9EK/xqrzHXrgo2HwTSpO7MpxaPmRc5G3RpevXIw=";
+  };
+  one-message-mcap = fetchurl {
+    url = "https://media.githubusercontent.com/media/foxglove/mcap/${fixturesRef}/tests/conformance/data/OneMessage/OneMessage.mcap";
+    hash = "sha256-c7iBIzDJonJV270OSg66UH/d0X49YFyjUVYMHcyoW8s=";
+  };
+in
+buildPythonPackage (finalAttrs: {
+  pname = "mcap";
+  inherit version;
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "mcap";
+    inherit version;
+    hash = "sha256-BSji+Gphv+xzd54GKObPJ6+D0B2J4gsn1eyfC1VqY6w=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    lz4
+    zstandard
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # these tests read the git-lfs fixtures; passthru.tests.full runs them
+  disabledTestPaths = [
+    "tests/test_read_crc_validation.py"
+    "tests/test_reader.py"
+  ];
+
+  pythonImportsCheck = [ "mcap" ];
+
+  passthru.tests = {
+    # the whole suite, with the fixtures placed where the tests expect them
+    # relative to their monorepo home at python/mcap/tests
+    full = finalAttrs.finalPackage.overrideAttrs (old: {
+      disabledTestPaths = [ ];
+      preCheck = ''
+        mkdir -p python/mcap
+        mv tests python/mcap/tests
+        mkdir -p testdata/mcap tests/conformance/data/OneMessage
+        cp ${demo-mcap} testdata/mcap/demo.mcap
+        cp ${one-message-mcap} tests/conformance/data/OneMessage/OneMessage.mcap
+      '';
+    });
+  };
+
+  meta = {
+    description = "Python library for reading and writing MCAP log files";
+    homepage = "https://github.com/foxglove/mcap";
+    changelog = "https://github.com/foxglove/mcap/releases/tag/releases%2Fpython%2Fmcap%2Fv${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jfr ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10549,6 +10549,8 @@ self: super: with self; {
 
   mbstrdecoder = callPackage ../development/python-modules/mbstrdecoder { };
 
+  mcap = callPackage ../development/python-modules/mcap { };
+
   mccabe = callPackage ../development/python-modules/mccabe { };
 
   mcdreforged = callPackage ../development/python-modules/mcdreforged { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10551,6 +10551,8 @@ self: super: with self; {
 
   mcap = callPackage ../development/python-modules/mcap { };
 
+  mcap-protobuf-support = callPackage ../development/python-modules/mcap-protobuf-support { };
+
   mccabe = callPackage ../development/python-modules/mccabe { };
 
   mcdreforged = callPackage ../development/python-modules/mcdreforged { };


### PR DESCRIPTION
Added `mcap` and `mcap_protobuf` python packages, which I use often. Ignoring the ROS1 and ROS2 encoders. Some of the tests for `mcap` use data in git-lfs, they are disabled in the package check and enabled in the `passthru.tests.full` package. `mcap_protobuf` has no such restrictions, so all the tests run.

Complements the existing `mcap-cli` package from FoxGlove.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
