### PR TITLE
dwl: refactor and adopt

### DIFF
--- a/pkgs/by-name/dw/dwl/package.nix
+++ b/pkgs/by-name/dw/dwl/package.nix
@@ -1,55 +1,61 @@
 {
   lib,
   fetchFromCodeberg,
-  installShellFiles,
-  libx11,
   libinput,
+  libx11,
   libxcb,
+  libxcb-wm,
   libxkbcommon,
+  nix-update-script,
+  nixosTests,
   pixman,
   pkg-config,
   stdenv,
-  testers,
-  nixosTests,
+  versionCheckHook,
   wayland,
   wayland-protocols,
   wayland-scanner,
   wlroots_0_19,
   writeText,
-  libxcb-wm,
   xwayland,
   # Boolean flags
   enableXWayland ? true,
-  withCustomConfigH ? (configH != null),
   # Configurable options
-  configH ?
-    if conf != null then
-      lib.warn ''
-        conf parameter is deprecated;
-        use configH instead
-      '' conf
-    else
-      null,
-  # Deprecated options
-  # Remove them before next version of either Nixpkgs or dwl itself
-  conf ? null,
+  configH ? null,
 }:
 
-# If we set withCustomConfigH, let's not forget configH
-assert withCustomConfigH -> (configH != null);
 stdenv.mkDerivation (finalAttrs: {
   pname = "dwl";
   version = "0.8";
 
+  strictDeps = true;
+
+  # required for whitespaces in makeFlags
+  __structuredAttrs = true;
+
   src = fetchFromCodeberg {
     owner = "dwl";
     repo = "dwl";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-J76L5ZOCYgfcY08wH5cSLG+UdgDrv50lQyEnJNqDkXI=";
   };
 
+  postPatch =
+    let
+      configFile =
+        if lib.isDerivation configH || builtins.isPath configH then
+          configH
+        else
+          writeText "config.h" configH;
+    in
+    lib.optionalString (configH != null) "cp ${configFile} config.h";
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
   nativeBuildInputs = [
-    installShellFiles
     pkg-config
     wayland-scanner
   ];
@@ -69,21 +75,6 @@ stdenv.mkDerivation (finalAttrs: {
     xwayland
   ];
 
-  outputs = [
-    "out"
-    "man"
-  ];
-
-  postPatch =
-    let
-      configFile =
-        if lib.isDerivation configH || builtins.isPath configH then
-          configH
-        else
-          writeText "config.h" configH;
-    in
-    lib.optionalString withCustomConfigH "cp ${configFile} config.h";
-
   makeFlags = [
     "PKG_CONFIG=${stdenv.cc.targetPrefix}pkg-config"
     "WAYLAND_SCANNER=wayland-scanner"
@@ -95,25 +86,21 @@ stdenv.mkDerivation (finalAttrs: {
     ''XLIBS="xcb xcb-icccm"''
   ];
 
-  strictDeps = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
-  # required for whitespaces in makeFlags
-  __structuredAttrs = true;
+  doInstallCheck = true;
+
+  # `dwl -v` emits its version string to stderr and returns 1
+  versionCheckProgramArg = "-v";
 
   passthru = {
-    tests = {
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        # `dwl -v` emits its version string to stderr and returns 1
-        command = "dwl -v 2>&1; return 0";
-      };
-      basic = nixosTests.dwl;
-    };
+    tests.basic = nixosTests.dwl;
+    updateScript = nix-update-script { };
   };
 
   meta = {
     homepage = "https://codeberg.org/dwl/dwl";
-    changelog = "https://codeberg.org/dwl/dwl/src/branch/${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://codeberg.org/dwl/dwl/src/tag/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Dynamic window manager for Wayland";
     longDescription = ''
       dwl is a compact, hackable compositor for Wayland based on wlroots. It is

--- a/pkgs/by-name/dw/dwl/package.nix
+++ b/pkgs/by-name/dw/dwl/package.nix
@@ -113,7 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
       - Tied to as few external dependencies as possible
     '';
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
     inherit (wayland.meta) platforms;
     mainProgram = "dwl";
   };


### PR DESCRIPTION
There's a comment about the deprecated option, which is due to be removed when any of nixpkgs/dwl is bumped, which is overdue.

Also some modernization touches, attrs order shuffling, and adoption by me. ^-^
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
