### PR TITLE
ags_1: migrate to typescript 7

### DIFF
--- a/pkgs/by-name/ag/ags_1/package.nix
+++ b/pkgs/by-name/ag/ags_1/package.nix
@@ -14,7 +14,7 @@
   libsoup_3,
   networkmanager,
   upower,
-  typescript_5,
+  typescript_7,
   wrapGAppsHook3,
   linux-pam,
   nix-update-script,
@@ -42,7 +42,7 @@ buildNpmPackage (finalAttrs: {
     pkg-config
     gjs
     gobject-introspection
-    typescript_5
+    typescript_7
     wrapGAppsHook3
   ];
 
@@ -62,10 +62,16 @@ buildNpmPackage (finalAttrs: {
   patches = [
     # Workaround for TypeScript 5.9: https://github.com/Aylur/ags/issues/725#issuecomment-3070009695
     ./ts59.patch
+    # Workaround for TypeScript 7
+    ./ts7.patch
   ];
 
   postPatch = ''
     chmod u+x ./post_install.sh && patchShebangs ./post_install.sh
+
+    # JS ERROR: TypeError: Repository.prepend_search_path is not a function
+    substituteInPlace src/com.github.Aylur.ags.js.in \
+      --replace-fail "Repository.prepend" "Repository.dup_default().prepend"
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ag/ags_1/ts7.patch
+++ b/pkgs/by-name/ag/ags_1/ts7.patch
@@ -1,0 +1,27 @@
+diff --git a/tsconfig.json b/tsconfig.json
+index 7f3406d..f03a43a 100644
+--- a/tsconfig.json
++++ b/tsconfig.json
+@@ -9,11 +9,20 @@
+         "checkJs": false,
+         "outDir": "_build/tsc-out",
+         "strict": true,
+-        "moduleResolution": "node",
+-        "baseUrl": ".",
++        "rootDir": "./src",
+         "typeRoots": [
+             "./node_modules/@girs"
+         ],
++        "types": [
++            "cairo-1.0",
++            "dbusmenugtk3-0.4",
++            "gjs",
++            "gtk-3.0",
++            "gvc-1.0",
++            "nm-1.0",
++            "notify-0.7",
++            "soup-3.0"
++        ],
+         "skipLibCheck": true,
+         "forceConsistentCasingInFileNames": true
+     },


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
