### PR TITLE
xmlsec: 1.3.7 -> 1.3.12, cleanup

### DIFF
--- a/pkgs/by-name/xm/xmlsec/package.nix
+++ b/pkgs/by-name/xm/xmlsec/package.nix
@@ -1,12 +1,10 @@
 {
   stdenv,
   fetchurl,
-  fetchpatch,
   libxml2,
   gnutls,
   libxslt,
   pkg-config,
-  libgcrypt,
   libtool,
   openssl,
   nss,
@@ -16,7 +14,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "xmlsec";
-  version = "1.3.7";
+  version = "1.3.12";
 
   __structuredAttrs = true;
 
@@ -27,17 +25,12 @@ stdenv.mkDerivation (finalAttrs: {
       # for when the ${finalAttrs.version} gets older than the last two
       "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-${finalAttrs.version}.tar.gz"
     ];
-    hash = "sha256-2C6TtpuKogWmFrYpF6JpMiv2Oj6q+zd1AU5hdSsgE+o=";
+    hash = "sha256-JARRma8S2T/l/bu/fjhugj5IQgcelDLiuQrBCLiJqSM=";
   };
 
   patches = [
     ./lt_dladdsearchdir.patch
     ./remove_bsd_base64_decode_flag.patch
-    (fetchpatch {
-      # xmlDoc.encoding is no longer const in libxml 2.15, so fetch the fix
-      url = "https://github.com/lsh123/xmlsec/commit/ef0e3b5cac04db13ce070b1e5bcad7dd7b0eb49b.patch?full_index=1";
-      hash = "sha256-Hv8PaJXkXLq++NuCAJ4IvsYBPj8wkN7dBTniYucq18o=";
-    })
   ];
 
   postPatch = ''
@@ -56,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libxml2
     gnutls
-    libgcrypt
     libtool
     openssl
     nss
@@ -78,9 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
   # enable deprecated soap headers required by lasso
   # https://dev.entrouvert.org/issues/18771
   configureFlags = [ "--enable-soap" ];
-
-  # otherwise libxmlsec1-gnutls.so won't find libgcrypt.so, after #909
-  env.NIX_LDFLAGS = "-lgcrypt";
 
   postInstall = ''
     moveToOutput "bin/xmlsec1-config" "$dev"
@@ -110,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
           }
         ''}
 
-        for crypto in "" gcrypt gnutls nss openssl; do
+        for crypto in "" gnutls nss openssl; do
           ./crypto-test $crypto
         done
         touch $out

--- a/pkgs/by-name/xm/xmlsec/package.nix
+++ b/pkgs/by-name/xm/xmlsec/package.nix
@@ -14,115 +14,111 @@
   runCommandCC,
   writeText,
 }:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xmlsec";
+  version = "1.3.7";
 
