### PR TITLE
doc/lib: show toSentenceCase's remainder lowering

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1563,7 +1563,8 @@ rec {
   toUpper = replaceStrings lowerChars upperChars;
 
   /**
-    Converts the first character of a string `s` to upper-case.
+    Converts the first character of a string `s` to upper-case and leaves the
+    remainder lower-case.
 
     # Inputs
 
@@ -1581,8 +1582,8 @@ rec {
     ## `lib.strings.toSentenceCase` usage example
 
     ```nix
-    toSentenceCase "home"
-    => "Home"
+    toSentenceCase "welcome Home"
+    => "Welcome home"
     ```
 
     :::


### PR DESCRIPTION
Updates `lib.toSentenceCase`'s documentation to show that it additionally lowers the remainder of the string, which was not immediately obvious.

Unlike #477214, this doesn't change any behaviour and is purely a documentation change.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
