### PR TITLE
opencode: 1.18.28 -> 1.18.29

### DIFF
--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -84,7 +84,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "1.18.28";
+  version = "1.18.29";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "anomalyco";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RuKE0unlDJThKpgnEyoR6X9k5bs6Jrv1zhQShSG2dc8=";
+    hash = "sha256-lCXlxTOhcX70jxJAbpolyGlIxQK2nst+6bFhq3Xzdmc=";
   };
 
   postPatch =


### PR DESCRIPTION
## Motivation

Update OpenCode from 1.18.28 to the latest released version, [v1.18.29](https://github.com/anomalyco/opencode/releases/tag/v1.18.29).

This release includes the OpenAI/Codex provider fix for `openai/gpt-6-astra`.

Upstream fixes: https://github.com/anomalyco/opencode/pull/47384 and https://github.com/anomalyco/opencode/pull/47385


## Things Done

- [x] Built `opencode` and `opencode-desktop` on `x86_64-linux`.
- [x] Passed the CLI's `--version` installation check and generated shell completions.
- [x] Ran upstream `test/plugin/codex.test.ts` in an isolated Nix derivation: 45 passed, 0 failed, including the GPT-6 Astra regression cases.
- [x] Ran the package's treefmt checks and `git diff --check`.
- [x] Ran `nixpkgs-review` on this PR: [3 builds passed](https://github.com/NixOS/nixpkgs/pull/560598#issuecomment-5560611057).

Interactive desktop sessions and authenticated API calls were not tested.

## Automation

OpenCode (`openai/gpt-6-astra`) assisted with the package update, validation, and this PR description.