### PR TITLE
calibre-web: 0.6.26-unstable-2026-03-01 -> 0.6.27

### DIFF
--- a/pkgs/by-name/ca/calibre-web/package.nix
+++ b/pkgs/by-name/ca/calibre-web/package.nix
@@ -6,17 +6,17 @@
   nixosTests,
   python3Packages,
 }:
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "calibre-web";
-  version = "0.6.26-unstable-2026-03-01";
+  version = "0.6.27";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "janeczku";
     repo = "calibre-web";
-    # remember changing this back (and changelog below) to tag after new release come out
-    rev = "6157f5027c979aa05f8d97a09f1388ceb3085ac5";
-    hash = "sha256-1ljMsf8Puvq4ELUSi8Vl3T7EHcd7MO3zGgT4j5PYsT0=";
+    tag = finalAttrs.version;
+    hash = "sha256-ULUEQ35R+jI0nCrwYkTvmaUqpi1a/Sjvs5kWHYfTTWY=";
   };
 
   patches = [
@@ -37,7 +37,7 @@ python3Packages.buildPythonApplication rec {
     mv cps src/calibreweb
 
     substituteInPlace pyproject.toml \
-      --replace-fail 'cps = "calibreweb:main"' 'calibre-web = "calibreweb:main"'
+      --replace-fail 'cps = "calibreweb.__main__:main"' 'calibre-web = "calibreweb.__main__:main"'
   '';
 
   build-system = [ python3Packages.setuptools ];
@@ -57,6 +57,7 @@ python3Packages.buildPythonApplication rec {
     iso-639
     lxml
     netifaces-plus
+    nh3
     pycountry
     pypdf
     python-magic
@@ -141,7 +142,7 @@ python3Packages.buildPythonApplication rec {
     "wand"
   ];
 
-  nativeCheckInputs = lib.concatAttrValues optional-dependencies;
+  nativeCheckInputs = lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   pythonImportsCheck = [ "calibreweb" ];
 
@@ -153,12 +154,10 @@ python3Packages.buildPythonApplication rec {
   meta = {
     description = "Web app for browsing, reading and downloading eBooks stored in a Calibre database";
     homepage = "https://github.com/janeczku/calibre-web";
-    # revert back to tag based changelog
-    # changelog = "https://github.com/janeczku/calibre-web/releases/tag/${src.tag}";
-    changelog = "https://github.com/janeczku/calibre-web/compare/0.6.26...${src.rev}";
+    changelog = "https://github.com/janeczku/calibre-web/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ juli0604 ];
     mainProgram = "calibre-web";
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Superseeds #499182
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
