### PR TITLE
unsloth-desktop: add updateScript, fix runtime gaps; 0.1.804-beta -> 0.1.806-beta

### DIFF
--- a/pkgs/by-name/un/unsloth-desktop/package.nix
+++ b/pkgs/by-name/un/unsloth-desktop/package.nix
@@ -3,12 +3,14 @@
   stdenv,
   cacert,
   buildFHSEnv,
+  nix-update-script,
   fetchurl,
   dpkg,
+  glib-networking,
 }:
 
 let
-  version = "0.1.804-beta";
+  version = "0.1.808-beta";
 
   unsloth-desktop-unwrapped = stdenv.mkDerivation {
     pname = "unsloth-desktop-unwrapped";
@@ -16,7 +18,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/unslothai/unsloth/releases/download/v${version}/Unsloth-Desktop-Ubuntu.deb";
-      hash = "sha256-DrHbR7pGeTtvlPIDZD0SPO6pUf792Rskd1x1ANMmpfw=";
+      hash = "sha256-cyKUax4L5foIOT6RyOeGnbH72kpLFKjWtYv0cJszkLw=";
     };
 
     nativeBuildInputs = [ dpkg ];
@@ -60,11 +62,15 @@ buildFHSEnv {
       libnghttp2
       nodejs_24
       cacert
+      gcc
+      pciutils
     ];
 
   profile = ''
     export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
+    export GIO_EXTRA_MODULES="${glib-networking}/lib/gio/modules:$GIO_EXTRA_MODULES"
     export WEBKIT_DISABLE_DMABUF_RENDERER=1
+    export CC=gcc
   '';
 
   runScript = "${unsloth-desktop-unwrapped}/usr/bin/unsloth-studio";
@@ -78,7 +84,13 @@ buildFHSEnv {
       $out/share/icons/hicolor/128x128/apps/unsloth-studio.png
   '';
 
-  passthru = { inherit unsloth-desktop-unwrapped; };
+  passthru = {
+    inherit unsloth-desktop-unwrapped;
+    updateScript = nix-update-script {
+      attrPath = "unsloth-desktop.unsloth-desktop-unwrapped";
+      extraArgs = [ "--version=unstable" ];
+    };
+  };
 
   meta = {
     description = "Desktop application for running and training AI models locally";


### PR DESCRIPTION
Follow-up to #559716 (`unsloth-desktop: init at 0.1.804-beta`, merged). This PR makes four changes to the package:

- **add updateScript** — wired to the `unsloth-desktop-unwrapped` subpackage via `attrPath`, because the top-level `buildFHSEnv` derivation has no `src` for nix-update to work with. Uses `--version=unstable` since upstream only publishes `X.Y.Z-beta` tags, which nix-update's stable-version filter rejects.
- **0.1.804-beta -> 0.1.806-beta** — performed with `nix-update --version=unstable unsloth-desktop.unsloth-desktop-unwrapped`.
- **add gcc to the FHS environment** — Triton JIT-compiles training kernels at runtime and needs a C compiler (read from the `CC` env var or `PATH`); without one, QLoRA training fails with `Failed to find C compiler`. The upstream installer relies on apt-installed gcc outside NixOS.
- **add pciutils to the FHS environment** — the app's runtime installer resolves AMD GPU gfx targets via a `lspci` name lookup; without it, AMD hosts silently fall back to CPU-only torch.

Verified on NixOS x86_64-linux: built the package, launched it, and ran a QLoRA fine-tune of `unsloth/Llama-3.2-3B-Instruct-bnb-4bit` end-to-end — training previously failed at the Triton compile step (`Failed to find C compiler`) and now completes. The package is a `pkgs/by-name` leaf with zero reverse dependencies.

Changelog: <https://github.com/unslothai/unsloth/releases/tag/v0.1.806-beta>

**AI disclosure**: this contribution was prepared with LLM assistance (opencode CLI, model glm-5.3-flash), per the [automation/AI policy]; the updateScript, gcc and pciutils commits carry the required `Assisted-by:` trailers. I reviewed all changes and verified the package on NixOS x86_64-linux: build, launch, and an end-to-end QLoRA training run that previously failed at the Triton compile step.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
