### PR TITLE
pronounscc: init at 0-unstable-2026-06-05

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1824,6 +1824,7 @@
   ./services/web-apps/pretalx.nix
   ./services/web-apps/pretix.nix
   ./services/web-apps/privatebin.nix
+  ./services/web-apps/pronounscc.nix
   ./services/web-apps/prosody-filer.nix
   ./services/web-apps/readeck.nix
   ./services/web-apps/remark42.nix

--- a/nixos/modules/services/web-apps/pronounscc.nix
+++ b/nixos/modules/services/web-apps/pronounscc.nix
@@ -1,0 +1,180 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.pronounscc;
+
+  environment = lib.mapAttrs (
+    _: value: if lib.isBool value then lib.boolToString value else toString value
+  ) cfg.settings;
+
+  dependencies = [
+    "postgresql.service"
+    "redis.service"
+  ];
+
+  serviceConfig = {
+    DynamicUser = true;
+    CapabilityBoundingSet = "";
+    NoNewPrivileges = true;
+    PrivateDevices = true;
+    PrivateTmp = true;
+    ProtectHome = true;
+    ProtectSystem = "strict";
+    RestartSec = 2;
+  };
+
+  backendServiceConfig = serviceConfig // {
+    EnvironmentFile = cfg.environmentFiles;
+  };
+in
+{
+  options.services.pronounscc = {
+    enable = lib.mkEnableOption "pronouns.cc";
+
+    package = lib.mkPackageOption pkgs "pronounscc" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType =
+          with lib.types;
+          attrsOf (oneOf [
+            bool
+            int
+            str
+          ]);
+
+        options = {
+          PORT = lib.mkOption {
+            type = lib.types.port;
+            default = 8080;
+            description = "Port on which the API listens.";
+          };
+
+          EXPORTER_PORT = lib.mkOption {
+            type = lib.types.port;
+            default = 9090;
+            description = "Port on which the data exporter listens.";
+          };
+        };
+      };
+      default = { };
+      example = {
+        BASE_URL = "https://pronouns.example.com";
+        DATABASE_URL = "postgresql:///pronounscc?host=/run/postgresql";
+        REDIS = "127.0.0.1:6379";
+        MINIO_ENDPOINT = "s3.example.com";
+        MINIO_BUCKET = "pronounscc";
+      };
+      description = ''
+        Environment variables for pronouns.cc. See
+        <https://codeberg.org/pronounscc/pronouns.cc/src/branch/main/docs/self-hosting.md#backend-keys>.
+      '';
+    };
+
+    environmentFiles = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
+      example = [ "/run/secrets/pronounscc" ];
+      description = "Files containing environment variables, including secrets.";
+    };
+
+    enableFrontend = lib.mkEnableOption "the pronouns.cc frontend" // {
+      default = true;
+    };
+
+    frontendPort = lib.mkOption {
+      type = lib.types.port;
+      default = 3000;
+      description = "Port on which the frontend listens.";
+    };
+
+    enableExporter = lib.mkEnableOption "the pronouns.cc data exporter" // {
+      default = true;
+    };
+
+    enableDatabaseCleaning = lib.mkEnableOption "daily pronouns.cc database cleaning" // {
+      default = true;
+    };
+
+    openFirewall = lib.mkEnableOption "opening the configured TCP ports";
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall (
+      [ cfg.settings.PORT ]
+      ++ lib.optional cfg.enableFrontend cfg.frontendPort
+      ++ lib.optional cfg.enableExporter cfg.settings.EXPORTER_PORT
+    );
+
+    systemd.services = {
+      pronounscc = {
+        description = "pronouns.cc API";
+        after = [ "network-online.target" ] ++ dependencies;
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+        inherit environment;
+
+        serviceConfig = backendServiceConfig // {
+          ExecStartPre = "${lib.getExe cfg.package} database migrate";
+          ExecStart = "${lib.getExe cfg.package} web";
+          Restart = "on-failure";
+        };
+      };
+
+      pronounscc-frontend = lib.mkIf cfg.enableFrontend {
+        description = "pronouns.cc frontend";
+        after = [ "pronounscc.service" ];
+        requires = [ "pronounscc.service" ];
+        wantedBy = [ "multi-user.target" ];
+        environment.PORT = toString cfg.frontendPort;
+
+        serviceConfig = serviceConfig // {
+          ExecStart = lib.getExe' cfg.package "pronounscc-frontend";
+          WorkingDirectory = "${cfg.package}/share/pronounscc/frontend";
+          Restart = "on-failure";
+        };
+      };
+
+      pronounscc-exporter = lib.mkIf cfg.enableExporter {
+        description = "pronouns.cc data exporter";
+        after = [ "network-online.target" ] ++ dependencies;
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+        inherit environment;
+
+        serviceConfig = backendServiceConfig // {
+          ExecStart = "${lib.getExe cfg.package} exporter";
+          Restart = "on-failure";
+        };
+      };
+
+      pronounscc-clean = lib.mkIf cfg.enableDatabaseCleaning {
+        description = "Clean the pronouns.cc database";
+        after = [ "network-online.target" ] ++ dependencies;
+        wants = [ "network-online.target" ];
+        inherit environment;
+
+        serviceConfig = backendServiceConfig // {
+          Type = "oneshot";
+          ExecStart = "${lib.getExe cfg.package} database clean";
+        };
+      };
+    };
+
+    systemd.timers.pronounscc-clean = lib.mkIf cfg.enableDatabaseCleaning {
+      description = "Daily pronouns.cc database cleaning";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "daily";
+        Persistent = true;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ philocalyst ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1493,6 +1493,7 @@ in
     inherit runTest;
     inherit (pkgs) lib;
   };
