### PR TITLE
libtlsrpt: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/by-name/li/libtlsrpt/package.nix
+++ b/pkgs/by-name/li/libtlsrpt/package.nix
@@ -3,11 +3,12 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  asciidoctor,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libtlsrpt";
-  version = "0.5.0";
+  version = "0.5.1";
 
   outputs = [
     "out"
@@ -19,10 +20,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "sys4";
     repo = "libtlsrpt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-h7bWxxllKFj8+/FfC4yHSmz+Qij1BcgV4OCQZr1OkA8=";
+    hash = "sha256-U11VMaLGnWMe4EALaOQUFJ35hDUX2jAYadGJNYDpeK0=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    asciidoctor
+  ];
 
   separateDebugInfo = true;
 


### PR DESCRIPTION
Changes: https://github.com/sys4/libtlsrpt/releases/tag/v0.5.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
