### PR TITLE
jrl-cmakemodules: add missing openmp checkInputs

### DIFF
--- a/pkgs/by-name/jr/jrl-cmakemodules/package.nix
+++ b/pkgs/by-name/jr/jrl-cmakemodules/package.nix
@@ -18,6 +18,7 @@
   catch2_3,
   cppad,
   gmp,
+  llvmPackages,
   matio,
   mpfr,
   python3Packages,
@@ -65,6 +66,11 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.pytest
     simde
     suitesparse
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    # Otherwise `FindCHOLMOD` fails
+    # Could NOT find OpenMP_C (missing: OpenMP_C_FLAGS OpenMP_C_LIB_NAMES)
+    llvmPackages.openmp
   ];
 
   passthru = {

--- a/pkgs/by-name/jr/jrl-cmakemodules/package.nix
+++ b/pkgs/by-name/jr/jrl-cmakemodules/package.nix
@@ -38,6 +38,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "jrl-cmakemodules";
   version = "2.3.0";
 
+  __structuredAttrs = true;
+  srictDeps = true;
+
   src = fetchFromGitHub {
     owner = "jrl-umi3218";
     repo = "jrl-cmakemodules";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **jrl-cmakemodules: add missing openmp checkInputs**
- **jrl-cmakemodules: enable __structuredAttrs and strictDeps**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
