### PR TITLE
libmatroska: 1.7.1 -> 1.7.2

### DIFF
--- a/pkgs/by-name/li/libmatroska/package.nix
+++ b/pkgs/by-name/li/libmatroska/package.nix
@@ -2,19 +2,17 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   libebml,
   nix-update-script,
   pkg-config,
   testers,
   validatePkgConfig,
-  libmatroska,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libmatroska";
-  version = "1.7.1";
+  version = "1.7.2";
 
   outputs = [
     "dev"
@@ -25,16 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Matroska-Org";
     repo = "libmatroska";
     rev = "release-${finalAttrs.version}";
-    hash = "sha256-hfu3Q1lIyMlWFWUM2Pu70Hie0rlQmua7Kq8kSIWnfHE=";
+    hash = "sha256-FedoJxUsRgKQn41PZGBaeF0O29PVQEOK20LsNMK3xHo=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "libmatroska-fix-cmake-4.patch";
-      url = "https://github.com/Matroska-Org/libmatroska/commit/dc80e194e93e6f0e25c8ad3e015d83aca2a99e10.patch";
-      hash = "sha256-2dKRJ6z5rOrLJ5agvXQ6k8TPi5rTMA3H1wCO2F5tBbc=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -47,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [ "-DBUILD_SHARED_LIBS=YES" ];
 
   passthru = {
-    tests.pkg-config = testers.hasPkgConfigModules { package = libmatroska; };
+    tests.pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"


### PR DESCRIPTION
changelog: https://github.com/Matroska-Org/libmatroska/blob/release-1.7.2/NEWS.md
diff: https://github.com/Matroska-Org/libmatroska/compare/release-1.7.1...release-1.7.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 560418`
Commit: `285bce17fd6df53f563f3e65562baf960c6ff03b`

### `x86_64-linux`
<details>
  <summary>:x: 6 packages failed to build:</summary>
  <ul>
    <li>gerbera</li> (https://hydra.nixos.org/build/343485830)
    <li>obs-studio-plugins.obs-dvd-screensaver</li> (https://hydra.nixos.org/build/344809615)
    <li>obs-studio-plugins.obs-move-transition</li> (https://hydra.nixos.org/build/344809643)
    <li>obs-studio-plugins.obs-replay-source</li> (https://hydra.nixos.org/build/344809637)
    <li>obs-studio-plugins.obs-shaderfilter</li> (https://hydra.nixos.org/build/344809652)
    <li>obs-studio-plugins.obs-source-switcher</li> (https://hydra.nixos.org/build/344809653)
  </ul>
</details>
<details>
  <summary>:white_check_mark: 92 packages built:</summary>
  <ul>
    <li>arcan</li>
    <li>arcan-all-wrapped</li>
    <li>arcan-wrapped</li>
    <li>av1an</li>
    <li>cantata</li>
    <li>castero</li>
    <li>cat9-wrapped</li>
    <li>ctune</li>
    <li>durden-wrapped</li>
    <li>eaglemode</li>
    <li>fastflix</li>
    <li>flexget</li>
    <li>gemrb</li>
    <li>gopro-tool</li>
    <li>kdePackages.elisa</li>
    <li>kdePackages.kasts</li>
    <li>kdePackages.phonon-vlc</li>
    <li>kphotoalbum</li>
    <li>libmatroska</li>
    <li>libvlc</li>
    <li>libvlcpp</li>
    <li>megaglest</li>
    <li>mfaomp</li>
    <li>mkvtoolnix</li>
    <li>mkvtoolnix-cli</li>
    <li>mpvScripts.autosub</li>
    <li>mpvScripts.convert</li>
    <li>obs-studio</li>
    <li>obs-studio-plugins.advanced-scene-switcher</li>
    <li>obs-studio-plugins.distroav</li>
    <li>obs-studio-plugins.droidcam-obs</li>
    <li>obs-studio-plugins.input-overlay</li>
    <li>obs-studio-plugins.looking-glass-obs</li>
    <li>obs-studio-plugins.obs-3d-effect</li>
    <li>obs-studio-plugins.obs-advanced-masks</li>
    <li>obs-studio-plugins.obs-aitum-multistream</li>
    <li>obs-studio-plugins.obs-backgroundremoval</li>
    <li>obs-studio-plugins.obs-browser-transition</li>
    <li>obs-studio-plugins.obs-color-monitor</li>
    <li>obs-studio-plugins.obs-command-source</li>
    <li>obs-studio-plugins.obs-composite-blur</li>
    <li>obs-studio-plugins.obs-dir-watch-media</li>
    <li>obs-studio-plugins.obs-freeze-filter</li>
    <li>obs-studio-plugins.obs-gradient-source</li>
    <li>obs-studio-plugins.obs-gstreamer</li>
    <li>obs-studio-plugins.obs-hyperion</li>
    <li>obs-studio-plugins.obs-livesplit-one</li>
    <li>obs-studio-plugins.obs-markdown</li>
    <li>obs-studio-plugins.obs-media-controls</li>
    <li>obs-studio-plugins.obs-multi-rtmp</li>
    <li>obs-studio-plugins.obs-mute-filter</li>
    <li>obs-studio-plugins.obs-noise</li>
    <li>obs-studio-plugins.obs-pipewire-audio-capture</li>
    <li>obs-studio-plugins.obs-plugin-countdown</li>
    <li>obs-studio-plugins.obs-recursion-effect</li>
    <li>obs-studio-plugins.obs-retro-effects</li>
    <li>obs-studio-plugins.obs-rgb-levels</li>
    <li>obs-studio-plugins.obs-scale-to-sound</li>
    <li>obs-studio-plugins.obs-scene-as-transition</li>
    <li>obs-studio-plugins.obs-source-clone</li>
    <li>obs-studio-plugins.obs-source-record</li>
    <li>obs-studio-plugins.obs-stroke-glow-shadow</li>
    <li>obs-studio-plugins.obs-teleport</li>
    <li>obs-studio-plugins.obs-text-pthread</li>
    <li>obs-studio-plugins.obs-transition-table</li>
    <li>obs-studio-plugins.obs-tuna</li>
    <li>obs-studio-plugins.obs-vaapi</li>
    <li>obs-studio-plugins.obs-vertical-canvas</li>
    <li>obs-studio-plugins.obs-vintage-filter</li>
    <li>obs-studio-plugins.obs-vkcapture</li>
    <li>obs-studio-plugins.obs-vnc</li>
    <li>obs-studio-plugins.obs-wayland-hotkeys</li>
    <li>obs-studio-plugins.obs-websocket</li>
    <li>obs-studio-plugins.pixel-art</li>
    <li>obs-studio-plugins.waveform</li>
    <li>obs-studio-plugins.wlrobs</li>
    <li>pipeworld-wrapped</li>
    <li>prio-wrapped</li>
    <li>pympress</li>
    <li>python313Packages.knowit</li>
    <li>python313Packages.python-vlc</li>
    <li>python313Packages.subliminal</li>
    <li>python314Packages.knowit</li>
    <li>python314Packages.python-vlc</li>
    <li>python314Packages.subliminal</li>
    <li>reaper</li>
    <li>tdarr</li>
    <li>tdarr-node</li>
    <li>tdarr-server</li>
    <li>vlc</li>
    <li>vlc-bittorrent</li>
    <li>xarcan</li>
  </ul>
</details>

<details>
<summary>Error logs: `x86_64-linux`</summary>
<details>
<summary>gerbera</summary>
<pre>      |             ^~~~~~~~~
In file included from /build/source/src/util/logger.h:43,
                 from /build/source/src/config/result/edit_helper.h:30,
                 from /build/source/src/config/result/autoscan.h:39,
                 from /build/source/src/config/config_definition.cc:31:
/build/source/src/util/thread_runner.h: In member function &#x27;void ThreadRunner&lt;Condition, Mutex&gt;::startThread()&#x27;:
/build/source/src/util/thread_runner.h:194:73: error: &#x27;strerror&#x27; is not a member of &#x27;std&#x27;; did you mean &#x27;perror&#x27;? [8;;https://gcc.gnu.org/onlinedocs/gcc-15.3.0/gcc/C_002b_002b-Dialect-Options.html#index-Wno-template-body-Wtemplate-body8;;]
  194 |             log_error(&quot;Could not start thread {}: {}&quot;, threadName, std::strerror(ret));
      |                                                                         ^~~~~~~~
/build/source/src/util/thread_runner.h:194:13: note: in expansion of macro &#x27;log_error&#x27;
  194 |             log_error(&quot;Could not start thread {}: {}&quot;, threadName, std::strerror(ret));
      |             ^~~~~~~~~
[ 11%] Building CXX object CMakeFiles/libgerbera.dir/src/config/result/directory_tweak.cc.o
[ 11%] Building CXX object CMakeFiles/libgerbera.dir/src/config/result/dynamic_content.cc.o
make[2]: *** [CMakeFiles/libgerbera.dir/build.make:191: CMakeFiles/libgerbera.dir/src/config/config_manager.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/libgerbera.dir/build.make:261: CMakeFiles/libgerbera.dir/src/config/result/autoscan.cc.o] Error 1
make[2]: *** [CMakeFiles/libgerbera.dir/build.make:163: CMakeFiles/libgerbera.dir/src/config/config_definition.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:90: CMakeFiles/libgerbera.dir/all] Error 2
make: *** [Makefile:156: all] Error 2</pre>
</details>
<details>
<summary>obs-studio-plugins.obs-dvd-screensaver</summary>
<pre>@nix { &quot;action&quot;: &quot;setPhase&quot;, &quot;phase&quot;: &quot;buildPhase&quot; }
build flags: -j16 SHELL=/nix/store/9ipfvwnqp1q8ijnmi5sxvlx9r8w34lw3-bash-5.3p15/bin/bash
[ 25%] Building C object CMakeFiles/plugin-support.dir/plugin-support.c.o
[ 50%] Linking C static library libplugin-support.a
[ 50%] Built target plugin-support
[ 75%] Building C object CMakeFiles/obs-dvd-screensaver.dir/src/plugin-main.c.o
/build/source/src/plugin-main.c: In function &#x27;dvd_source_properties&#x27;:
/build/source/src/plugin-main.c:417:25: error: &#x27;obs_properties_add_button&#x27; is deprecated [8;;https://gcc.gnu.org/onlinedocs/gcc-15.3.0/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
  417 |                         obs_properties_add_button(props, S_RESET, T_RESET,
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs.h:35,
                 from /nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs-module.h:20,
                 from /build/source/src/plugin-main.c:21:
/nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs-properties.h:217:39: note: declared here
  217 | OBS_DEPRECATED EXPORT obs_property_t *obs_properties_add_button(obs_properties_t *props, const char *name,
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/obs-dvd-screensaver.dir/build.make:79: CMakeFiles/obs-dvd-screensaver.dir/src/plugin-main.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:122: CMakeFiles/obs-dvd-screensaver.dir/all] Error 2
make: *** [Makefile:156: all] Error 2</pre>
</details>
<details>
<summary>obs-studio-plugins.obs-move-transition</summary>
<pre>      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/move-value-filter.c:1788:9: error: &#x27;obs_properties_add_button&#x27; is deprecated [8;;https://gcc.gnu.org/onlinedocs/gcc-15.3.0/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
 1788 |         obs_properties_add_button(settings, &quot;values_get&quot;, obs_module_text(&quot;GetValues&quot;), move_value_get_values);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs-properties.h:217:39: note: declared here
  217 | OBS_DEPRECATED EXPORT obs_property_t *obs_properties_add_button(obs_properties_t *props, const char *name,
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/move-transition.dir/build.make:107: CMakeFiles/move-transition.dir/move-filter.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
cc1: all warnings being treated as errors
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/move-transition.dir/build.make:121: CMakeFiles/move-transition.dir/move-source-filter.c.o] Error 1
make[2]: *** [CMakeFiles/move-transition.dir/build.make:135: CMakeFiles/move-transition.dir/move-source-swap-filter.c.o] Error 1
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/move-transition.dir/build.make:163: CMakeFiles/move-transition.dir/move-action-filter.c.o] Error 1
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/move-transition.dir/build.make:149: CMakeFiles/move-transition.dir/move-value-filter.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/move-transition.dir/all] Error 2
make: *** [Makefile:156: all] Error 2</pre>
</details>
<details>
<summary>obs-studio-plugins.obs-replay-source</summary>
<pre>build flags: -j16 SHELL=/nix/store/9ipfvwnqp1q8ijnmi5sxvlx9r8w34lw3-bash-5.3p15/bin/bash
[ 66%] Building C object CMakeFiles/replay-source.dir/replay-filter.c.o
[ 66%] Building C object CMakeFiles/replay-source.dir/replay-source.c.o
[ 66%] Building C object CMakeFiles/replay-source.dir/replay.c.o
[ 66%] Building C object CMakeFiles/replay-source.dir/replay-filter-async.c.o
[ 83%] Building C object CMakeFiles/replay-source.dir/replay-filter-audio.c.o
/build/source/replay-source.c: In function &#x27;replay_source_properties&#x27;:
/build/source/replay-source.c:3098:9: error: &#x27;obs_properties_add_button&#x27; is deprecated [8;;https://gcc.gnu.org/onlinedocs/gcc-15.3.0/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
 3098 |         obs_properties_add_button(props, &quot;replay_button&quot;, obs_module_text(&quot;LoadReplay&quot;), replay_button);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs.h:35,
                 from /nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs-module.h:20,
                 from /build/source/replay-source.c:1:
/nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs-properties.h:217:39: note: declared here
  217 | OBS_DEPRECATED EXPORT obs_property_t *obs_properties_add_button(obs_properties_t *props, const char *name,
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/replay-source.dir/build.make:93: CMakeFiles/replay-source.dir/replay-source.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/replay-source.dir/all] Error 2
make: *** [Makefile:156: all] Error 2</pre>
</details>
<details>
<summary>obs-studio-plugins.obs-shaderfilter</summary>
<pre>cmake: enabled parallel building
cmake: enabled parallel installing
Running phase: buildPhase
@nix { &quot;action&quot;: &quot;setPhase&quot;, &quot;phase&quot;: &quot;buildPhase&quot; }
build flags: -j16 SHELL=/nix/store/9ipfvwnqp1q8ijnmi5sxvlx9r8w34lw3-bash-5.3p15/bin/bash
[ 50%] Building C object CMakeFiles/obs-shaderfilter.dir/obs-shaderfilter.c.o
/build/source/obs-shaderfilter.c: In function &#x27;shader_filter_properties&#x27;:
/build/source/obs-shaderfilter.c:2218:9: error: &#x27;obs_properties_add_button&#x27; is deprecated [8;;https://gcc.gnu.org/onlinedocs/gcc-15.3.0/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
 2218 |         obs_properties_add_button(props, &quot;reload_effect&quot;, obs_module_text(&quot;ShaderFilter.ReloadEffect&quot;),
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs.h:35,
                 from /nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs-module.h:20,
                 from /build/source/obs-shaderfilter.c:4:
/nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs-properties.h:217:39: note: declared here
  217 | OBS_DEPRECATED EXPORT obs_property_t *obs_properties_add_button(obs_properties_t *props, const char *name,
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/obs-shaderfilter.dir/build.make:79: CMakeFiles/obs-shaderfilter.dir/obs-shaderfilter.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/obs-shaderfilter.dir/all] Error 2
make: *** [Makefile:156: all] Error 2</pre>
</details>
<details>
<summary>obs-studio-plugins.obs-source-switcher</summary>
<pre>                 from /build/source/source-switcher.c:1:
/nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs-properties.h:217:39: note: declared here
  217 | OBS_DEPRECATED EXPORT obs_property_t *obs_properties_add_button(obs_properties_t *props, const char *name,
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/source-switcher.c:939:9: error: &#x27;obs_properties_add_button&#x27; is deprecated [8;;https://gcc.gnu.org/onlinedocs/gcc-15.3.0/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
  939 |         obs_properties_add_button(transition_group, S_SHOW_TRANSITION_PROPERTIES, obs_module_text(&quot;Properties&quot;),
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs-properties.h:217:39: note: declared here
  217 | OBS_DEPRECATED EXPORT obs_property_t *obs_properties_add_button(obs_properties_t *props, const char *name,
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
/build/source/source-switcher.c:946:9: error: &#x27;obs_properties_add_button&#x27; is deprecated [8;;https://gcc.gnu.org/onlinedocs/gcc-15.3.0/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
  946 |         obs_properties_add_button(transition_group, S_HIDE_TRANSITION_PROPERTIES, obs_module_text(&quot;Properties&quot;),
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/ld9fqhj030bxrp40mxrbz52nn7pai287-obs-studio-32.2.2/include/obs/obs-properties.h:217:39: note: declared here
  217 | OBS_DEPRECATED EXPORT obs_property_t *obs_properties_add_button(obs_properties_t *props, const char *name,
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/source-switcher.dir/build.make:79: CMakeFiles/source-switcher.dir/source-switcher.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/source-switcher.dir/all] Error 2
make: *** [Makefile:156: all] Error 2</pre>
</details>
</details>

all failures are preexisting, added links to the hydra logs with each failing one
