### PR TITLE
python3Packages.checkdmarc: 5.17.5 -> 6.0.1

### DIFF
--- a/pkgs/development/python-modules/checkdmarc/default.nix
+++ b/pkgs/development/python-modules/checkdmarc/default.nix
@@ -1,12 +1,16 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   cryptography,
   dnspython,
   expiringdict,
   fetchFromGitHub,
   hatchling,
+  httpx,
+  iana-etc,
   importlib-resources,
+  libredirect,
   pem,
   publicsuffixlist,
   pyleri,
@@ -19,14 +23,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "checkdmarc";
-  version = "5.17.5";
+  version = "6.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "domainaware";
     repo = "checkdmarc";
     tag = finalAttrs.version;
-    hash = "sha256-jwsAemOqJzMpQXliesr+wntAXjVoo/1rFr+1SSqqeRY=";
+    hash = "sha256-yyyaA0gLnRpyf1MueHWd67kzXDMOJYd5CHzAG/mBIA0=";
   };
 
   pythonRelaxDeps = [
@@ -41,6 +45,7 @@ buildPythonPackage (finalAttrs: {
     cryptography
     dnspython
     expiringdict
+    httpx
     importlib-resources
     pem
     publicsuffixlist
@@ -49,26 +54,39 @@ buildPythonPackage (finalAttrs: {
     requests
     timeout-decorator
     xmltodict
-  ];
+  ]
+  ++ dnspython.optional-dependencies.doh;
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    httpx
+    pytestCheckHook
+  ]
+  ++ httpx.optional-dependencies.http2;
 
   pythonImportsCheck = [ "checkdmarc" ];
+
+  preCheck = lib.optionalString stdenv.hostPlatform.isLinux ''
+    echo "nameserver 127.0.0.1" > resolv.conf
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf) \
+      LD_PRELOAD=${libredirect}/lib/libredirect.so
+  '';
 
   disabledTests = [
     # Tests require network access
     "testBIMI"
+    "testCheckSoaDelegatedChildZoneLive"
+    "testCheckSoaFallsBackToBaseDomainLive"
     "testDMARCPctLessThan100Warning"
-    "testSPFMissingARecord"
-    "testSPFMissingMXRecord"
-    "testSplitSPFRecord"
-    "testTooManySPFDNSLookups"
-    "testTooManySPFVoidDNSLookups"
     "testDNSSEC"
     "testDnssecFalseWhenNoKey"
     "testGetDnskeyCache"
     "testIncludeMissingSPF"
     "testKnownGood"
+    "testSPFMissingARecord"
+    "testSPFMissingMXRecord"
+    "testSplitSPFRecord"
+    "testTooManySPFDNSLookups"
+    "testTooManySPFVoidDNSLookups"
   ];
 
   meta = {


### PR DESCRIPTION
Changelog: https://github.com/domainaware/checkdmarc/blob/6.0.1/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
