### PR TITLE
nixos/systemd-confinement: fix with PrivateTmp=disconnected

### DIFF
--- a/nixos/modules/security/systemd-confinement.nix
+++ b/nixos/modules/security/systemd-confinement.nix
@@ -236,7 +236,8 @@ in
 
               # If DynamicUser= is enabled, PrivateTmp=true is implied (and cannot be turned off).
               # so disable them unless PrivateTmp=true is explicitely set.
-              ${lib.optionalString (!cfg.serviceConfig.PrivateTmp) ''
+              # We're explicitely comparing to `false` here, because PrivateTmp can also be "disconnected".
+              ${lib.optionalString (cfg.serviceConfig.PrivateTmp == false) ''
                 echo "InaccessiblePaths=-+/tmp" >> "$serviceFile"
                 echo "InaccessiblePaths=-+/var/tmp" >> "$serviceFile"
               ''}

--- a/nixos/tests/systemd-confinement/default.nix
+++ b/nixos/tests/systemd-confinement/default.nix
@@ -94,7 +94,17 @@ import ../make-test-python.nix {
           (
             { user, privateTmp }:
             let
-              withTmp = if privateTmp then "with PrivateTmp" else "without PrivateTmp";
+              isPrivateTmp = lib.elem privateTmp [
+                true
+                "disconnected"
+              ];
+              withTmp =
+                if privateTmp == true then
+                  "with PrivateTmp=true"
+                else if privateTmp == "disconnected" then
+                  "with PrivateTmp=disconnected"
+                else
+                  "without PrivateTmp";
 
               serviceConfig =
                 if user == "static-user" then
@@ -118,7 +128,7 @@ import ../make-test-python.nix {
                   # Only set if privateTmp is true to ensure that the default is false.
                   serviceConfig =
                     serviceConfig
-                    // lib.optionalAttrs privateTmp {
+                    // lib.optionalAttrs isPrivateTmp {
                       PrivateTmp = true;
                     };
                 };
@@ -132,9 +142,9 @@ import ../make-test-python.nix {
                         'bin': Accessibility.READABLE,
                         'nix': Accessibility.READABLE,
                         'run': Accessibility.READABLE,
-                        ${lib.optionalString privateTmp "'tmp': Accessibility.STICKY,"}
-                        ${lib.optionalString privateTmp "'var': Accessibility.READABLE,"}
-                        ${lib.optionalString privateTmp "'var/tmp': Accessibility.STICKY,"}
+                        ${lib.optionalString isPrivateTmp "'tmp': Accessibility.STICKY,"}
+                        ${lib.optionalString isPrivateTmp "'var': Accessibility.READABLE,"}
+                        ${lib.optionalString isPrivateTmp "'var/tmp': Accessibility.STICKY,"}
                       })
                     ''
                   else
@@ -146,9 +156,9 @@ import ../make-test-python.nix {
                         'bin': Accessibility.READABLE,
                         'nix': Accessibility.READABLE,
                         'run': Accessibility.READABLE,
-                        ${lib.optionalString privateTmp "'tmp': Accessibility.STICKY,"}
-                        ${lib.optionalString privateTmp "'var': Accessibility.READABLE,"}
-                        ${lib.optionalString privateTmp "'var/tmp': Accessibility.STICKY,"}
+                        ${lib.optionalString isPrivateTmp "'tmp': Accessibility.STICKY,"}
+                        ${lib.optionalString isPrivateTmp "'var': Accessibility.READABLE,"}
+                        ${lib.optionalString isPrivateTmp "'var/tmp': Accessibility.STICKY,"}
                       })
                     '';
               }
@@ -158,7 +168,7 @@ import ../make-test-python.nix {
                   # Only set if privateTmp is false to ensure that the default is true.
                   serviceConfig =
                     serviceConfig
-                    // lib.optionalAttrs (!privateTmp) {
+                    // lib.optionalAttrs (!isPrivateTmp) {
                       PrivateTmp = false;
                     };
                 };
@@ -171,15 +181,15 @@ import ../make-test-python.nix {
                       assert_permissions({
                         'bin': Accessibility.READABLE,
                         'nix': Accessibility.READABLE,
-                        ${lib.optionalString privateTmp "'tmp': Accessibility.STICKY,"}
+                        ${lib.optionalString isPrivateTmp "'tmp': Accessibility.STICKY,"}
                         'run': Accessibility.WRITABLE,
 
                         'proc': Accessibility.SPECIAL,
                         'sys': Accessibility.SPECIAL,
                         'dev': Accessibility.WRITABLE,
 
-                        ${lib.optionalString privateTmp "'var': Accessibility.READABLE,"}
-                        ${lib.optionalString privateTmp "'var/tmp': Accessibility.STICKY,"}
+                        ${lib.optionalString isPrivateTmp "'var': Accessibility.READABLE,"}
+                        ${lib.optionalString isPrivateTmp "'var/tmp': Accessibility.STICKY,"}
                       })
                     ''
                   else
@@ -190,7 +200,7 @@ import ../make-test-python.nix {
                       assert_permissions({
                         'bin': Accessibility.READABLE,
                         'nix': Accessibility.READABLE,
-                        ${lib.optionalString privateTmp "'tmp': Accessibility.STICKY,"}
+                        ${lib.optionalString isPrivateTmp "'tmp': Accessibility.STICKY,"}
                         'run': Accessibility.STICKY,
 
                         'proc': Accessibility.SPECIAL,
@@ -199,8 +209,8 @@ import ../make-test-python.nix {
                         'dev/shm': Accessibility.STICKY,
                         'dev/mqueue': Accessibility.STICKY,
 
-                        ${lib.optionalString privateTmp "'var': Accessibility.READABLE,"}
-                        ${lib.optionalString privateTmp "'var/tmp': Accessibility.STICKY,"}
+                        ${lib.optionalString isPrivateTmp "'var': Accessibility.READABLE,"}
+                        ${lib.optionalString isPrivateTmp "'var/tmp': Accessibility.STICKY,"}
                       })
                     '';
               }
@@ -216,6 +226,7 @@ import ../make-test-python.nix {
               privateTmp = [
                 true
                 false
+                "disconnected"
               ];
             }
           );


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
