### PR TITLE
python3Packages.torchrl: skip failing test

### DIFF
--- a/pkgs/development/python-modules/torchrl/default.nix
+++ b/pkgs/development/python-modules/torchrl/default.nix
@@ -198,6 +198,10 @@ buildPythonPackage (finalAttrs: {
     # Tests memory consumption grows significantly with the number of parallel processes
     # -> Limit the number of parallel jobs to prevent OOMing
     "--maxprocesses=16"
+
+    # Some tests are flaky when ran with pytest-xdist. Give them 2 more chances to succeed.
+    "--reruns=3"
+    "--reruns-delay=1"
   ];
 
   nativeCheckInputs = [
@@ -221,6 +225,8 @@ buildPythonPackage (finalAttrs: {
     # likely means that a valid OpenGL context has not been created before mjr_makeContext was
     # called
     "test_from_pixels_spec_and_rollout"
+    "test_render_every"
+    "test_vecenvs_env"
 
     # Hang forever
     "test_pixels_only_drops_observation_key"
@@ -265,9 +271,6 @@ buildPythonPackage (finalAttrs: {
     "test_auto_register"
     "test_info_dict_reader"
 
-    # mujoco.FatalError: an OpenGL platform library has not been loaded into this process, this most likely means that a valid OpenGL context has not been created before mjr_makeContext was called
-    "test_vecenvs_env"
-
     # ValueError: Can't write images with one color channel.
     "test_log_video"
 
@@ -289,6 +292,9 @@ buildPythonPackage (finalAttrs: {
     # nondeterministic
     "test_distributed_collector_updatepolicy"
     "test_timeit"
+
+    # AssertionError: assert tensor(7.6068e-06) > 1e-05
+    "test_ddpg_prioritized_weights"
 
     # On a 24 threads system
     # assert torch.get_num_threads() == max(1, init_threads - 3)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```
mujoco.FatalError: an OpenGL platform library has not been loaded into this process, this most likely means that a valid OpenGL context has not been created before mjr_makeContext was called
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
