### PR TITLE
[Backport release-26.05] sabnzbd: 5.0.4 -> 5.1.2, python3Packages.rarfile: 4.2 -> 4.5, security fixes

### DIFF
--- a/pkgs/by-name/sa/sabnzbd/package.nix
+++ b/pkgs/by-name/sa/sabnzbd/package.nix
@@ -15,8 +15,8 @@
 }:
 
 let
-  sabctoolsVersion = "9.4.0";
-  sabctoolsHash = "sha256-JkRRtZnzp83dMKXiuqOXaTm8UOpkkhmjH2ysS8TY0DI=";
+  sabctoolsVersion = "9.6.3";
+  sabctoolsHash = "sha256-+qzSDV7JER45yBMmyh5Jor4rJLlcE8KPguPnrBmMkSk=";
 
   pythonEnv = python3.withPackages (
     ps: with ps; [
@@ -73,14 +73,14 @@ let
   ];
 in
 stdenv.mkDerivation rec {
-  version = "5.0.4";
+  version = "5.1.2";
   pname = "sabnzbd";
 
   src = fetchFromGitHub {
     owner = "sabnzbd";
     repo = "sabnzbd";
     rev = version;
-    hash = "sha256-Fi42ctRVNv3fJwNF/5CW/EJjdrjgotJS5sD2jHoc7/I=";
+    hash = "sha256-7U9SbvA3AGQmx99ayiBrPxx4HrCpKCSc6Qz/zpPFd0E=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/sa/sabnzbd/package.nix
+++ b/pkgs/by-name/sa/sabnzbd/package.nix
@@ -31,6 +31,7 @@ let
       cryptography
       feedparser
       guessit
+      hachoir
       jaraco-classes
       jaraco-collections
       jaraco-context

--- a/pkgs/development/python-modules/rarfile/default.nix
+++ b/pkgs/development/python-modules/rarfile/default.nix
@@ -15,14 +15,14 @@ assert !useUnrar -> libarchive != null;
 
 buildPythonPackage rec {
   pname = "rarfile";
-  version = "4.2";
+  version = "4.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "markokr";
     repo = "rarfile";
     tag = "v${version}";
-    hash = "sha256-ZiwD2LG25fMd4Z+QWsh/x3ceG5QRBH4s/TZDwMnfpNI=";
+    hash = "sha256-QhNzpNKOuBF/QEQ9XBXwKudcq4VqJyN/0chT+9uCcKg=";
   };
 
   prePatch = ''


### PR DESCRIPTION
Manual backport of #542486, #554059 and #557504 to `release-26.05`.

sabnzbd 5.0.4 is affected by four advisories fixed in 5.1.x. Overview: https://sabnzbd.org/wiki/extra/5.1-vulnerabilities.html and https://github.com/sabnzbd/sabnzbd/releases/tag/5.1.2

- https://github.com/sabnzbd/sabnzbd/security/advisories/GHSA-xrfq-jhgh-wqch (Critical 9.4): authentication bypass via the logout endpoint. Fixed in 5.1.1.
- https://github.com/sabnzbd/sabnzbd/security/advisories/GHSA-rgqj-28c2-gxwp (Critical 9.8): unauthenticated config takeover, RCE. The advisory confirms 5.1.1; `check_apikey()` in `interface.py` is byte-identical in 5.0.4, so stable is likely affected.
- https://github.com/sabnzbd/sabnzbd/security/advisories/GHSA-75g3-96fr-7p2r (High 7.5): PAR2 path traversal, RCE. Affected >= 3.1.0. I would rank this higher than the rating implies. From the wiki: "**Unlike the other two, this does not involve the web interface** — it is reachable through normal downloading of untrusted content."
- https://github.com/sabnzbd/sabnzbd/security/advisories/GHSA-hxwh-mmrg-p8f5 (Low): arbitrary file deletion via the orphan-job API.

Changelog: https://github.com/sabnzbd/sabnzbd/compare/5.0.4...5.1.2 and https://github.com/sabnzbd/sabnzbd/releases/tag/5.1.2

`python3Packages.rarfile` 4.2 -> 4.5 is required: 5.1.2 calls `rarfile.rar5_s2k` at import and fails to start with 4.2. rarfile 4.3 to 4.5 also fix two High advisories, https://github.com/markokr/rarfile/security/advisories/GHSA-v5rw-pq35-5xw4 and https://github.com/markokr/rarfile/security/advisories/GHSA-94vx-95fq-wwvp. 13 direct consumers on stable, all small Python packages.

`unblob`'s test failure is pre-existing on unmodified `release-26.05`.

Related: unrar backport #560373.

Tested sabnzbd using the module end to end, including the unrar backport.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests): `nixosTests.sabnzbd` passes on this branch, also on plain `release-26.05` and `master`; fails without the rarfile commit as described above.
  - [x] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests` (same test). Built rarfile consumers on this branch: comicapi, subliminal, ratarmountcore, ratarmount, beets, calibre-web, shelfmark, crosspatch, packj; flexget and komikku not built.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

Automation/AI disclosure: the commits are unmodified cherry-picks from master. The backport reason in the rarfile commit message, this descriptions draft and the test runs were produced with Claude Code (Claude Fable 5.1) and reviewed by me. I added the RCE severity caveat in particular.
