### PR TITLE
python3Packages.baselines: fix by using setuptools_80 as build-system

### DIFF
--- a/pkgs/development/python-modules/baselines/default.nix
+++ b/pkgs/development/python-modules/baselines/default.nix
@@ -2,26 +2,28 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
-  pytest,
-  gym,
-  scipy,
-  tqdm,
-  joblib,
-  dill,
-  progressbar2,
-  cloudpickle,
+
+  # dependencies
   click,
-  pyzmq,
-  tensorflow,
+  cloudpickle,
+  dill,
+  gym,
+  joblib,
   mpi4py,
+  progressbar2,
+  pyzmq,
+  scipy,
+  tensorflow,
+  tqdm,
 }:
 
 buildPythonPackage {
   pname = "baselines";
   version = "0.1.6"; # remember to manually adjust the rev
   pyproject = true;
-
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
@@ -35,17 +37,17 @@ buildPythonPackage {
   build-system = [ setuptools ];
 
   dependencies = [
-    gym
-    scipy
-    tqdm
-    joblib
-    pyzmq
-    dill
-    progressbar2
-    mpi4py
-    cloudpickle
-    tensorflow
     click
+    cloudpickle
+    dill
+    gym
+    joblib
+    mpi4py
+    progressbar2
+    pyzmq
+    scipy
+    tensorflow
+    tqdm
   ];
 
   postPatch = ''
@@ -57,8 +59,6 @@ buildPythonPackage {
 
   # fails to create a daemon, probably because of sandboxing
   doCheck = false;
-
-  nativeCheckInputs = [ pytest ];
 
   pythonImportsCheck = [ "baselines" ];
 

--- a/pkgs/development/python-modules/baselines/default.nix
+++ b/pkgs/development/python-modules/baselines/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   # build-system
-  setuptools,
+  setuptools_80,
 
   # dependencies
   click,
@@ -34,7 +34,11 @@ buildPythonPackage {
     hash = "sha256-lK1HRBdKR92E2hHZF5cFZ0P3N1aJ57pw8tazrPOZTEg=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    # `pkg_resources` was removed from more recent versions
+    #   ModuleNotFoundError: No module named 'pkg_resources'
+    setuptools_80
+  ];
 
   dependencies = [
     click


### PR DESCRIPTION
## Things done

```
ModuleNotFoundError: No module named 'pkg_resources'
```

- **python3Packages.baselines: cleanup**
- **python3Packages.baselines: fix by using setuptools_80 as build-system**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
