### PR TITLE
moonshine: modernize package

### DIFF
--- a/nixos/modules/services/networking/moonshine.nix
+++ b/nixos/modules/services/networking/moonshine.nix
@@ -7,13 +7,30 @@
 
 let
   cfg = config.services.moonshine;
-  tomlFormat = pkgs.formats.toml { };
-  configFile = tomlFormat.generate "moonshine-config.toml" cfg.settings;
+  settingsFormat = pkgs.formats.toml { };
+  configFile = settingsFormat.generate "moonshine-config.toml" cfg.settings;
+  runtimeDir = "/run/user/${toString cfg.uid}";
 
-  runScript = pkgs.writeShellScriptBin "moonshine-server" ''
-    export XDG_RUNTIME_DIR="''${XDG_RUNTIME_DIR:-/run/user/$(${lib.getExe' pkgs.coreutils "id"} -u)}"
-    export DBUS_SESSION_BUS_ADDRESS="''${DBUS_SESSION_BUS_ADDRESS:-unix:path=$XDG_RUNTIME_DIR/bus}"
-    exec ${lib.getExe cfg.package} ${configFile} "$@"
+  ports = {
+    tcp = [
+      (cfg.settings.webserver.port_https or 47984)
+      (cfg.settings.webserver.port or 47989)
+      (cfg.settings.stream.port or 48010)
+    ];
+    udp = [
+      5353 # mDNS
+      (cfg.settings.stream.video.port or 47998)
+      (cfg.settings.stream.control.port or 47999)
+      (cfg.settings.stream.audio.port or 48000)
+    ];
+  };
+
+  # Only the manifest belongs in the graphics driver path. It refers to the
+  # layer library in cfg.package by its absolute store path.
+  wsiLayer = pkgs.runCommand "moonshine-wsi-layer" { } ''
+    install -Dm644 \
+      ${cfg.package}/share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json \
+      $out/share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json
   '';
 in
 {
@@ -26,77 +43,57 @@ in
       type = lib.types.nonEmptyStr;
       example = "alice";
       description = ''
-        User under which to run Moonshine. The user must be declared separately
-        in {option}`users.users`. Lingering is enabled automatically so the
-        server can run without an active login session.
+        User under which to run Moonshine. The user must be declared in
+        {option}`users.users`. Lingering is enabled automatically.
+      '';
+    };
+
+    uid = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.unsigned;
+      default = config.users.users.${cfg.user}.uid or null;
+      defaultText = lib.literalExpression "config.users.users.<name>.uid";
+      example = 1000;
+      description = ''
+        Numeric uid of {option}`services.moonshine.user`. This is used for the
+        runtime directory and user systemd instance. Set it explicitly when
+        the user's uid is not declared in the NixOS configuration.
       '';
     };
 
     settings = lib.mkOption {
-      type = tomlFormat.type;
+      inherit (settingsFormat) type;
       default = { };
       example = lib.literalExpression ''
         {
           name = "my-desktop";
-          address = "0.0.0.0";
           application = [
             {
               title = "Steam";
-              command = [ "steam" "steam://open/bigpicture" ];
-            }
-          ];
-          application_scanner = [
-            {
-              type = "steam";
-              library = "$HOME/.local/share/Steam";
-              command = [ "steam" "-bigpicture" "steam://rungameid/{game_id}" ];
+              command = [ "/run/current-system/sw/bin/steam" "steam://open/bigpicture" ];
             }
           ];
         }
       '';
       description = ''
         Moonshine configuration, generated as a TOML file in the Nix store.
-        See <https://github.com/hgaiser/moonshine/blob/main/moonshine-core/src/config.rs>
-        for the available settings and <https://github.com/hgaiser/moonshine#configuration> for some examples.
-
-        Do not leave this option empty: Moonshine's upstream defaults configure
-        Steam at {file}`/usr/bin/steam`, which does not exist on NixOS. Define
-        at least `application` with an executable in the Nix store, as shown in
-        the example. Setting `application` explicitly is sufficient;
-        `application_scanners` may be omitted.
-
-        Moonshine stores {file}`cert.pem` and {file}`key.pem` in
-        {file}`~/.config/moonshine/`, and paired-client state in
-        {file}`~/.local/share/moonshine/state.toml` for the configured user.
-
-        Since the service runs without a desktop session, its notification
-        action cannot reliably open the pairing page. Pair clients by visiting
-        {file}`http://<host>:47989/pin` in a browser instead.
+        See <https://github.com/hgaiser/moonshine#configuration> for available
+        settings. Upstream's default application uses `/usr/bin/steam`, so an
+        application with a NixOS executable path should normally be specified.
       '';
     };
 