-lib.fix (
-  self:
-  stdenv.mkDerivation (finalAttrs: {
-    pname = "xmlsec";
-    version = "1.3.7";
+  src = fetchurl {
+    urls = [
+      "https://www.aleksey.com/xmlsec/download/xmlsec1-${finalAttrs.version}.tar.gz"
 
-    src = fetchurl {
-      urls = [
-        "https://www.aleksey.com/xmlsec/download/xmlsec1-${finalAttrs.version}.tar.gz"
-
-        # for when the ${finalAttrs.version} gets older than the last two
-        "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-${finalAttrs.version}.tar.gz"
-      ];
-      hash = "sha256-2C6TtpuKogWmFrYpF6JpMiv2Oj6q+zd1AU5hdSsgE+o=";
-    };
-
-    patches = [
-      ./lt_dladdsearchdir.patch
-      ./remove_bsd_base64_decode_flag.patch
-      (fetchpatch {
-        # xmlDoc.encoding is no longer const in libxml 2.15, so fetch the fix
-        url = "https://github.com/lsh123/xmlsec/commit/ef0e3b5cac04db13ce070b1e5bcad7dd7b0eb49b.patch?full_index=1";
-        hash = "sha256-Hv8PaJXkXLq++NuCAJ4IvsYBPj8wkN7dBTniYucq18o=";
-      })
+      # for when the ${finalAttrs.version} gets older than the last two
+      "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-${finalAttrs.version}.tar.gz"
     ];
+    hash = "sha256-2C6TtpuKogWmFrYpF6JpMiv2Oj6q+zd1AU5hdSsgE+o=";
+  };
 
-    postPatch = ''
-      substituteAllInPlace src/dl.c
-    '';
+  patches = [
+    ./lt_dladdsearchdir.patch
+    ./remove_bsd_base64_decode_flag.patch
+    (fetchpatch {
+      # xmlDoc.encoding is no longer const in libxml 2.15, so fetch the fix
+      url = "https://github.com/lsh123/xmlsec/commit/ef0e3b5cac04db13ce070b1e5bcad7dd7b0eb49b.patch?full_index=1";
+      hash = "sha256-Hv8PaJXkXLq++NuCAJ4IvsYBPj8wkN7dBTniYucq18o=";
+    })
+  ];
 
-    outputs = [
-      "out"
-      "dev"
-    ];
+  postPatch = ''
+    substituteAllInPlace src/dl.c
+  '';
 
-    nativeBuildInputs = [ pkg-config ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
-    buildInputs = [
-      libxml2
-      gnutls
-      libgcrypt
-      libtool
-      openssl
-      nss
-    ];
+  nativeBuildInputs = [ pkg-config ];
 
-    propagatedBuildInputs = [
-      # required by xmlsec/transforms.h
-      libxslt
-    ];
+  buildInputs = [
+    libxml2
+    gnutls
+    libgcrypt
+    libtool
+    openssl
+    nss
+  ];
 
-    enableParallelBuilding = true;
-    doCheck = true;
-    nativeCheckInputs = [ nss.tools ];
-    preCheck = ''
-      export TMPFOLDER=$(mktemp -d)
-      substituteInPlace tests/testrun.sh --replace 'timestamp=`date +%Y%m%d_%H%M%S`' 'timestamp=19700101_000000'
-    '';
+  propagatedBuildInputs = [
+    # required by xmlsec/transforms.h
+    libxslt
+  ];
 
-    # enable deprecated soap headers required by lasso
-    # https://dev.entrouvert.org/issues/18771
-    configureFlags = [ "--enable-soap" ];
+  enableParallelBuilding = true;
+  doCheck = true;
+  nativeCheckInputs = [ nss.tools ];
+  preCheck = ''
+    export TMPFOLDER=$(mktemp -d)
+    substituteInPlace tests/testrun.sh --replace 'timestamp=`date +%Y%m%d_%H%M%S`' 'timestamp=19700101_000000'
+  '';
 
-    # otherwise libxmlsec1-gnutls.so won't find libgcrypt.so, after #909
-    env.NIX_LDFLAGS = "-lgcrypt";
+  # enable deprecated soap headers required by lasso
+  # https://dev.entrouvert.org/issues/18771
+  configureFlags = [ "--enable-soap" ];
 
-    postInstall = ''
-      moveToOutput "bin/xmlsec1-config" "$dev"
-      moveToOutput "lib/xmlsec1Conf.sh" "$dev"
-    '';
+  # otherwise libxmlsec1-gnutls.so won't find libgcrypt.so, after #909
+  env.NIX_LDFLAGS = "-lgcrypt";
 
-    passthru.tests.libxmlsec1-crypto =
-      runCommandCC "libxmlsec1-crypto-test"
-        {
-          nativeBuildInputs = [ pkg-config ];
-          buildInputs = [
-            self
-            libxml2
-            libxslt
-            libtool
-          ];
-        }
-        ''
-          $CC $(pkg-config --cflags --libs xmlsec1) -o crypto-test ${writeText "crypto-test.c" ''
-            #include <xmlsec/xmlsec.h>
-            #include <xmlsec/crypto.h>
+  postInstall = ''
+    moveToOutput "bin/xmlsec1-config" "$dev"
+    moveToOutput "lib/xmlsec1Conf.sh" "$dev"
+  '';
 
-            int main(int argc, char **argv) {
-              return xmlSecInit() ||
-                xmlSecCryptoDLLoadLibrary(argc > 1 ? argv[1] : 0) ||
-                xmlSecCryptoInit();
-            }
-          ''}
+  passthru.tests.libxmlsec1-crypto =
+    runCommandCC "libxmlsec1-crypto-test"
+      {
+        nativeBuildInputs = [ pkg-config ];
+        buildInputs = [
+          finalAttrs.finalPackage
+          libxml2
+          libxslt
+          libtool
+        ];
+      }
+      ''
+        $CC $(pkg-config --cflags --libs xmlsec1) -o crypto-test ${writeText "crypto-test.c" ''
+          #include <xmlsec/xmlsec.h>
+          #include <xmlsec/crypto.h>
 
-          for crypto in "" gcrypt gnutls nss openssl; do
-            ./crypto-test $crypto
-          done
-          touch $out
-        '';
+          int main(int argc, char **argv) {
+            return xmlSecInit() ||
+              xmlSecCryptoDLLoadLibrary(argc > 1 ? argv[1] : 0) ||
+              xmlSecCryptoInit();
+          }
+        ''}
 
-    meta = {
-      description = "XML Security Library in C based on libxml2";
-      homepage = "https://www.aleksey.com/xmlsec/";
-      downloadPage = "https://www.aleksey.com/xmlsec/download.html";
-      license = lib.licenses.mit;
-      mainProgram = "xmlsec1";
-      maintainers = [ ];
-      platforms = with lib.platforms; linux ++ darwin;
-    };
-  })
-)
+        for crypto in "" gcrypt gnutls nss openssl; do
+          ./crypto-test $crypto
+        done
+        touch $out
+      '';
+
+  meta = {
+    description = "XML Security Library in C based on libxml2";
+    homepage = "https://www.aleksey.com/xmlsec/";
+    downloadPage = "https://www.aleksey.com/xmlsec/download.html";
+    license = lib.licenses.mit;
+    mainProgram = "xmlsec1";
+    maintainers = [ ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})

--- a/pkgs/by-name/xm/xmlsec/package.nix
+++ b/pkgs/by-name/xm/xmlsec/package.nix
@@ -9,6 +9,7 @@
   openssl,
   nss,
   lib,
+  python3Packages,
   runCommandCC,
   writeText,
 }:
@@ -76,34 +77,37 @@ stdenv.mkDerivation (finalAttrs: {
     moveToOutput "lib/xmlsec1Conf.sh" "$dev"
   '';
 
-  passthru.tests.libxmlsec1-crypto =
-    runCommandCC "libxmlsec1-crypto-test"
-      {
-        nativeBuildInputs = [ pkg-config ];
-        buildInputs = [
-          finalAttrs.finalPackage
-          libxml2
-          libxslt
-          libtool
-        ];
-      }
-      ''
-        $CC $(pkg-config --cflags --libs xmlsec1) -o crypto-test ${writeText "crypto-test.c" ''
-          #include <xmlsec/xmlsec.h>
-          #include <xmlsec/crypto.h>
+  passthru.tests = {
+    python-xmlsec = python3Packages.xmlsec;
+    libxmlsec1-crypto =
+      runCommandCC "libxmlsec1-crypto-test"
+        {
+          nativeBuildInputs = [ pkg-config ];
+          buildInputs = [
+            finalAttrs.finalPackage
+            libxml2
+            libxslt
+            libtool
+          ];
+        }
+        ''
+          $CC $(pkg-config --cflags --libs xmlsec1) -o crypto-test ${writeText "crypto-test.c" ''
+            #include <xmlsec/xmlsec.h>
+            #include <xmlsec/crypto.h>
 
-          int main(int argc, char **argv) {
-            return xmlSecInit() ||
-              xmlSecCryptoDLLoadLibrary(argc > 1 ? argv[1] : 0) ||
-              xmlSecCryptoInit();
-          }
-        ''}
+            int main(int argc, char **argv) {
+              return xmlSecInit() ||
+                xmlSecCryptoDLLoadLibrary(argc > 1 ? argv[1] : 0) ||
+                xmlSecCryptoInit();
+            }
+          ''}
 
-        for crypto in "" gnutls nss openssl; do
-          ./crypto-test $crypto
-        done
-        touch $out
-      '';
+          for crypto in "" gnutls nss openssl; do
+            ./crypto-test $crypto
+          done
+          touch $out
+        '';
+  };
 
   meta = {
     description = "XML Security Library in C based on libxml2";

--- a/pkgs/by-name/xm/xmlsec/package.nix
+++ b/pkgs/by-name/xm/xmlsec/package.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "xmlsec";
   version = "1.3.7";
 
+  __structuredAttrs = true;
+
   src = fetchurl {
     urls = [
       "https://www.aleksey.com/xmlsec/download/xmlsec1-${finalAttrs.version}.tar.gz"
@@ -39,13 +41,15 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    substituteAllInPlace src/dl.c
+    substituteInPlace src/dl.c --replace-fail "@out@" "$out"
   '';
 
   outputs = [
     "out"
     "dev"
   ];
+
+  strictDeps = true;
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/python-modules/xmlsec/default.nix
+++ b/pkgs/development/python-modules/xmlsec/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   pkgconfig,
@@ -37,6 +38,20 @@ buildPythonPackage (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-p3V75DLUI2PKdharP3/0HrKOgma9Kh3lAOZLRAQjo80=";
   };
+
+  patches = [
+    # https://github.com/lsh123/xmlsec/issues/1148
+    # https://github.com/xmlsec/python-xmlsec/pull/422
+    (fetchpatch {
+      name = "xmlsec-1.3.11-test-compatibility.patch";
+      url = "https://github.com/xmlsec/python-xmlsec/commit/5e8b4e6aa133c358b8aaf8e17ceb5b3b7fea78e8.patch";
+      includes = [
+        "src/*"
+        "tests/*"
+      ];
+      hash = "sha256-+J2L6oq802/534qIDvFqsWYfn9LExRlXXIeDvVqZEYk=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \


### PR DESCRIPTION
changelog: https://www.aleksey.com/xmlsec/news.html

see the individual commits; each is relatively straightforward. the whitespace changes in the first commit fuck up a diff unless you have an ast-aware diff tool (e.g. difftastic), so it's probably best viewed commit-by-commit.

the reverse closure has far too many hefty deps to run a nixpkgs-review, but i did build a few assorted dependencies out of the eval summary just fine on x86_64-linux: `python3Packages.xmlsec`, `pretix`, `authentik`, `mailmanPackages.hyperkitty`, `mailmanPackages.postorius`, `mailmanPackages.web`, `netbox`, `openscap`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
