### PR TITLE
python3Packages.tika: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/tika/default.nix
+++ b/pkgs/development/python-modules/tika/default.nix
@@ -7,13 +7,15 @@
   requests,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tika";
   version = "3.1.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-TDpATD2EZDfJQtam/Xtx1QKFaQ+uVImqim8A/5zND8c=";
   };
 
@@ -26,7 +28,7 @@ buildPythonPackage rec {
 
   # Requires network
   doCheck = false;
-  pythonImportsCheck = [ pname ];
+  pythonImportsCheck = [ "tika" ];
 
   meta = {
     description = "Python binding to the Apache Tika™ REST services";
@@ -35,4 +37,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ Flakebi ];
   };
-}
+})

--- a/pkgs/development/python-modules/tika/default.nix
+++ b/pkgs/development/python-modules/tika/default.nix
@@ -5,6 +5,7 @@
   setuptools,
   pyyaml,
   requests,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -26,8 +27,13 @@ buildPythonPackage (finalAttrs: {
     requests
   ];
 
-  # Requires network
-  doCheck = false;
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # Only test that does not require network
+  enabledTestPaths = [
+    "tika/tests/test_from_file_service.py::CreateTest::test_remote_endpoint"
+  ];
+
   pythonImportsCheck = [ "tika" ];
 
   meta = {

--- a/pkgs/development/python-modules/tika/default.nix
+++ b/pkgs/development/python-modules/tika/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   pyyaml,
   requests,
 }:
@@ -9,14 +10,16 @@
 buildPythonPackage rec {
   pname = "tika";
   version = "3.1.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-TDpATD2EZDfJQtam/Xtx1QKFaQ+uVImqim8A/5zND8c=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     pyyaml
     requests
   ];


### PR DESCRIPTION
As part of #515974
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