-    extraPackages = lib.mkOption {
-      type = lib.types.listOf lib.types.package;
-      default = [ ];
-      example = lib.literalExpression "[ pkgs.steam ]";
-      description = ''
-        Packages added to the service's {env}`PATH` for applications launched
-        by Moonshine.
-      '';
+    logFilter = lib.mkOption {
+      type = lib.types.str;
+      default = "moonshine=info";
+      description = "Value of the `MOONSHINE_LOG` tracing filter.";
     };
 
-    environment = lib.mkOption {
-      type = lib.types.attrsOf lib.types.str;
-      default = { };
-      example = {
-        MESA_VK_DEVICE_SELECT = "10de:25a2!";
-      };
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
       description = ''
-        Environment variables set for Moonshine.
-
-        ::: {.note}
-        Those are not inherited by launched applications.
-        :::
+        Open the configured GameStream ports on all interfaces. Moonshine is
+        not designed for public networks; expose it only on a LAN or VPN.
       '';
     };
 
@@ -108,9 +105,25 @@ in
         "wg0"
       ];
       description = ''
-        Network interfaces on which to open the Moonlight/GameStream ports.
-        The ports are not opened when this list is empty.
-        Moonshine is not designed for use on public networks. Do not expose Moonshine ports directly to the internet. See https://github.com/hgaiser/moonshine#security
+        Interfaces on which to open the configured GameStream ports. This is
+        a narrower alternative to {option}`services.moonshine.openFirewall`.
+      '';
+    };
+
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression "[ pkgs.steam ]";
+      description = "Packages added to the Moonshine service's executable search path.";
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example.MESA_VK_DEVICE_SELECT = "10de:25a2!";
+      description = ''
+        Environment variables for the Moonshine daemon. These are not
+        inherited by applications launched through the user's systemd instance.
       '';
     };
   };
@@ -118,8 +131,17 @@ in
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = lib.hasAttr cfg.user config.users.users;
-        message = "services.moonshine.user refers to undeclared user '${cfg.user}'.";
+        assertion =
+          config.users.users.${cfg.user}.isNormalUser || config.users.users.${cfg.user}.isSystemUser;
+        message = "services.moonshine.user must refer to a declared normal or system user.";
+      }
+      {
+        assertion = cfg.uid != null;
+        message = ''
+          services.moonshine.uid could not be derived because
+          users.users.${cfg.user}.uid is not set. Set services.moonshine.uid
+          explicitly or declare a fixed uid for the user.
+        '';
       }
     ];
 
@@ -130,51 +152,20 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    # Make the implicit WSI Vulkan layer available to launched applications.
     hardware.graphics = {
       enable = true;
-      extraPackages = [ cfg.package ];
+      extraPackages = [ wsiLayer ];
     };
-
-    networking.firewall.interfaces = lib.genAttrs cfg.firewallInterfaces (_: {
-      allowedTCPPorts = [
-        (cfg.settings.webserver.port_https or 47984)
-        (cfg.settings.webserver.port or 47989)
-        (cfg.settings.stream.port or 48010)
-      ];
-      allowedUDPPorts = [
-        5353 # moonshine has an embedded mDNS responder that does not conflict with avahi
-        (cfg.settings.stream.video.port or 47998)
-        (cfg.settings.stream.control.port or 47999)
-        (cfg.settings.stream.audio.port or 48000)
-      ];
-    });
 
     services.udev.packages = [ cfg.package ];
 
