### PR TITLE
xtables-addons: init at 3.31 and adjust iptables

### DIFF
--- a/pkgs/by-name/ip/iptables/package.nix
+++ b/pkgs/by-name/ip/iptables/package.nix
@@ -16,6 +16,8 @@
   bashNonInteractive,
   nftablesCompat ? true,
   gitUpdater,
+  xtablesAddons ? false,
+  xtables-addons,
 
   # For tests
   vmTools,
@@ -77,15 +79,22 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  postInstall = lib.optionalString nftablesCompat ''
-    rm $out/sbin/{iptables,iptables-restore,iptables-save,ip6tables,ip6tables-restore,ip6tables-save}
-    ln -sv xtables-nft-multi $out/bin/iptables
-    ln -sv xtables-nft-multi $out/bin/iptables-restore
-    ln -sv xtables-nft-multi $out/bin/iptables-save
-    ln -sv xtables-nft-multi $out/bin/ip6tables
-    ln -sv xtables-nft-multi $out/bin/ip6tables-restore
-    ln -sv xtables-nft-multi $out/bin/ip6tables-save
-  '';
+  postInstall =
+    lib.optionalString nftablesCompat ''
+      rm $out/sbin/{iptables,iptables-restore,iptables-save,ip6tables,ip6tables-restore,ip6tables-save}
+      ln -sv xtables-nft-multi $out/bin/iptables
+      ln -sv xtables-nft-multi $out/bin/iptables-restore
+      ln -sv xtables-nft-multi $out/bin/iptables-save
+      ln -sv xtables-nft-multi $out/bin/ip6tables
+      ln -sv xtables-nft-multi $out/bin/ip6tables-restore
+      ln -sv xtables-nft-multi $out/bin/ip6tables-save
+    ''
+    + (lib.optionalString xtablesAddons ''
+      find "${xtables-addons.out}/lib/xtables" \
+        -type f \
+        -name "*.so" \
+        -exec install -pm0755 '{}' "$lib/lib/xtables/" \; ;
+    '');
 
   outputChecks.lib.disallowedRequisites = [
     bash

--- a/pkgs/by-name/xt/xtables-addons/package.nix
+++ b/pkgs/by-name/xt/xtables-addons/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  pkg-config,
+  fetchFromCodeberg,
+  coreutils,
+  gnumake,
+  zstd,
+  autoreconfHook,
+  iptables,
+  kernel ? null,
+  ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xtables-addons";
+  version = "3.31";
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  src = fetchFromCodeberg {
+    owner = "jengelh";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-jjcpiSwTL3wvDFzaUpaCsA543c+eloQ9KVgWJE0sEv8=";
+  };
+
+  nativeBuildInputs = [
+    coreutils
+    gnumake
+    zstd
+    autoreconfHook
+    pkg-config
+  ]
+  ++ lib.optionals (kernel != null) kernel.moduleBuildDependencies;
+
+  buildInputs = [
+    ## Prevent infinite recursion
+    (iptables.override { xtablesAddons = false; })
+  ];
+
+  hardeningDisable = lib.optionals (kernel != null) [
+    "pic"
+    "format"
+  ];
+
+  env = {
+    DESTDIR = placeholder "out";
+  };
+
+  configureFlags = [
+    ## NOTE: it would be cool to re-use `DESTDIR` but Makefiles do not like it
+    # "--libdir=$DESTDIR/lib"
+    "--libdir=${placeholder "out"}/lib"
+  ]
+  ++ lib.optionals (kernel == null) [
+    "--without-kbuild"
+  ]
+  ++ (lib.optionals (kernel != null) [
+    "--with-kbuild=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ]);
+
+  makeFlags = lib.optionals (kernel != null) [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ];
+
+  installFlags = [
+    "xtlibdir=lib/xtables"
+  ];
+
+  postInstall = ''
+    find "$out" -type f -name '*.ko' -exec printf '%s\n' {} \; ;
+  '';
+
+  meta = {
+    description = "Xtables-addons is a set of extensions that were not accepted in the Linux kernel and/or main Xtables/iptables package";
+    homepage = "https://inai.de/projects/xtables-addons/";
+    changelog = "https://codeberg.org/jengelh/xtables-addons/src/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ S0AndS0 ];
+  };
+})


### PR DESCRIPTION
Adds iptables addons such as `TARPIT` target which, when configured correctly, is fantastic for teaching web-scrapers some respect ;-]

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## Quick start


### Build **without** Kernel modules

```nix
{
  config,
  ...
}:
let
  nixpkgs_xtables-addons = import /home/s0ands0/git/hub/NixOS/nixpkgs/wt/xtables-addons { };

  iptables = nixpkgs_xtables-addons.iptables.override {
    xtablesAddons = true;
  };
in
{
  networking.firewall = {
    enable = true;
    package = iptables;
  };
}
```

### Build **with** Kernel modules

