### PR TITLE
gogcli: 0.38.1 -> 0.39.1

### DIFF
--- a/pkgs/by-name/go/gogcli/package.nix
+++ b/pkgs/by-name/go/gogcli/package.nix
@@ -7,16 +7,16 @@
 
 buildGo127Module (finalAttrs: {
   pname = "gogcli";
-  version = "0.38.1";
+  version = "0.39.1";
 
   src = fetchFromGitHub {
     owner = "openclaw";
     repo = "gogcli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AaChyDvbMnPkWkBCnpISQm8U2WjXvwBSCfuN6fuIHaY=";
+    hash = "sha256-217KA+gLC4FwtY+UnV4o6pp4/ZMUfib6jcTtUe7Sjpg=";
   };
 
-  vendorHash = "sha256-+Nbuwok3dY/82gUDKeGgrC0F1ZqXSW8IpV6Q1yzIPvo=";
+  vendorHash = "sha256-GUOGvz6eDApnYxaALAVbHTpqzvIKys+fSpLcrpr2N70=";
 
   subPackages = [ "cmd/gog" ];
 


### PR DESCRIPTION
Updates `gogcli` from 0.38.1 to 0.39.1.

Upstream 0.39.0 added opt-in read-only AdSense commands, Workspace Chat message search, quota-project selection, Gmail `reply_to` support, and Docs A3 page size. Version 0.39.1 adds repeated-page-token protection across backups and Drive, Calendar, Contacts, Tasks, Groups, Admin, Keep, Gmail, and Docs scans, and refreshes Google support and MCP dependencies. The package remains a single `gog` binary with the same linker metadata variables and no new runtime dependencies. Upstream still declares Go 1.26 compatibility while suggesting Go 1.27.1, so `buildGo127Module` remains appropriate.

- [Changelog](https://github.com/openclaw/gogcli/blob/6895139ab1b46c2f0548d0244c345ef5f68663b1/CHANGELOG.md#0391---2026-09-05)
- [Full diff (v0.38.1 → v0.39.1)](https://github.com/openclaw/gogcli/compare/324f656a4949c3adbf8e1f18066d3965757ed9db...6895139ab1b46c2f0548d0244c345ef5f68663b1)

Additional verification:

- Built the package and `passthru.tests.version` with Go 1.27.1 on x86_64-linux and emulated aarch64-linux.
- Verified the output contains only `gog`, with exact version, tag, and reproducible date metadata on both architectures.
- Verified `deepthought` locks `nixpkgs-rschaffar-latest` to the exact PR commit and includes `gogcli` 0.39.1 in the active NixOS closure; both account-isolated underwrap wrappers report the exact metadata.
- Ran the complete upstream `go test ./...` suite against vendored dependencies; all 45 package results passed, including the newly added repeated-page-token tests.
- Confirmed the 0.39.1 output has the same direct runtime references as 0.39.0 and no new dynamic dependency.
- Checked installed-wrapper help and JSON schema discovery for the affected backup, Calendar, Gmail, Contacts, Drive, and Docs commands, plus the 0.39.0 AdSense, Chat, Gmail Reply-To, and Docs A3 additions.
- Checked installed-wrapper, credential-free `--dry-run` request generation for Gmail archive, Gmail Reply-To, and Docs A3 page layout.
- Ran `nixpkgs-review` against current `master`; it built `gogcli` successfully.
- No OAuth grants, Google accounts, or live Google API reads or writes were used.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (emulated)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

AI assistance: pi (openai-codex/gpt-5.6-sol) helped inspect upstream changes, prepare the package update, and draft this description; all reported changes and tests were verified locally.