-    systemd.services.moonshine = {
-      description = "Streaming server using the NVIDIA GameStream / Moonlight protocol.";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
-      path = [ pkgs.xwayland ] ++ cfg.extraPackages;
-      environment = {
-        MOONSHINE_LOG = "moonshine=info";
-      }
-      // cfg.environment;
-      serviceConfig = {
-        User = cfg.user;
-        SupplementaryGroups = [ "moonshine" ];
-        ExecStart = lib.getExe runScript;
-        Restart = "on-failure";
-        RestartSec = 5;
-        DeviceAllow = [
-          "/dev/uinput rw"
-          "/dev/uhid rw"
-          "char-drm rw"
-          "char-nvidia rw"
-          "char-nvidia-uvm rw"
-        ];
-      };
+    networking.firewall = {
+      allowedTCPPorts = lib.mkIf cfg.openFirewall ports.tcp;
+      allowedUDPPorts = lib.mkIf cfg.openFirewall ports.udp;
+      interfaces = lib.genAttrs cfg.firewallInterfaces (_: {
+        allowedTCPPorts = ports.tcp;
+        allowedUDPPorts = ports.udp;
+      });
     };
 
     users = {
@@ -184,5 +175,46 @@ in
         extraGroups = [ "input" ];
       };
     };
+
+    systemd.services.moonshine = {
+      description = "Moonshine game streaming server";
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "user@${toString cfg.uid}.service" ];
+      after = [
+        "network.target"
+        "user@${toString cfg.uid}.service"
+      ];
+      path = [ pkgs.xwayland ] ++ cfg.extraPackages;
+      environment = {
+        MOONSHINE_LOG = cfg.logFilter;
+        XDG_RUNTIME_DIR = runtimeDir;
+        DBUS_SESSION_BUS_ADDRESS = "unix:path=${runtimeDir}/bus";
+      }
+      // cfg.environment;
+      serviceConfig = {
+        User = cfg.user;
+        SupplementaryGroups = [
+          "moonshine"
+          "video"
+        ];
+        ExecStart = "${lib.getExe cfg.package} ${configFile}";
+        Restart = "on-failure";
+        RestartSec = 5;
+        DeviceAllow = [
+          "/dev/uinput rw"
+          "/dev/uhid rw"
+          "char-drm rw"
+          "char-nvidia rw"
+          "char-nvidia-uvm rw"
+        ];
+        UMask = "0077";
+      };
+    };
   };
+
+  meta.maintainers = with lib.maintainers; [
+    neobrain
+    anish
+    philocalyst
+  ];
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1110,6 +1110,7 @@ in
   monica = runTest ./web-apps/monica.nix;
   moodle = runTest ./moodle.nix;
   moonraker = runTest ./moonraker.nix;
+  moonshine = runTest ./moonshine.nix;
   moosefs = runTest ./moosefs.nix;
   mopidy = runTest ./mopidy.nix;
   morph-browser = discoverTests (import ./morph-browser.nix);

