### PR TITLE
stdenv: add PURLs to common-path packages

### DIFF
--- a/pkgs/by-name/co/coreutils/package.nix
+++ b/pkgs/by-name/co/coreutils/package.nix
@@ -292,5 +292,9 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = with lib.platforms; unix ++ windows;
     priority = 10;
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version;
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/coreutils@${finalAttrs.version}";
+    };
   };
 })

--- a/pkgs/by-name/di/diffutils/package.nix
+++ b/pkgs/by-name/di/diffutils/package.nix
@@ -91,5 +91,9 @@ stdenv.mkDerivation (finalAttrs: {
       das_j
       helsinki-Jo
     ];
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/diffutils@${finalAttrs.version}";
+    };
   };
 })

--- a/pkgs/by-name/gn/gnugrep/package.nix
+++ b/pkgs/by-name/gn/gnugrep/package.nix
@@ -115,6 +115,10 @@ stdenv.mkDerivation (finalAttrs: {
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version // {
       product = "grep";
     };
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/gnugrep@${finalAttrs.version}";
+    };
   };
 
   passthru = {

--- a/pkgs/by-name/gn/gnumake/package.nix
+++ b/pkgs/by-name/gn/gnumake/package.nix
@@ -102,5 +102,9 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "make";
     maintainers = with lib.maintainers; [ mdaniels5757 ];
     platforms = lib.platforms.all;
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/gnumake@${finalAttrs.version}";
+    };
   };
 })

--- a/pkgs/by-name/gn/gnupatch/package.nix
+++ b/pkgs/by-name/gn/gnupatch/package.nix
@@ -47,5 +47,9 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ mdaniels5757 ];
     platforms = lib.platforms.all;
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/patch@${finalAttrs.version}";
+    };
   };
 })

--- a/pkgs/by-name/gn/gnutar/package.nix
+++ b/pkgs/by-name/gn/gnutar/package.nix
@@ -93,5 +93,9 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ RossComputerGuy ];
     platforms = lib.platforms.all;
     priority = 10;
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/gnutar@${finalAttrs.version}";
+    };
   };
 })

--- a/pkgs/by-name/xz/xz/package.nix
+++ b/pkgs/by-name/xz/xz/package.nix
@@ -104,5 +104,9 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     pkgConfigModules = [ "liblzma" ];
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "tukaani" finalAttrs.version;
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/xz@${finalAttrs.version}";
+    };
   };
 })

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -295,5 +295,9 @@ lib.warnIf (withDocs != null)
           version = lib.elemAt versionSplit 0;
           update = lib.elemAt versionSplit 2;
         };
+      identifiers.purlParts = {
+        type = "nix";
+        spec = "nixpkgs/bash@${fa.version}";
+      };
     };
   })

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -82,6 +82,10 @@ stdenv.mkDerivation (
       pkgConfigModules = [ "bzip2" ];
       platforms = lib.platforms.all;
       maintainers = with lib.maintainers; [ mic92 ];
+      identifiers.purlParts = {
+        type = "nix";
+        spec = "nixpkgs/bzip2@${finalAttrs.version}";
+      };
     };
   }
 )

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -109,5 +109,9 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     mainProgram = "gzip";
     maintainers = [ lib.maintainers.mdaniels5757 ];
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/gzip@${finalAttrs.version}";
+    };
   };
 })

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -68,5 +68,9 @@ stdenv.mkDerivation (finalAttrs: {
     pkgConfigModules = [ "libmagic" ];
     platforms = lib.platforms.all;
     mainProgram = "file";
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/file@${finalAttrs.version}";
+    };
   };
 })

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -110,5 +110,9 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.mdaniels5757 ];
     teams = [ lib.teams.security-review ];
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version;
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/findutils@${finalAttrs.version}";
+    };
   };
 })

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -129,5 +129,9 @@ stdenv.mkDerivation (finalAttrs: {
       helsinki-Jo
     ];
     mainProgram = "gawk";
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/gawk@${finalAttrs.version}";
+    };
   };
 })

--- a/pkgs/tools/text/gnused/default.nix
+++ b/pkgs/tools/text/gnused/default.nix
@@ -53,5 +53,9 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ mic92 ];
     mainProgram = "sed";
+    identifiers.purlParts = {
+      type = "nix";
+      spec = "nixpkgs/gnused@${finalAttrs.version}";
+    };
   };
 })


### PR DESCRIPTION
## Motivation

As part of my GSoC work with @RossComputerGuy, I'm filling missing Package URLs in the packages used by `stdenv`'s common PATH so SBOM tools can use declared identifiers instead of reconstructing them from package names. We started with this bounded set to improve the `stdenv` SBOM; this is not coverage of its entire dependency closure or all of nixpkgs.

