### PR TITLE
mcp-server-{filesystem,memory,sequential-thinking}: migrate to typescript 7

### DIFF
--- a/pkgs/by-name/mc/mcp-server-filesystem/package.nix
+++ b/pkgs/by-name/mc/mcp-server-filesystem/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
   buildNpmPackage,
-  typescript_5,
+  yq-go,
+  typescript_7,
   fetchFromGitHub,
 }:
 
@@ -16,8 +17,13 @@ buildNpmPackage (finalAttrs: {
     hash = "sha256-tRx/ZCyHnDP3BmK/xOgVKtjlKCyKUfIll8y1sSDgzV8=";
   };
 
+  postPatch = ''
+    yq -i '.compilerOptions.types = ["node"]' tsconfig.json
+  '';
+
   nativeBuildInputs = [
-    typescript_5
+    yq-go
+    typescript_7
   ];
 
   dontNpmPrune = true;

--- a/pkgs/by-name/mc/mcp-server-memory/package.nix
+++ b/pkgs/by-name/mc/mcp-server-memory/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
   buildNpmPackage,
-  typescript_5,
+  yq-go,
+  typescript_7,
   fetchFromGitHub,
 }:
 
@@ -16,8 +17,13 @@ buildNpmPackage (finalAttrs: {
     hash = "sha256-tRx/ZCyHnDP3BmK/xOgVKtjlKCyKUfIll8y1sSDgzV8=";
   };
 
+  postPatch = ''
+    yq -i '.compilerOptions.types = ["node"]' tsconfig.json
+  '';
+
   nativeBuildInputs = [
-    typescript_5
+    yq-go
+    typescript_7
   ];
 
   dontNpmPrune = true;

--- a/pkgs/by-name/mc/mcp-server-sequential-thinking/package.nix
+++ b/pkgs/by-name/mc/mcp-server-sequential-thinking/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
   buildNpmPackage,
-  typescript_5,
+  yq-go,
+  typescript_7,
   fetchFromGitHub,
 }:
 
@@ -16,8 +17,13 @@ buildNpmPackage (finalAttrs: {
     hash = "sha256-tRx/ZCyHnDP3BmK/xOgVKtjlKCyKUfIll8y1sSDgzV8=";
   };
 
+  postPatch = ''
+    yq -i '.compilerOptions.types = ["node"]' tsconfig.json
+  '';
+
   nativeBuildInputs = [
-    typescript_5
+    yq-go
+    typescript_7
   ];
 
   dontNpmPrune = true;


### PR DESCRIPTION
The only error during migration is 

```
index.ts(133,3): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
```

Adding `types: ["node"]'` to `compilerOptions` fixes the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
