### PR TITLE
python3Packages.oss2: 2.18.3 -> 2.19.1

### DIFF
--- a/pkgs/development/python-modules/oss2/default.nix
+++ b/pkgs/development/python-modules/oss2/default.nix
@@ -5,7 +5,7 @@
   aliyun-python-sdk-sts,
   buildPythonPackage,
   crcmod,
-  fetchFromGitHub,
+  fetchPypi,
   mock,
   pycryptodome,
   pytestCheckHook,
@@ -15,14 +15,12 @@
 
 buildPythonPackage rec {
   pname = "oss2";
-  version = "2.18.3";
+  version = "2.19.1";
   format = "setuptools";
 
-  src = fetchFromGitHub {
-    owner = "aliyun";
-    repo = "aliyun-oss-python-sdk";
-    tag = version;
-    hash = "sha256-jDSXPVyy8XvPgsGZXsdfavFPptq28pCwr9C63OZvNrY=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-qKue5+uZ6Ip+E4LtxupkHSGdWFp+B043duneyUc+WcE=";
   };
 
   propagatedBuildInputs = [
@@ -46,12 +44,16 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # Tests require network access
+    "tests/test_access_point.py"
     "tests/test_api_base.py"
     "tests/test_async_fetch_task.py"
+    "tests/test_bucket_archive_direct_read.py"
     "tests/test_bucket_access_monitor.py"
     "tests/test_bucket_callback_policy.py"
     "tests/test_bucket_cname.py"
+    "tests/test_bucket_data_redundancy_transition.py"
     "tests/test_bucket_describe_regions.py"
+    "tests/test_bucket_https_config.py"
     "tests/test_bucket_inventory.py"
     "tests/test_bucket_meta_query.py"
     "tests/test_bucket_replication.py"
@@ -82,7 +84,9 @@ buildPythonPackage rec {
     "tests/test_object_versioning.py"
     "tests/test_object.py"
     "tests/test_proxy.py"
+    "tests/test_public_access_block.py"
     "tests/test_put_object_chunked.py"
+    "tests/test_qos_and_resource_pool.py"
     "tests/test_qos_info.py"
     "tests/test_request_payment.py"
     "tests/test_select_csv_object.py"
@@ -96,6 +100,9 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    # Test fixtures are not included in the sdist
+    "test_crypto_get_compact"
+    "test_crypto_get_compact_deprecated_rsa"
     "test_crypto_get_compact_deprecated_kms"
     # RuntimeError
     "test_crypto_put"
@@ -106,7 +113,7 @@ buildPythonPackage rec {
   meta = {
     description = "Alibaba Cloud OSS SDK for Python";
     homepage = "https://github.com/aliyun/aliyun-oss-python-sdk";
-    changelog = "https://github.com/aliyun/aliyun-oss-python-sdk/releases/tag/${version}";
+    changelog = "https://github.com/aliyun/aliyun-oss-python-sdk/blob/master/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };


### PR DESCRIPTION
2.18.3 lacks V4 signature support required for new OSS buckets.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