+  pronounscc = runTest ./pronounscc.nix;
   prosody = runTest ./xmpp/prosody.nix;
   prosody-mysql = handleTest ./xmpp/prosody-mysql.nix { };
   prowlarr = runTest ./prowlarr.nix;

--- a/nixos/tests/pronounscc.nix
+++ b/nixos/tests/pronounscc.nix
@@ -1,0 +1,52 @@
+{ lib, ... }:
+{
+  name = "pronounscc";
+  meta.maintainers = with lib.maintainers; [ philocalyst ];
+
+  nodes.machine = {
+    services.pronounscc = {
+      enable = true;
+      settings = {
+        HMAC_KEY = "dGVzdA==";
+        DATABASE_URL = "postgresql://pronounscc@127.0.0.1/pronounscc?sslmode=disable";
+        REDIS = "127.0.0.1:6379";
+        BASE_URL = "http://localhost:3000";
+        MINIO_ENDPOINT = "example.com";
+        MINIO_BUCKET = "test";
+      };
+    };
+
+    services.postgresql = {
+      enable = true;
+      authentication = lib.mkOverride 10 ''
+        local all all trust
+        host all all 127.0.0.1/32 trust
+        host all all ::1/128 trust
+      '';
+      ensureDatabases = [ "pronounscc" ];
+      ensureUsers = [
+        {
+          name = "pronounscc";
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    services.redis.servers."".enable = true;
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("pronounscc.service")
+    machine.wait_for_unit("pronounscc-frontend.service")
+    machine.wait_for_unit("pronounscc-exporter.service")
+    machine.wait_for_unit("pronounscc-clean.timer")
+    machine.wait_for_open_port(8080)
+    machine.wait_for_open_port(3000)
+    machine.wait_for_open_port(9090)
+
+    machine.succeed("curl --fail --silent http://127.0.0.1:8080/v1/meta | grep -q git_commit")
+    machine.succeed("curl --fail --silent http://127.0.0.1:3000/ | grep -qi '<html'")
+  '';
+}

--- a/pkgs/by-name/pr/pronounscc/package.nix
+++ b/pkgs/by-name/pr/pronounscc/package.nix
@@ -1,0 +1,145 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromCodeberg,
+  fetchPnpmDeps,
+  makeWrapper,
+  nixosTests,
+  nix-update-script,
+  nodejs,
+  pkg-config,
+  pnpm_10,
+  pnpmConfigHook,
+  testers,
+  vips,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pronounscc";
+  version = "0-unstable-2026-06-05";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  # pnpmConfigHook is needed for the frontend build, but must not run while
+  # buildGoModule is creating its separate Go vendor derivation.
+  overrideModAttrs = _: {
+    dontPnpmConfigure = true;
+    preBuild = "";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  # Latest tag is v0.6.4 (2025-09); main is ahead, so track commit on main branch.
+  src = fetchFromCodeberg {
+    owner = "pronounscc";
+    repo = "pronouns.cc";
+    rev = "e4a83a8534abf160d6c280b1706ef770a62670bb";
+    hash = "sha256-qAorGWCUNRATtLgHw7EjDAP7DtNwLqAfev0K+Ncy8M8=";
+  };
+
+  vendorHash = "sha256-trnua0ZdHgLEGhPAh8nqeLF9uGJDZvQsC/YaB4ByPM0=";
+  proxyVendor = true;
+
+  pnpmWorkspaces = [ "pronouns-fe" ];
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpmWorkspaces = [ "pronouns-fe" ];
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-y+r5kzAPg1MFmRWF7ZlLsrE2lK8zDW5c6RtSEJvqdnY=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pkg-config
+    pnpm_10
+    pnpmConfigHook
+  ];
+  buildInputs = [ vips ];
+
+  env = {
+    CGO_ENABLED = 1;
+    NODE_ENV = "production";
+    # SvelteKit build-time public/private env stubs.  Public values are
+    # compiled into the frontend; empty values intentionally make API/media
+    # URLs same-origin
+    PUBLIC_BASE_URL = "";
+    PUBLIC_HCAPTCHA_SITEKEY = "";
+    PUBLIC_MEDIA_URL = "";
+    PUBLIC_SHORT_BASE = "";
+    PRIVATE_ASSETS_PREFIX = "";
+    PRIVATE_SENTRY_DSN = "";
+  };
+
+  postPatch = ''
+    substituteInPlace frontend/svelte.config.js \
+      --replace-fail 'child_process.execSync("git describe --tags --long --always").toString().trim()' '"${finalAttrs.version}"'
+
+    substituteInPlace scripts/{cleandb,migrate,seeddb,snowflakes}/main.go \
+      --replace-fail $'err := godotenv.Load()\n\tif err != nil {' \
+                     $'err := godotenv.Load()\n\tif err != nil && !os.IsNotExist(err) {'
+  '';
+
+  preBuild = ''
+    go generate ./...
+    pnpm --dir frontend build
+  '';
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X codeberg.org/pronounscc/pronouns.cc/backend/server.Revision=${
+      lib.substring 0 7 finalAttrs.src.rev
+    }"
+    "-X codeberg.org/pronounscc/pronouns.cc/backend/server.Tag=${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    pnpm --filter pronouns-fe --prod deploy --offline \
+      --config.inject-workspace-packages=true frontend-deploy
+
+    install -d "$out/share/pronounscc/frontend"
+    cp -r frontend-deploy/{build,node_modules,package.json} \
+      "$out/share/pronounscc/frontend/"
+    makeWrapper ${lib.getExe nodejs} $out/bin/pronounscc-frontend \
+      --add-flags "$out/share/pronounscc/frontend/build/index.js" \
+      --chdir "$out/share/pronounscc/frontend" \
+      --set NODE_ENV production
+
+    install -Dm644 LICENSE $out/share/licenses/pronounscc/LICENSE
+    install -Dm644 README.md docs/self-hosting.md -t $doc/share/doc/pronounscc
+    install -Dm644 docs/config-examples/* -t $doc/share/doc/pronounscc/config-examples
+  '';
+
+  passthru = {
+    tests = {
+      inherit (nixosTests) pronounscc;
+      version = testers.testVersion { package = finalAttrs.finalPackage; };
+    };
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch=main" ];
+    };
+  };
+
+  meta = {
+    description = "Website for sharing names and pronouns";
+    longDescription = ''
+      pronouns.cc lets users create shareable pages listing their names,
+      pronouns, and related preferences. This package builds the Go backend
+      and SvelteKit frontend together.
+    '';
+    homepage = "https://codeberg.org/pronounscc/pronouns.cc";
+    changelog = "https://codeberg.org/pronounscc/pronouns.cc/commits/branch/main";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "pronouns.cc";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Summary

- added pronouncs.css from upstream main (no tagged releases) at `e4a83a8534abf160d6c280b1706ef770a62670bb`, including the complete Go command, production SvelteKit frontend, documentation, and a NixOS module with API, frontend, exporter, and database-cleaning services :D
- added module too, which typed API/exporter/frontend ports, backend settings, and secret env files.
- u can also database migrations before the API starts.
- with optional firewall openings derived from the enabled components.
- Add a NixOS test with PostgreSQL and Redis that verifies migrations, all default units, all three listeners, and HTTP responses from the API and frontend...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
