### PR TITLE
flatpak-builder: 1.4.4 -> 1.4.10

### DIFF
--- a/pkgs/development/tools/flatpak-builder/default.nix
+++ b/pkgs/development/tools/flatpak-builder/default.nix
@@ -36,12 +36,12 @@
   gnupg,
   gnutar,
   json-glib,
+  libarchive,
   libcap,
   libyaml,
   ostree,
   patch,
   rpm,
-  unzip,
   attr,
 }:
 
@@ -52,7 +52,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "flatpak-builder";
-  version = "1.4.4";
+  version = "1.4.10";
 
   outputs = [
     "out"
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   # fetchFromGitHub fetches an archive which does not contain the full source (https://github.com/flatpak/flatpak-builder/issues/558)
   src = fetchurl {
     url = "https://github.com/flatpak/flatpak-builder/releases/download/${finalAttrs.version}/flatpak-builder-${finalAttrs.version}.tar.xz";
-    hash = "sha256-3CcVk5S6qiy1I/Uvh0Ry/1DRYZgyMyZMoqIuhQdB7Ho=";
+    hash = "sha256-sXIQeMBpfIyh19uWUjK1CdGqh/aLTa43jrUAvd3bnME=";
   };
 
   patches = [
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
       cp = "${coreutils}/bin/cp";
       patch = "${patch}/bin/patch";
       tar = "${gnutar}/bin/tar";
-      unzip = "${unzip}/bin/unzip";
+      bsdunzip = "${libarchive}/bin/bsdunzip";
       rpm2cpio = "${rpm}/bin/rpm2cpio";
       cpio = "${cpio}/bin/cpio";
       git = "${gitMinimal}/bin/git";

--- a/pkgs/development/tools/flatpak-builder/fix-paths.patch
+++ b/pkgs/development/tools/flatpak-builder/fix-paths.patch
@@ -11,15 +11,15 @@ index dde12790..3a379297 100644
    self->have_rofiles = path != NULL;
  }
  
-@@ -800,7 +800,7 @@ builder_context_enable_rofiles (BuilderContext *self,
+@@ -889,7 +889,7 @@ builder_context_enable_rofiles (BuilderContext *self,
    g_autoptr(GFile) rofiles_base = NULL;
    g_autoptr(GFile) rofiles_dir = NULL;
    g_autofree char *tmpdir_name = NULL;
 -  char *argv[] = { "rofiles-fuse",
 +  char *argv[] = { "@rofilesfuse@",
                     "-o",
-                    "kernel_cache,entry_timeout=60,attr_timeout=60,splice_write,splice_move",
-                    (char *)flatpak_file_get_path_cached (self->app_dir),
+                    (
+                     "kernel_cache,entry_timeout=60,attr_timeout=60"
 diff --git a/src/builder-git.c b/src/builder-git.c
 index ef517adb..6ab095f0 100644
 --- a/src/builder-git.c
@@ -59,8 +59,8 @@ index ed66d5b..9ca9486 100644
         GError     **error)
  {
    gboolean res;
--  const char *argv[] = { "unzip", "-q", zip_path, NULL };
-+  const char *argv[] = { "@unzip@", "-q", zip_path, NULL };
+-  const char *argv[] = { "bsdunzip", "-q", zip_path, NULL };
++  const char *argv[] = { "@bsdunzip@", "-q", zip_path, NULL };
 
    res = flatpak_spawnv (dir, NULL, 0, error, argv, NULL);
 
@@ -99,7 +99,7 @@ diff --git a/src/builder-source-patch.c b/src/builder-source-patch.c
 index 8721e1e4..d7f4d840 100644
 --- a/src/builder-source-patch.c
 +++ b/src/builder-source-patch.c
-@@ -247,15 +247,15 @@ patch (GFile      *dir,
+@@ -250,16 +250,16 @@ patch (GFile      *dir,
  
    args = g_ptr_array_new ();
    if (use_git) {
@@ -112,6 +112,7 @@ index 8721e1e4..d7f4d840 100644
 +    g_ptr_array_add (args, "@git@");
      g_ptr_array_add (args, "am");
      g_ptr_array_add (args, "--keep-cr");
+     g_ptr_array_add (args, "--no-gpg-sign");
    } else {
 -    g_ptr_array_add (args, "patch");
 +    g_ptr_array_add (args, "@patch@");


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Refresh patch to apply to latest. unzip got replaced by libarchive

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
