### PR TITLE
komodo: fix version reported by core/periphery

### DIFF
--- a/pkgs/by-name/ko/komodo/package.nix
+++ b/pkgs/by-name/ko/komodo/package.nix
@@ -29,6 +29,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # > error: doctest failed, to rerun pass `-p komodo_client --doc`
   doCheck = false;
 
+  # upstream moved to build-time versioning in moghtech/komodo#1605
+  # this sets [workspace.package] so binaries inherit/report correct version
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
+  '';
+
   # xtask is a workspace-internal build helper, not a user-facing program.
   postInstall = ''
     rm -f $out/bin/xtask


### PR DESCRIPTION
This is an amendment/follow-up to PR #560133, which has already been merged. It implements a postPatch step to set the value of [workspace.package.version] to ${finalAttrs.version}.

Komodo changed to build-time versioning in moghtech/komodo#1605, which results in the nix builds completing with a version set to `v0.0.0`; I missed this in the first pass, as it's only mentioned in the commit log. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
This change sets Cargo.toml's [workspace.package.version] to be equivalent to {finalAttrs.version}, replicating the behavior of `cargo set-version` in their Dockerfile builds; workspace.version is initially set to v0.0.0 and then later updated using `cargo set-version`. Any instance in the codebase that refers to `CARGO_PKG_VERSION` is impacted by not having `workspace.package` set, which has the impacts as observed below.

Observations/context:
- `periphery --version` reports a version of v2.3.3; if you connect it to a running instance of `core`, it will report a version of `v0.0.0`.
- `core`'s init reports a version of `v0.0.0`. I am uncertain if this breaks behavior with other instances of `periphery` that correctly report their version (ie. periphery 2.3.3 to a core reporting v0.0.0).
- `km --version` reports a version of v2.3.3; I am not sure what it would report to `core` upon usage.

Before...
```
[root@nix-containerhost:~/tmp/nixpkgs]# km --version
komodo-cli 2.3.3

[root@nix-containerhost:~/tmp/nixpkgs]# periphery
[]
INFO: No config paths found, using default config
2026-09-06T09:25:02.936489Z  INFO PeripheryStartup: Komodo Periphery version: v0.0.0

[root@nix-containerhost:~/tmp/nixpkgs]# core
INFO: Config File Keywords: ["*config.*"]
2026-09-06T09:25:19.654515Z  INFO CoreStartup: Komodo Core version: v0.0.0

[a separate core instance shows the server reporting v0.0.0]
```

After the change...
```
[root@nix-containerhost:~/tmp/nixpkgs]# ./result/bin/km --version
komodo-cli 2.3.3

[root@nix-containerhost:~/tmp/nixpkgs]# ./result/bin/periphery
[]
INFO: No config paths found, using default config
2026-09-06T09:24:30.523714Z  INFO PeripheryStartup: Komodo Periphery version: v2.3.3

[root@nix-containerhost:~/tmp/nixpkgs]# ./result/bin/core
INFO: Config File Keywords: ["*config.*"]
2026-09-06T09:24:17.646734Z  INFO CoreStartup: Komodo Core version: v2.3.3


[a separate core instance shows the server reporting the correct v2.3.3]
```

Apologies for the oversight; I'm happy to answer any questions you may have regarding this change.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
