### PR TITLE
gzdoom,uzdoom,zmusic: change dynamic linking to static

### DIFF
--- a/pkgs/by-name/gz/gzdoom/package.nix
+++ b/pkgs/by-name/gz/gzdoom/package.nix
@@ -81,6 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (lib.cmakeBool "HAVE_GLES2" false)
+    (lib.cmakeFeature "OPENAL_INCLUDE_DIR" "${openal}/include/AL")
+    (lib.cmakeFeature "OPENAL_LIBRARY" "${openal}/lib/libopenal.dylib")
   ];
 
   desktopItems = lib.optionals stdenv.hostPlatform.isLinux [

--- a/pkgs/by-name/gz/gzdoom/package.nix
+++ b/pkgs/by-name/gz/gzdoom/package.nix
@@ -76,10 +76,12 @@ stdenv.mkDerivation (finalAttrs: {
   # Apple dropped GL support
   # Shader's loading will throw an error while linking
   cmakeFlags = [
-    "-DDYN_GTK=OFF"
-    "-DDYN_OPENAL=OFF"
+    (lib.cmakeBool "DYN_GTK" false)
+    (lib.cmakeBool "DYN_OPENAL" false)
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ "-DHAVE_GLES2=OFF" ];
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (lib.cmakeBool "HAVE_GLES2" false)
+  ];
 
   desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
     (makeDesktopItem {

--- a/pkgs/by-name/uz/uzdoom/package.nix
+++ b/pkgs/by-name/uz/uzdoom/package.nix
@@ -119,6 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       Gliczy
       keenanweaver
+      r4v3n6101
     ];
     platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "uzdoom";

--- a/pkgs/by-name/uz/uzdoom/package.nix
+++ b/pkgs/by-name/uz/uzdoom/package.nix
@@ -57,8 +57,10 @@ stdenv.mkDerivation (finalAttrs: {
     bzip2
     glib
     libGL
+    libsndfile
     libvpx
     libwebp
+    mpg123
     openal
     sdl2-compat
     vulkan-loader
@@ -74,7 +76,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
+    (lib.cmakeBool "DYN_MPG123" false)
     (lib.cmakeBool "DYN_OPENAL" false)
+    (lib.cmakeBool "DYN_SNDFILE" false)
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (lib.cmakeFeature "OPENAL_INCLUDE_DIR" "${openal}/include/AL")
@@ -100,13 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     mv $out/bin/uzdoom $out/share/games/uzdoom/uzdoom
     makeWrapper $out/share/games/uzdoom/uzdoom $out/bin/uzdoom \
-      --set LD_LIBRARY_PATH ${
-        lib.makeLibraryPath [
-          libsndfile
-          mpg123
-          vulkan-loader
-        ]
-      }
+      --set LD_LIBRARY_PATH ${lib.makeLibraryPath [ vulkan-loader ]}
   '';
 
   meta = {

--- a/pkgs/by-name/zm/zmusic/package.nix
+++ b/pkgs/by-name/zm/zmusic/package.nix
@@ -51,6 +51,11 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ];
 
+  cmakeFlags = [
+    (lib.cmakeBool "DYN_MPG123" false)
+    (lib.cmakeBool "DYN_SNDFILE" false)
+  ];
+
   meta = {
     description = "GZDoom's music system as a standalone library";
     homepage = "https://github.com/ZDoom/ZMusic";


### PR DESCRIPTION
Fixes silence on Darwin targets.
Also enforce `cmake` to use provided OpenAL instead of system.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
