### PR TITLE
cliamp: installed cliamp.desktop and icon

### DIFF
--- a/pkgs/by-name/cl/cliamp/package.nix
+++ b/pkgs/by-name/cl/cliamp/package.nix
@@ -14,6 +14,8 @@
   flac,
   yt-dlp,
   versionCheckHook,
+  copyDesktopItems,
+  makeDesktopItem,
 }:
 
 buildGoModule (finalAttrs: {
@@ -39,6 +41,7 @@ buildGoModule (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     makeWrapper
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -51,12 +54,45 @@ buildGoModule (finalAttrs: {
     alsa-lib
   ];
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "cliamp";
+      type = "Application";
+      desktopName = "Cliamp";
+      genericName = "Music Player";
+      comment = "A retro terminal music player inspired by Winamp 2.x";
+      icon = "cliamp";
+      exec = "cliamp";
+      terminal = true;
+      keywords = [
+        "music"
+        "audio"
+        "player"
+        "terminal"
+        "tui"
+        "winamp"
+        "radio"
+        "podcast"
+      ];
+      categories = [
+        "Audio"
+        "Music"
+        "Player"
+        "AudioVideo"
+        "ConsoleOnly"
+      ];
+      startupNotify = false;
+    })
+  ];
+
   # macOS limits Unix socket paths to 104 bytes; use a shorter TMPDIR.
   preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
     export TMPDIR="$(mktemp -d /tmp/cliamp-XXXXXX)"
   '';
 
   postInstall = ''
+    mkdir -p "$out/share/icons/hicolor/512x512/apps";
+    cp "$src/Cliamp.png" "$out/share/icons/hicolor/512x512/apps/cliamp.png";
     wrapProgram $out/bin/cliamp \
       --prefix PATH : ${
         lib.makeBinPath [


### PR DESCRIPTION
<!--
^ I installed a .desktop file for cliamp and the icon  ^

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