```nix
{
  config,
  ...
}:
let
  nixpkgs_xtables-addons = import /home/s0ands0/git/hub/NixOS/nixpkgs/wt/xtables-addons { };

  xtables-addons = nixpkgs_xtables-addons.xtables-addons.override {
    kernel = config.boot.kernelPackages.kernel;
  };

  iptables = nixpkgs_xtables-addons.iptables.override {
    inherit xtables-addons;
    xtablesAddons = true;
  };
in
{
  networking.firewall = {
    enable = true;
    package = iptables;
  };

  boot.extraModulePackages = [
    xtables-addons
  ];
}
```


______


## Notes


After re-build the following may be useful to check things built correctly;

`modprobe --dry-run --verbose -b /run/current-system/kernel-modules xt_CHAOS`

`modinfo "/run/current-system/kernel-modules/lib/modules/$(uname -r)/updates/xt_CHAOS.ko.xz"`

... Because, by default, `modprobe` (and friends) check `/run/booted-system/kernel-modules` not the `current-system` sub-directory.  Which is a sane default!

After reboot modules _should_ be available without special paths, they were for me :-]

Which means, **after reboot**, it should be possible to auto-load via;

```nix
  boot.kernelModules = [
    "xt_TARPIT"
    # ...
  ];
```

A list of available modules may be generated via;

```bash
ls /run/current-system/kernel-modules/lib/modules/$(uname -r)/updates/xt_*.ko.xz |
  awk 'BEGIN {
    FS="/";
  }
  {
    gsub(".ko.xz$", "");
    print $NF;
  }'
```

... Or via;

```bash
ls ~/git/codeberg/jengelh/xtables-addons.git/wt/master/extensions/xt_*.c |
  awk 'BEGIN {
    FS="/";
  }
  {
    gsub(".c$", "");
    print $NF;
  }'
```

As of 2026-09-06 to load all available modules (which is untested) may require something similar to;

```nix
  boot.kernelModules = [
    "xt_asn"
    "xt_CHAOS"
    "xtondition"
    "xt_DELUDE"
    "xt_DHCPMAC"
    "xt_DNETMAP"
    "xt_ECHO"
    "xt_fuzzy"
    "xt_geoip"
    "xt_ife"
    "xt_IPMARK"
    "xt_ipp2p"
    "xt_ipv4options"
    "xt_length2"
    "xt_LOGMARK"
    "xt_lan"
    "xt_PROTO"
    "xt_psd"
    "xt_quota2"
    "xt_SYSRQ"
    "xt_TARPIT"
  ];
```


______


## Warnings


Using `kernelModuleMakeFlags` within `makeFlags` list results in build errors;

```
/nix/store/<NAR_00>-gcc-15.3.0/bin/gcc  -shared  -o libxt_CHAOS.so libxt_CHAOS.oo -L/nix/store/<NAR_01>-iptables-1.8.13-lib/lib -lxtables ;
/nix/store/<NAR_02>-binutils-2.46/bin/ld.bfd: cannot find crti.o: No such file or directory
/nix/store/<NAR_02>-binutils-2.46/bin/ld.bfd: cannot find -lgcc_s: No such file or directory
```


______


## Attributions


- [Codeberg -- `jengelh/xtables-addons`](https://codeberg.org/jengelh/xtables-addons)
- [GitHub -- NixOS/nixpkgs -- `pkgs/by-name/ch/chipsec/package.nix`](https://github.com/NixOS/nixpkgs/blob/7f546b4208bd576c24a4922bd25198bafbc1bdd0/pkgs/by-name/ch/chipsec/package.nix)
- [NixOS Wiki -- Linux kernel -- Out of tree kernel modules](https://wiki.nixos.org/wiki/Linux_kernel#Out-of-tree_kernel_modules)
- [NixOS discourse -- How to add a local package to `boot.extraModulePackages`](https://discourse.nixos.org/t/how-to-add-a-local-package-to-boot-extramodulepackages/36614)
- [Practicing Pragmatism -- Building kernel modules on NixOS](https://blog.prag.dev/building-kernel-modules-on-nixos)


______


## Edits and updates

### 2026-09-06 20:54

I believe I've satisfied the CI/CD linter(s), however, also believe adjustments to `nixos/modules/services/networking/firewall.nix` may make things somewhat easier for users, so would be open to maybe implementing reasonable suggestions there

Also also, I think `meta.platforms` should be added to `xtables-addons`, and am tempted to yoink this value from `iptables.meta.platforms`, but figured it wise to hold-off on force pushing that change until told that's a bad/good idea

I've tested that `iptables -N test && iptables -A test -p tcp -j TARPIT` executes without errors, but am reasonably certain instructions from [Gist -- flaviovs](https://gist.github.com/flaviovs/103a0dbf62c67ff371ff75fc62fdded3) would be wiser to adopt