### PR TITLE
agent-browser: 0.27.0 -> 0.36.0

### DIFF
--- a/pkgs/by-name/ag/agent-browser/package.nix
+++ b/pkgs/by-name/ag/agent-browser/package.nix
@@ -5,7 +5,7 @@
   fetchPnpmDeps,
   rustPlatform,
   nodejs,
-  pnpm_10,
+  pnpm_11,
   pnpmConfigHook,
   geist-font,
   nix-update-script,
@@ -14,15 +14,15 @@
 }:
 
 let
-  pnpm = pnpm_10;
+  pnpm = pnpm_11;
 
-  version = "0.27.0";
+  version = "0.36.0";
 
   src = fetchFromGitHub {
     owner = "vercel-labs";
     repo = "agent-browser";
     tag = "v${version}";
-    hash = "sha256-c+AJAXMX88t+zzFsEAtFJDjDY5EbhmEyMRGFL4t63nE=";
+    hash = "sha256-HzX1M1Gdd9N0iYxiEGuWrV3fc7yNevGiOvc/0csttZA=";
   };
 
   # The Rust CLI embeds the dashboard UI via RustEmbed at compile time.
@@ -43,8 +43,8 @@ let
       pname = "agent-browser-dashboard";
       inherit version src pnpm;
       pnpmWorkspaces = [ "dashboard" ];
-      fetcherVersion = 3;
-      hash = "sha256-ldxmXpejqVN/xuWcdLYMwNPc1VZ1rdNwRrumy8Is3N4=";
+      fetcherVersion = 4;
+      hash = "sha256-AEWwJtzmAUspGwFrMqoCvUfefPg2aTvMilBfJPSF9jA=";
     };
 
     pnpmWorkspaces = [ "dashboard" ];
@@ -83,7 +83,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/cli";
 
-  cargoHash = "sha256-2u7yokHCxIVq16370Mg+n5kf03yUDYJmctFxN1fnaAA=";
+  cargoHash = "sha256-6xphNOYi+tJvFlprY8DCVw1XzVFapqFQfeIy0w2pyCs=";
 
   # Place the pre-built dashboard where RustEmbed expects it
   postUnpack = ''
@@ -94,12 +94,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # `which_exists` spawns the external `which` binary at runtime to probe
   # for optional tools; pin it to an absolute store path.
   postPatch = ''
-    substituteInPlace src/doctor/helpers.rs src/install.rs --replace-fail \
+    substituteInPlace src/doctor/helpers.rs src/install.rs \
+      src/native/cdp/chrome.rs src/native/cdp/lightpanda.rs --replace-fail \
       '"which"' '"${lib.getExe which}"'
   '';
 
   nativeCheckInputs = [
     writableTmpDirAsHomeHook
+  ];
+
+  # Flaky test: reads the AGENT_BROWSER_CDP env variable without using the
+  # shared test lock.
+  checkFlags = [
+    "--skip"
+    "native::actions::tests::test_execute_unknown_command"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Changelog: https://github.com/vercel-labs/agent-browser/blob/v0.36.0/CHANGELOG.md

Updated to pnpm 11 with `fetcherVersion = 4`. I needed to skip a flaky test for the package to build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ x Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
