### PR TITLE
protobuf: add `meta.pkgConfigModules`, split outputs

### DIFF
--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -186,6 +186,10 @@ stdenv.mkDerivation (finalAttrs: {
       inherit (python3.pkgs) celery;
 
       version = testers.testVersion { package = protobuf; };
+
+      pkg-config = testers.hasPkgConfigModules {
+        package = protobuf;
+      };
     };
 
     inherit abseil-cpp;
@@ -203,5 +207,15 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://protobuf.dev/";
     maintainers = with lib.maintainers; [ GaetanLepage ];
     mainProgram = "protoc";
+    pkgConfigModules = [
+      "protobuf"
+      "protobuf_lite"
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "22") [
+      "utf8_range"
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "27") [
+      "upb"
+    ];
   };
 })

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -37,6 +37,12 @@ stdenv.mkDerivation (finalAttrs: {
     inherit hash;
   };
 
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
   patches =
     lib.optionals (lib.versionOlder version "22") [
       # fix protobuf-targets.cmake installation paths, and allow for CMAKE_INSTALL_LIBDIR to be absolute


### PR DESCRIPTION
Before:

```console
$ du -sh $(nix-build -A protobuf.all)
 19M    /nix/store/r1npr0vx8d17c0fhh9gvg9mpaiphn62a-protobuf-36.1
```

After:

```console
$ du -sh $(nix-build -A protobuf.all)
1.8M    /nix/store/mvyq35lnzcbdjd8jhf1dkkk5mcz3hk9a-protobuf-36.1
 12M    /nix/store/wkawprc7k8mll2pypcff9876cpd2h365-protobuf-36.1-lib
5.7M    /nix/store/vb3hq2n7zc22dbplvvbypf7b0f8yvjgw-protobuf-36.1-dev
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
