### PR TITLE
zcode: init at 3.11.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2574,6 +2574,12 @@
     githubId = 91414737;
     keys = [ { fingerprint = "C5C8 4658 CCFD 7E8E 71DE  E933 AF3A E54F C3A3 5C9F"; } ];
   };
+  asgpipo = {
+    name = "ASGPIPO";
+    email = "kuandepuqian@protonmail.com";
+    github = "ASGPIPO";
+    githubId = 146902144;
+  };
   ashalkhakov = {
     email = "artyom.shalkhakov@gmail.com";
     github = "ashalkhakov";

--- a/pkgs/by-name/zc/zcode/package.nix
+++ b/pkgs/by-name/zc/zcode/package.nix
@@ -1,0 +1,137 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  makeShellWrapper,
+  wrapGAppsHook3,
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libGL,
+  libdrm,
+  libgbm,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  libxkbcommon,
+  libxshmfence,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  systemd,
+}:
+
+let
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://cdn-zcode.z.ai/zcode/electron/releases/3.11.2/linux-x64/ZCode-3.11.2-linux-x64.deb";
+      hash = "sha256-fRO4OGMTAs9h4bgEDLZ/NJ7CNWZ5WJfxdGQyxcXXfVs=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://cdn-zcode.z.ai/zcode/electron/releases/3.11.2/linux-arm64/ZCode-3.11.2-linux-arm64.deb";
+      hash = "sha256-3jFIe5eq3hNlvb8cOhYkM2zRY9uJlkFqT4lG9JHu7bA=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zcode";
+  version = "3.11.2";
+
+  src =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeShellWrapper
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    gdk-pixbuf
+    glib
+    gtk3
+    libGL
+    libdrm
+    libgbm
+    libx11
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    libxkbcommon
+    libxshmfence
+    mesa
+    nspr
+    nss
+    pango
+    systemd
+  ];
+
+  # deb 内 chrome-sandbox 是 setuid 二进制，dpkg -x 会因权限失败，
+  # 对齐 feishu 包：--fsys-tarfile 走 tar 解（对齐 nixpkgs feishu 包）
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt/ZCode $out/bin
+    dpkg --fsys-tarfile $src | tar --extract -C .
+    cp -r opt/ZCode/. $out/opt/ZCode/
+
+    # 主二进制：Wayland/X11 自适应 + 关闭 setuid sandbox（NixOS 无 SUID 环境）
+    makeShellWrapper $out/opt/ZCode/zcode $out/bin/zcode \
+      "''${gappsWrapperArgs[@]}" \
+      --add-flags "--ozone-platform-hint=auto" \
+      --add-flags "--no-sandbox"
+
+    # 桌面入口 + 图标
+    mkdir -p $out/share/applications $out/share/icons/hicolor
+    cp usr/share/applications/zcode.desktop $out/share/applications/
+    substituteInPlace $out/share/applications/zcode.desktop \
+      --replace-fail /opt/ZCode/zcode zcode
+    cp -r usr/share/icons/hicolor/. $out/share/icons/hicolor/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Z.AI ZCode, official harness for GLM coding";
+    homepage = "https://zcode.z.ai";
+    downloadPage = "https://zcode.z.ai/en#all-downloads";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ asgpipo ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "zcode";
+  };
+})


### PR DESCRIPTION
###### Description of changes

Adds [ZCode](https://zcode.z.ai), Z.AI's official desktop harness for GLM coding models. Upstream ships prebuilt Electron binaries only (deb/rpm/AppImage on the [download page](https://zcode.z.ai/en#all-downloads)), so this packages the official deb with autoPatchelf, following the same pattern as `feishu` and `hakuneko`:

- `dpkg --fsys-tarfile | tar` unpack (deb contains a setuid chrome-sandbox)
- `makeShellWrapper` + `gappsWrapperArgs`, adds `--ozone-platform-hint=auto --no-sandbox` (no SUID sandbox env on NixOS)
- desktop entry rewritten to `zcode`, hicolor icons installed
- both `x86_64-linux` and `aarch64-linux` from official CDN debs

<!-- remove `maintainers: add asgpipo` commit concern -->
Also adds `asgpipo` to the maintainer list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux platforms that are statically linked, does the package work there too? (n/a)
- [x] Tested basic functionality: app launches, host process and UI work (tested locally on NixOS + niri/Wayland)
- [ ] Tests are included or not necessary (no test suite for a binary distribution)
- [x] Tested that the package builds via `nix-build -A zcode`
- [ ] Tested execution of all binary artifacts
- [ ] Determinism: sources are version-pinned official CDN debs with fixed SRI hashes
- [x] Added a release notes entry if required — not required (new package)