[#454333](https://github.com/NixOS/nixpkgs/pull/454333) introduced the PURL metadata infrastructure and support in several fetchers. All 14 package definitions here use `fetchurl` for their main source, which does not currently derive PURLs. This addresses the [explicitly identified follow-up of maintaining metadata for `fetchurl` packages](https://github.com/NixOS/nixpkgs/pull/454333#issuecomment-4289007810), using the existing interface rather than adding new fetcher behavior.

This adds `meta.identifiers.purlParts` to 14 package definitions: coreutils, findutils, diffutils, gnused, gnugrep, gawk, gnutar, gzip, bzip2, gnumake, bash, patch, xz, and file. For example, coreutils now evaluates to `pkg:nix/nixpkgs/coreutils@9.11`. Versions come from each package definition; no build instructions or dependencies are changed.

The companion [sbomnix PR #320](https://github.com/tiiuae/sbomnix/pull/320) consumes these identifiers when experimental [Nix #16285](https://github.com/NixOS/nix/pull/16285) and [nixpkgs #466932](https://github.com/NixOS/nixpkgs/pull/466932) expose them in derivation JSON. Those transport changes are **not included** here and are not needed to evaluate `meta.identifiers.purl`.

## Verification and draft scope

- Evaluated all 14 common-PATH PURLs on `aarch64-darwin` from this branch; all are populated.
- `nix build` succeeded for all 14 common-PATH packages on `aarch64-darwin`, using binary-cache substitutes (not local source compilation). One main executable per package passed a version/help startup check; native executables were confirmed as arm64.
- `nixfmt --check` on the 14 changed files and `git diff HEAD^ HEAD --check` pass.
- Earlier end-to-end experiment with the experimental transport and patched sbomnix: exact metadata matches increased from 0/14 to 14/14; SPDX package and dependency counts remained 495 and 2,483. This demonstrates metadata transport, not independent verification of package identity.
- Local sandboxed source builds: gzip `makecheck` passed all 30 tests. Guile-enabled make built, but its regression harness silently skipped tests without Perl. A local rerun supplying Perl failed 24 tests across 8 categories (the 8 Guile-specific tests passed). Removing make's PURL metadata produces the identical failing test derivation. These failures remain unresolved.
- Draft for review of the `pkg:nix/nixpkgs/<name>@<version>` convention and package/variant naming. `nixpkgs-review` has not been performed. CI passes and reports zero rebuilds on Linux and Darwin.

Reproduce the metadata evaluation from the checkout:

```sh
nix eval --impure --json --expr '
  let pkgs = import ./. { system = "aarch64-darwin"; };
  in map (p: {
    inherit (p) name;
    purl = p.meta.identifiers.purl or null;
  }) (import ./pkgs/stdenv/generic/common-path.nix { inherit pkgs; })
' --option allow-import-from-derivation false
```

## Things done

Checks for commit `1eb1424ad2d0` ([CI run](https://github.com/NixOS/nixpkgs/actions/runs/34059560090)):

- [x] Evaluated all 14 common-PATH PURLs locally on `aarch64-darwin`.
- [x] Local formatting and whitespace checks.
- [x] Local `ci/github-script` typecheck and all 29 tests pass.
- [x] CI lint checks: treefmt, parse, nixpkgs-vet, and commits.
- [x] CI package-set evaluation on the current supported-system matrix: x86_64-linux, aarch64-linux, and aarch64-darwin.
- [x] CI github-script and evaluation comparison checks; zero Linux or Darwin rebuilds.

The platform check below records the local `nix build` result, not the CI shell/docs builds. It used cached binaries; source compilation was not forced.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin (`nix build` succeeded for all 14 common-PATH packages using binary-cache substitutes; main-executable startup checks passed).
- Tested, as applicable:
  - [ ] NixOS tests (not run; require Linux).
  - [ ] Package tests at `passthru.tests` (partial: bzip2, xz, and file `pkg-config` checks and gzip `makecheck` passed; make's regression rerun with Perl failed as noted above. Static variants were not run; Bash `withChecks` is marked broken on Darwin).
  - [x] Core evaluation tests: `nix-instantiate --eval --strict lib/tests/{misc,systems,fetchers}.nix`, run separately; all returned `[ ]`. Other core suites were not run locally.
- [ ] Ran `nixpkgs-review`.
- [ ] Tested basic functionality of all binary files.
- Nixpkgs Release Notes
  - [ ] Package update: major or breaking change (not applicable).
- NixOS Release Notes
  - [ ] Module addition (not applicable).
  - [ ] Significant module update (not applicable).
- [ ] Full self-review against contribution standards before marking ready.

AI assistance: Codex helped prepare the metadata changes and verification tooling; the commit records the earlier assistance in its `Assisted-by:` trailer. This PR description and the latest verification were prepared with Codex using GPT-6 Astra (reasoning effort: high). Full self-review remains pending under the [draft contribution exemption](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#exemptions).
