### PR TITLE
fluent-bit: disable SIMD on riscv64

### DIFF
--- a/pkgs/by-name/fl/fluent-bit/package.nix
+++ b/pkgs/by-name/fl/fluent-bit/package.nix
@@ -85,6 +85,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "FLB_RELEASE" true)
     (lib.cmakeBool "FLB_PREFER_SYSTEM_LIBS" true)
   ]
+  ++ lib.optionals stdenv.hostPlatform.isRiscV64 [
+    # Auto would raise the baseline to rv64gcv_zba
+    (lib.cmakeFeature "FLB_SIMD" "Off")
+  ]
   ++ lib.optionals stdenv.cc.isClang [
     # `FLB_SECURITY` causes bad linker options for Clang to be set.
     (lib.cmakeBool "FLB_SECURITY" false)


### PR DESCRIPTION
`FLB_SIMD=Auto` builds the whole binary with `-march=rv64gcv_zba` when the compiler accepts it, which SIGILLs at startup on rv64gc cores (e.g. SG2042 / Milk-V Pioneer).

## Things done
- [x] Tested on riscv64-linux (cross from x86_64-linux), Milk-V Pioneer
