### PR TITLE
[Backport release-26.05] unrar: 7.2.6 -> 7.2.7, fix CVE-2026-14191

### DIFF
--- a/pkgs/by-name/un/unrar/package.nix
+++ b/pkgs/by-name/un/unrar/package.nix
@@ -6,12 +6,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "unrar";
-  version = "7.2.6";
+  version = "7.2.7";
 
   src = fetchzip {
     url = "https://www.rarlab.com/rar/unrarsrc-${finalAttrs.version}.tar.gz";
     stripRoot = false;
-    hash = "sha256-rYW8ytF/eyhlgmQugbPXSyaQOPu+UmP6A6xmKh80iuE=";
+    hash = "sha256-X0MOIbsIL5iczClCLSj8UX0ofLHBu1Asap4EKKbLVnw=";
   };
 
   sourceRoot = finalAttrs.src.name;


### PR DESCRIPTION
Manual backport of #537042 to `release-26.05`.

unrar 7.2.6 on stable is the WinRAR 7.21 code base (`version.hpp`); 7.2.7 is 7.23, which per the [upstream changelog](https://www.rarlab.com/rarnew.htm) carries two security fixes:

- [CVE-2026-14191](https://www.cve.org/CVERecord?id=CVE-2026-14191) (High 7.8): out-of-bounds heap write in the RAR5 recovery-volume parser (`RecVolumes5::ReadHeader`, `recvol5.cpp`), triggered by test, repair or auto-recovery on a crafted `.rev` set. The CVE record lists UnRAR <= 7.21 in WinRAR versioning, i.e. the 7.2.6 on stable.
- A symbolic link pointing outside the destination folder could be created even without `-ola` (`extinfo.cpp`).

The rest of the source diff: the `-iver` output fix (`cmdmix.cpp`), the version bump, and a libunrar API change in `dll.cpp`/`dll.hpp` (`RAR_DLL_VERSION` 9 -> 10, new `ROADOF_SHARED` flag, shared open no longer the default). The latter should only change Windows file-sharing semantics.

unrar is run on untrusted downloads by sabnzbd, nzbget, calibre, ark and others. Related: sabnzbd backport #560393.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests): `nixosTests.sabnzbd` passes on this branch (`NIXPKGS_ALLOW_UNFREE=1`); note it only checks service start and HTTP, not unrar itself.
  - [x] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests): `python3Packages.rarfile` test suite with `useUnrar = true` against 7.2.7, 148 passed; `python3Packages.python-unrar` against 7.2.7, 39 passed.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

**Automation/AI disclosure:** the commit is an unmodified cherry-pick from master except for the commit message. The backport reason in the commit message, this PR's description and title, the source diff review and the test runs were produced with Claude Code (Claude Fable 5.1) and reviewed by me (including verifying the unrar diff conclusions, the CVE, the rar release notes, and re-running the tests myself).

