### PR TITLE
libp11: 0.4.18 -> 0.4.21

### DIFF
--- a/nixos/tests/networking/networkmanager.nix
+++ b/nixos/tests/networking/networkmanager.nix
@@ -401,17 +401,6 @@ let
               driver = "nl80211";
               pkcs11 = {
                 enable = true;
-                package = pkgs.libp11.overrideAttrs {
-                  # TODO: Remove this override once a libp11 release includes the fix for
-                  # https://github.com/OpenSC/libp11/issues/672
-                  version = "0.4.21-unstable-2026-08-19";
-                  src = pkgs.fetchFromGitHub {
-                    owner = "OpenSC";
-                    repo = "libp11";
-                    rev = "e72a2014eb078c7b784e2a9be3e7abd3dce8fd5a";
-                    hash = "sha256-V9ZRPUJp2FkK+Zb/qYC13SDE7+oyJ/hlnO/XEN2zDD8=";
-                  };
-                };
               };
             };
           };

--- a/pkgs/by-name/li/libp11/package.nix
+++ b/pkgs/by-name/li/libp11/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libp11";
-  version = "0.4.18";
+  version = "0.4.21";
 
   src = fetchFromGitHub {
     owner = "OpenSC";
     repo = "libp11";
     rev = "${pname}-${version}";
-    sha256 = "sha256-bvVUiv8y5c0P9fHAFs1JX3V7xsorbKUmm0qt3l2SoQQ=";
+    sha256 = "sha256-Tqc9PJsVBmq1Qy+YQVmSiD2Yb7ppif5pJ7uRHyTlqQ8=";
   };
 
   configureFlags = [


### PR DESCRIPTION
Contains fix for https://github.com/OpenSC/libp11/issues/672 Required for https://github.com/NixOS/nixpkgs/pull/550650

Changelog: https://github.com/OpenSC/libp11/blob/fa48b0a9ee634b4c6721094840575c7f6d1f498e/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
