### PR TITLE
python3Packages.scikit-survival: fix tests.full eval error

### DIFF
--- a/pkgs/development/python-modules/scikit-survival/default.nix
+++ b/pkgs/development/python-modules/scikit-survival/default.nix
@@ -112,9 +112,8 @@ buildPythonPackage (finalAttrs: {
 
   disabledTests = slowTests ++ flakyTests;
 
-  passthru.tests.full = finalAttrs.finalPackage.overridePythonAttrs (old: {
-    pname = old.pname + "-full-tests";
-    nativeCheckInputs = old.nativeCheckInputs ++ [ polars ];
+  passthru.tests.full = finalAttrs.finalPackage.overrideAttrs (old: {
+    nativeInstallCheckInputs = old.nativeInstallCheckInputs ++ [ polars ];
     disabledTests = flakyTests;
     disabledTestPaths = [ ];
   });


### PR DESCRIPTION
The `passthru` attribute is currently broken:

```
$ nix build .#python3Packages.scikit-survival.passthru.tests.full
error:
       … while evaluating the attribute 'finalPackage.overridePythonAttrs'
         at /home/joe/repos/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:236:40:
          235|       # An infinite recursion here can be caused by having the attribute names of expression `e` in `.overrideAttrs(finalAttrs: previousAttrs: e)` depend on `finalAttrs`. Only the attribute values of `e` can depend on `finalAttrs`.
          236|       args = rattrs (args // { inherit finalPackage overrideAttrs; });
             |                                        ^
          237|       #              ^^^^

       error: attribute 'overridePythonAttrs' missing
       at /home/joe/repos/nixpkgs/pkgs/development/python-modules/scikit-survival/default.nix:115:25:
          114|
          115|   passthru.tests.full = finalAttrs.finalPackage.overridePythonAttrs (old: {
             |                         ^
          116|     pname = old.pname + "-full-tests";
```

This fixes it using the same technique suggested in #560335.

The test package rename is removed: only a couple of other packages in nixpkgs appear to choose renaming and turning off the metadata check over not renaming. 

Confirmed that the passthru tests really are pretty slow.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
