### PR TITLE
maple-font: use installFonts

### DIFF
--- a/pkgs/data/fonts/maple-font/default.nix
+++ b/pkgs/data/fonts/maple-font/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   unzip,
   fetchurl,
+  installFonts,
 }:
 
 let
@@ -14,6 +15,7 @@ let
       pname,
       hash,
       desc,
+      suffix,
     }:
     stdenv.mkDerivation rec {
       inherit pname;
@@ -26,12 +28,15 @@ let
       # Work around the "unpacker appears to have produced no directories"
       # case that happens when the archive doesn't have a subdirectory.
       sourceRoot = ".";
-      nativeBuildInputs = [ unzip ];
-      installPhase = ''
-        find . -name '*.ttf'    -exec install -Dt $out/share/fonts/truetype {} \;
-        find . -name '*.otf'    -exec install -Dt $out/share/fonts/opentype {} \;
-        find . -name '*.woff2'  -exec install -Dt $out/share/fonts/woff2 {} \;
-      '';
+      nativeBuildInputs = [
+        installFonts
+        unzip
+      ];
+
+      # installFonts checks if "$webfont" exists and copies any woff files there,
+      # this is typically done with a second "webfont" output, resulting in a second derivation
+      # we set this to `placeholder "out"` to keep webfonts in the same derivation instead
+      webfont = lib.optionalString (suffix == "Woff2") (placeholder "out");
 
       meta = {
         homepage = "https://github.com/subframe7536/Maple-font";
@@ -129,6 +134,7 @@ let
             inherit pname;
             desc = "${ligVariant.desc} ${typeVariant.desc}";
             hash = hashes.${pname};
+            inherit (typeVariant) suffix;
           };
         }
       ) typeVariants
@@ -142,6 +148,7 @@ let
         inherit pname;
         inherit (value) desc;
         hash = hashes.${pname};
+        inherit (value) suffix;
       }
     ) typeVariants;
 in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #495640 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
