### PR TITLE
smc-manjari: use installFonts

### DIFF
--- a/pkgs/by-name/sm/smc-manjari/package.nix
+++ b/pkgs/by-name/sm/smc-manjari/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchFromGitLab,
   python3Packages,
+  installFonts,
   gnumake,
   truetype ? false,
 }:
@@ -22,21 +23,16 @@ stdenvNoCC.mkDerivation rec {
   nativeBuildInputs = [
     gnumake
     python3Packages.fontmake
+    installFonts
   ];
 
   buildFlags = [ "otf" ] ++ lib.optional truetype "ttf";
 
-  installPhase = ''
-    runHook preInstall
+  makeFlags = [ "INSTALLPATH=." ];
 
-    install -Dm444 -t $out/share/fonts/opentype build/*.otf
-    ${lib.optionalString truetype "install -Dm444 -t $out/share/fonts/truetype build/*.ttf"}
-
+  postInstall = ''
     install -Dm644 -t $out/etc/fonts/conf.d *.conf
-
     install -Dm644 -t $out/share/doc/${pname}-${version} OFL.txt FONTLOG.md
-
-    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #495640 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