--- a/nixos/tests/moonshine.nix
+++ b/nixos/tests/moonshine.nix
@@ -1,0 +1,101 @@
+{ lib, ... }:
+
+let
+  tcpPorts = [
+    48084
+    48089
+    48110
+  ];
+  udpPorts = [
+    5353
+    48098
+    48099
+    48100
+  ];
+in
+{
+  name = "moonshine";
+  meta.maintainers = with lib.maintainers; [
+    neobrain
+    anish
+    philocalyst
+  ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    let
+      server = pkgs.writeShellApplication {
+        name = "moonshine";
+        runtimeInputs = [ pkgs.coreutils ];
+        text = ''
+          test "$#" -eq 1
+          test "''${XDG_RUNTIME_DIR-}" = /run/user/1000
+          test "''${DBUS_SESSION_BUS_ADDRESS-}" = unix:path=/run/user/1000/bus
+          test "''${MOONSHINE_LOG-}" = moonshine=debug
+          test "''${MOONSHINE_TEST-}" = present
+          command -v hello
+          grep -F 'title = "Test"' "$1"
+          touch /run/user/1000/moonshine-test-ready
+          exec sleep infinity
+        '';
+      };
+      package = pkgs.symlinkJoin {
+        name = "moonshine-test";
+        paths = [
+          server
+          (pkgs.writeTextDir "share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json" "{}")
+        ];
+        meta.mainProgram = "moonshine";
+      };
+    in
+    {
+      services.moonshine = {
+        enable = true;
+        inherit package;
+        user = "alice";
+        openFirewall = true;
+        firewallInterfaces = [ "eth0" ];
+        logFilter = "moonshine=debug";
+        extraPackages = [ pkgs.hello ];
+        environment.MOONSHINE_TEST = "present";
+        settings = {
+          application = [
+            {
+              title = "Test";
+              command = [ "true" ];
+            }
+          ];
+          webserver = {
+            port = 48089;
+            port_https = 48084;
+          };
+          stream = {
+            port = 48110;
+            video.port = 48098;
+            control.port = 48099;
+            audio.port = 48100;
+          };
+        };
+      };
+
+      users.users.alice = {
+        isNormalUser = true;
+        uid = 1000;
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    assert nodes.machine.networking.firewall.allowedTCPPorts == tcpPorts;
+    assert nodes.machine.networking.firewall.allowedUDPPorts == udpPorts;
+    assert nodes.machine.networking.firewall.interfaces.eth0.allowedTCPPorts == tcpPorts;
+    assert nodes.machine.networking.firewall.interfaces.eth0.allowedUDPPorts == udpPorts;
+    ''
+      start_all()
+      machine.wait_for_unit("moonshine.service")
+      machine.wait_for_file("/run/user/1000/moonshine-test-ready")
+      machine.succeed("loginctl show-user alice -p Linger --value | grep -Fx yes")
+      machine.succeed("systemctl show moonshine -p SupplementaryGroups --value | grep -Fw moonshine")
+      machine.succeed("test -f /run/opengl-driver/share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json")
+    '';
+}

--- a/pkgs/by-name/mo/moonshine/package.nix
+++ b/pkgs/by-name/mo/moonshine/package.nix
@@ -1,16 +1,18 @@
 {
+  addDriverRunpath,
   cmake,
   fetchFromGitHub,
-  pkg-config,
   lib,
+  libdrm,
   libevdev,
   libgbm,
-  libGL,
+  libglvnd,
   libopus,
-  libx11,
+  libpulseaudio,
   libxkbcommon,
-  libxres,
+  nixosTests,
   nix-update-script,
+  pkg-config,
   rustPlatform,
   versionCheckHook,
   vulkan-loader,
@@ -18,8 +20,8 @@
 }:
 
 let
-  # Fetch the C++ sources of inputtino explicitly since the inputtino-sys crate requires them to be present.
-  # Revision matches Cargo.lock
+  # Fetch the C++ sources of inputtino explicitly since the inputtino-sys crate
+  # expects the repository root to be available. The revision matches Cargo.lock.
   inputtino-src = fetchFromGitHub {
     owner = "games-on-whales";
     repo = "inputtino";
@@ -30,6 +32,8 @@ in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "moonshine";
   version = "0.15.0";
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "hgaiser";
@@ -38,79 +42,83 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-TvL3s738wooQwZfBKyCqp0V8qcYFtJL98tsxlSX8fLM=";
   };
 
-  __structuredAttrs = true;
-  strictDeps = true;
-
   cargoHash = "sha256-PAC8PcGOXxFNN8Eeiik4JrXeH2H+YcqRaBpJVtUoZ44=";
 
-  # Build Moonshine binary and Vulkan layer
-  cargoBuildFlags = [
-    "-p"
-    "moonshine"
-    "-p"
-    "moonshine-wsi"
-  ];
+  # Also installs moonshine-bench and builds the WSI layer.
+  cargoBuildFlags = [ "--workspace" ];
 
   nativeBuildInputs = [
-    pkg-config
+    addDriverRunpath
     cmake
+    pkg-config
     rustPlatform.bindgenHook
   ];
+  dontUseCmakeConfigure = true;
 
   buildInputs = [
+    libdrm
     libevdev
     libgbm
+    libglvnd
     libopus
+    libpulseaudio
     libxkbcommon
+    vulkan-loader
     wayland
   ];
 
-  # Patch build.rs from inputtino-sys with the C++ inputtino sources.
-  # Also drop the unneeded libc++ dependency.
-  postPatch = ''
-    grep -q 'inputtino#${inputtino-src.rev}' Cargo.lock || {
-      echo "ERROR: inputtino revision needs update (must match Cargo.lock)"
-      exit 1
-    }
+  # The integration tests exercise Vulkan, uinput, and a running systemd user
+  # manager; those devices and services are deliberately absent in a Nix build sandbox.
+  doCheck = false;
 
-    substituteInPlace $cargoDepsCopy/*/inputtino-sys-*/build.rs \
+  postPatch = ''
+    # Keep the separately fetched C++ tree in lock-step with the git crate.
+    grep -Fq "inputtino#${inputtino-src.rev}" Cargo.lock
+
+    substituteInPlace "$cargoDepsCopy"/*/inputtino-sys-*/build.rs \
       --replace-fail 'PathBuf::from("../../../")' 'PathBuf::from("${inputtino-src}")' \
       --replace-fail 'println!("cargo:rustc-link-lib=c++");' ""
   '';
 
   postInstall = ''
-    # Setup implicit Vulkan layer manifest as required by Moonshine
-    install -d "$out/share/vulkan/implicit_layer.d"
-    substitute dist/VkLayer_moonshine_wsi.json \
-      "$out/share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json" \
+    for artifact in \
+      $out/bin/moonshine \
+      $out/bin/moonshine-bench \
+      $out/lib/libmoonshine_wsi.so
+    do
+      test -f "$artifact"
+    done
+
+    manifest="$out/share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json"
+    install -Dm644 dist/VkLayer_moonshine_wsi.json "$manifest"
+    substituteInPlace "$manifest" \
       --replace-fail /usr/lib/moonshine/vulkan-layers/libmoonshine_wsi.so \
-        "$out/lib/libmoonshine_wsi.so"
+      $out/lib/libmoonshine_wsi.so
 
-    # udev rules for input
-    install -Dm644 dist/60-moonshine.rules "$out/lib/udev/rules.d/60-moonshine.rules"
-
-    # polkit rule for sleep inhibitor
+    install -Dm644 dist/60-moonshine.rules $out/lib/udev/rules.d/60-moonshine.rules
     install -Dm644 dist/50-moonshine-inhibit-sleep.rules \
-      "$out/share/polkit-1/rules.d/50-moonshine-inhibit-sleep.rules"
+      $out/share/polkit-1/rules.d/50-moonshine-inhibit-sleep.rules
   '';
 
   postFixup = ''
-    patchelf --add-rpath ${
-      lib.makeLibraryPath [
-        libGL
-        vulkan-loader
-        # Required by Steam focus protocol (x11_focus.rs)
-        libx11
-        libxres
-      ]
-    } "$out/bin/moonshine"
+    for executable in $out/bin/*; do
+      patchelf --add-rpath ${
+        lib.makeLibraryPath [
+          vulkan-loader
+          libglvnd
+        ]
+      } "$executable"
+      addDriverRunpath "$executable"
+    done
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  # NOTE: If upstream bumps inputtino, this must be manually updated above
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = { inherit (nixosTests) moonshine; };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Headless streaming server for Moonlight clients";
@@ -125,6 +133,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       neobrain
       anish
+      philocalyst
     ];
     mainProgram = "moonshine";
     platforms = lib.platforms.linux;


### PR DESCRIPTION
## Summary

- I modernized the package, so it installs the entire/complete upstream workspace output.
- The module was updated to provide the runtime env Moonshine needs to launch streamed apps through the user's sytemd manager.
- Added some light testing

## Motivation

Moonshine isn't just it's main daemon binary. Its headless compositor relies on an implicit Vulkan WSI layer, dynamically loads the Vulkan and GL dispatch libraries, creates virtual input devices, talks to the user's D-Bus/systemd instance, and optionally inhibits sleep through polkit. It's actually a ton of stuff! Didn't want to leave it all out.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
