### PR TITLE
[Backport release-26.05] typora: 1.13.6 -> 1.14.9

### DIFF
--- a/pkgs/by-name/ty/typora/package.nix
+++ b/pkgs/by-name/ty/typora/package.nix
@@ -20,7 +20,7 @@
 
 let
   pname = "typora";
-  version = "1.13.6";
+  version = "1.14.8";
 
   passthru = {
     sources = {
@@ -29,21 +29,21 @@ let
           "https://download.typora.io/linux/typora_${version}_amd64.deb"
           "https://downloads.typoraio.cn/linux/typora_${version}_amd64.deb"
         ];
-        hash = "sha256-EwVqMinvC26R5ULDGiiONwS3sH3GBJ/sPr2pnqfQR5s=";
+        hash = "sha256-mfnGSAlWeLq7bas6SQKgWLLJXY1xM9CIA+iIf464z0U=";
       };
       aarch64-linux = fetchurl {
         urls = [
           "https://download.typora.io/linux/typora_${version}_arm64.deb"
           "https://downloads.typoraio.cn/linux/typora_${version}_arm64.deb"
         ];
-        hash = "sha256-3/eS9xAC7+V55grhHPLU/9+JefkXgIyKlEh3vRkqZUo=";
+        hash = "sha256-FsV0u9CXf6FdEeKqJZlpNjvGOv1pDNYD3J4neKpD0pw=";
       };
       aarch64-darwin = fetchurl {
         urls = [
           "https://download.typora.io/mac/Typora-${version}.dmg"
           "https://downloads.typoraio.cn/mac/Typora-${version}.dmg"
         ];
-        hash = "sha256-kXnzhuu3ItF9mV0x+v7+hbYNCOo1DAfIzYMHwAL+LHM=";
+        hash = "sha256-XVXfmKTsKuougrBaecJWatP4g93bl0p8xEUzbjf4374=";
       };
     };
     updateScript = ./update.sh;

--- a/pkgs/by-name/ty/typora/package.nix
+++ b/pkgs/by-name/ty/typora/package.nix
@@ -20,7 +20,7 @@
 
 let
   pname = "typora";
-  version = "1.14.8";
+  version = "1.14.9";
 
   passthru = {
     sources = {
@@ -29,21 +29,21 @@ let
           "https://download.typora.io/linux/typora_${version}_amd64.deb"
           "https://downloads.typoraio.cn/linux/typora_${version}_amd64.deb"
         ];
-        hash = "sha256-mfnGSAlWeLq7bas6SQKgWLLJXY1xM9CIA+iIf464z0U=";
+        hash = "sha256-iIUgfPni2u2iWS/ancsFwS1rXEZloqBVpQ5lSADmM+o=";
       };
       aarch64-linux = fetchurl {
         urls = [
           "https://download.typora.io/linux/typora_${version}_arm64.deb"
           "https://downloads.typoraio.cn/linux/typora_${version}_arm64.deb"
         ];
-        hash = "sha256-FsV0u9CXf6FdEeKqJZlpNjvGOv1pDNYD3J4neKpD0pw=";
+        hash = "sha256-RXSQKwEffTcWgFR/P04UJ/e41mr26YGcGC2byNyGACw=";
       };
       aarch64-darwin = fetchurl {
         urls = [
           "https://download.typora.io/mac/Typora-${version}.dmg"
           "https://downloads.typoraio.cn/mac/Typora-${version}.dmg"
         ];
-        hash = "sha256-XVXfmKTsKuougrBaecJWatP4g93bl0p8xEUzbjf4374=";
+        hash = "sha256-QAJrZ1vIESSk8RLoYBvwxHzEtbfwXlK/rxTFzo+F/7U=";
       };
     };
     updateScript = ./update.sh;


### PR DESCRIPTION
Backport necessary because 1.13.6 is affected by [CVE-2026-82805](https://nvd.nist.gov/vuln/detail/CVE-2026-82805) (see #558812)

(cherry picked from commit c303ba319bea664a969ca900989fb361eff49958)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
