### PR TITLE
weylus: migrate to typescript 7

### DIFF
--- a/pkgs/by-name/we/weylus/package.nix
+++ b/pkgs/by-name/we/weylus/package.nix
@@ -31,11 +31,12 @@
   typescript_5,
   wayland,
   libxkbcommon,
+  unstableGitUpdater,
 }:
 
 rustPlatform.buildRustPackage {
   pname = "weylus";
-  version = "unstable-2025-10-08";
+  version = "0.11.4-unstable-2025-10-08";
 
   src = fetchFromGitHub {
     owner = "H-M-H";
@@ -105,6 +106,10 @@ rustPlatform.buildRustPackage {
     NIX_CFLAGS_COMPILE = toString [
       "-Wno-incompatible-pointer-types"
     ];
+  };
+
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
   };
 
   meta = {

--- a/pkgs/by-name/we/weylus/package.nix
+++ b/pkgs/by-name/we/weylus/package.nix
@@ -28,7 +28,8 @@
   git,
   autoconf,
   libtool,
-  typescript_5,
+  yq-go,
+  typescript_7,
   wayland,
   libxkbcommon,
   unstableGitUpdater,
@@ -44,6 +45,10 @@ rustPlatform.buildRustPackage {
     rev = "56e29ecbde3a4aba994a9df047b5398feb447c1b";
     hash = "sha256-dHdgWrygSXqKf9fpYRVDj+Ql97Or/kjBfN/mECy2ipc=";
   };
+
+  postPatch = ''
+    yq -i '.compilerOptions += {"strict": false, "rootDir": "ts"}' tsconfig.json
+  '';
 
   buildInputs = [
     ffmpeg
@@ -73,7 +78,8 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     cmake
     git
-    typescript_5
+    yq-go
+    typescript_7
     makeWrapper
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
