### PR TITLE
nixos/incus/virtual-machine: switch to repart image for more customization

### DIFF
--- a/nixos/modules/virtualisation/incus-virtual-machine.nix
+++ b/nixos/modules/virtualisation/incus-virtual-machine.nix
@@ -14,6 +14,7 @@ in
   };
 
   imports = [
+    ../image/repart.nix
     ./lxc-instance-common.nix
 
     ../profiles/qemu-guest.nix
@@ -26,6 +27,50 @@ in
       partitionTableType = "efi";
       format = "qcow2-compressed";
       copyChannel = config.system.installer.channel.enable;
+    };
+
+    system.build.repartImage = config.image.repart.image.overrideAttrs (previousAttrs: {
+      nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [ pkgs.qemu-utils ];
+      postBuild = ''
+        qemu-img convert -f raw -O qcow2 -c ${config.image.baseName}.raw ${config.image.baseName}.qcow2
+        rm ${config.image.baseName}.raw
+      '';
+    });
+
+    image.repart = {
+      name = "nixos";
+      version = null;
+      sectorSize = 512;
+      compression.enable = false;
+      partitions = {
+        esp = {
+          contents =
+            let
+              efiArch = pkgs.stdenv.hostPlatform.efiArch;
+            in
+            {
+              "/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI".source =
+                "${config.systemd.package}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
+              "/EFI/Linux/${config.system.boot.loader.ukiFile}".source =
+                "${config.system.build.uki}/${config.system.boot.loader.ukiFile}";
+            };
+          repartConfig = {
+            Type = "esp";
+            Format = "vfat";
+            Label = "ESP";
+            SizeMinBytes = if pkgs.stdenv.hostPlatform.isx86_64 then "64M" else "96M";
+          };
+        };
+        root = {
+          storePaths = [ config.system.build.toplevel ];
+          repartConfig = {
+            Type = "root";
+            Format = "ext4";
+            Label = "nixos";
+            Minimize = "guess";
+          };
+        };
+      };
     };
 
     fileSystems = {

--- a/nixos/modules/virtualisation/incus-virtual-machine.nix
+++ b/nixos/modules/virtualisation/incus-virtual-machine.nix
@@ -44,6 +44,10 @@ in
       version = null;
       sectorSize = 512;
       compression.enable = false;
+      mkfsOptions.ext4 = [
+        "-i"
+        "8192"
+      ];
       partitions = {
         esp = {
           contents = {

--- a/nixos/modules/virtualisation/incus-virtual-machine.nix
+++ b/nixos/modules/virtualisation/incus-virtual-machine.nix
@@ -7,6 +7,8 @@
 
 let
   serialDevice = if pkgs.stdenv.hostPlatform.isx86 then "ttyS0" else "ttyAMA0";
+
+  efiArch = pkgs.stdenv.hostPlatform.efiArch;
 in
 {
   meta = {
@@ -44,21 +46,18 @@ in
       compression.enable = false;
       partitions = {
         esp = {
-          contents =
-            let
-              efiArch = pkgs.stdenv.hostPlatform.efiArch;
-            in
-            {
-              "/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI".source =
-                "${config.systemd.package}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
-              "/EFI/Linux/${config.system.boot.loader.ukiFile}".source =
-                "${config.system.build.uki}/${config.system.boot.loader.ukiFile}";
-            };
+          contents = {
+            "/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI".source =
+              "${config.systemd.package}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
+            "/EFI/Linux/${config.system.boot.loader.ukiFile}".source =
+              "${config.system.build.uki}/${config.system.boot.loader.ukiFile}";
+          };
+
           repartConfig = {
             Type = "esp";
             Format = "vfat";
             Label = "ESP";
-            SizeMinBytes = if pkgs.stdenv.hostPlatform.isx86_64 then "64M" else "96M";
+            SizeMinBytes = "256M";
           };
         };
         root = {
@@ -68,6 +67,7 @@ in
             Format = "ext4";
             Label = "nixos";
             Minimize = "guess";
+            PaddingMinBytes = "512M";
           };
         };
       };

--- a/nixos/modules/virtualisation/incus-virtual-machine.nix
+++ b/nixos/modules/virtualisation/incus-virtual-machine.nix
@@ -33,9 +33,16 @@ in
 
     system.build.repartImage = config.image.repart.image.overrideAttrs (previousAttrs: {
       nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [ pkgs.qemu-utils ];
+
       postBuild = ''
         qemu-img convert -f raw -O qcow2 -c ${config.image.baseName}.raw ${config.image.baseName}.qcow2
         rm ${config.image.baseName}.raw
+      '';
+
+      # expose a hydra build product so lxc-ci can download it
+      postInstall = ''
+        mkdir $out/nix-support
+        echo "file qcow2-image $out/${config.image.baseName}.qcow2" > $out/nix-support/hydra-build-products
       '';
     });
 

--- a/nixos/modules/virtualisation/incus-virtual-machine.nix
+++ b/nixos/modules/virtualisation/incus-virtual-machine.nix
@@ -61,7 +61,8 @@ in
             Type = "esp";
             Format = "vfat";
             Label = "ESP";
-            SizeMinBytes = "256M";
+            # support 10 kernels, assuming 50MB on x86 and 100MB on aarch64
+            SizeMinBytes = if pkgs.stdenv.hostPlatform.isx86 then "512M" else "1G";
           };
         };
         root = {

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -437,7 +437,7 @@ rec {
               versionModule
               ./maintainers/scripts/incus/incus-virtual-machine-image.nix
             ];
-          }).config.system.build.qemuImage
+          }).config.system.build.repartImage
         )
       );
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

LLM assisted.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
