### PR TITLE
[26.05] python3Packages.nltk: 3.9.4 -> 3.10.3

### DIFF
--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -180,6 +180,7 @@ python.pkgs.buildPythonApplication rec {
     "drf-spectacular-sidecar"
     "python-dotenv"
     "gotenberg-client"
+    "nltk"
     "redis"
     "scikit-learn"
     "tika-client"

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   buildPythonPackage,
   click,
+  defusedxml,
   joblib,
   regex,
   setuptools,
@@ -23,49 +24,53 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "nltk";
-  version = "3.9.4";
+  version = "3.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nltk";
     repo = "nltk";
-    tag = finalAttrs.version;
-    hash = "sha256-kDfMiqXgLq91zzDjv/qDn0XwQkYRn2sITI6E4pgWe/8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1iflqb3cOyaviW3IostFCuJtZ9KBZI0n9dfKfqqbcO0=";
   };
 
   postPatch = ''
     # In the nix store we trust
     substituteInPlace nltk/pathsec.py \
-      --replace-fail 'if not (target == scoped_root or target.is_relative_to(scoped_root)):' 'if not (target == scoped_root or target.is_relative_to(scoped_root) or target.is_relative_to("/nix/store")):'
+      --replace-fail 'if not (target == scoped_root or target.is_relative_to(scoped_root)):' \
+                     'if not (target == scoped_root or target.is_relative_to(scoped_root) or target.is_relative_to("/nix/store")):' \
+      --replace-fail ' "/usr/share/nltk_data", ' ' "/usr/share/nltk_data", "/nix/store", '
   '';
 
   build-system = [ setuptools ];
 
   dependencies = [
     click
+    defusedxml
     joblib
     regex
     tqdm
   ];
 
-  # Use new passthru function to pass dependencies required for testing
   preInstallCheck = ''
     export NLTK_DATA=${
       nltk.dataDir (
         d: with d; [
           averaged-perceptron-tagger-eng
           averaged-perceptron-tagger-rus
+          bcp47
           brown
           cess-cat
           cess-esp
           conll2007
           floresta
           gutenberg
+          ieer
           inaugural
           indian
           large-grammars
           nombank-1-0
-          omw-1-4
+          omw-2-0
           pl196x
           porter-test
           ptb
@@ -114,9 +119,10 @@ buildPythonPackage (finalAttrs: {
   };
 
   meta = {
+    changelog = "https://github.com/nltk/nltk/blob/${finalAttrs.src.tag}/ChangeLog";
     description = "Natural Language Processing ToolKit";
     mainProgram = "nltk";
-    homepage = "http://nltk.org/";
+    homepage = "https://nltk.org/";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.bengsparks ];
   };

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -24,22 +24,26 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "nltk";
-  version = "3.10.0";
+  version = "3.10.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nltk";
     repo = "nltk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1iflqb3cOyaviW3IostFCuJtZ9KBZI0n9dfKfqqbcO0=";
+    hash = "sha256-PaMW9QNV+++Gz+OoG7m2VFn6L3vkG/Mg9ZLx9KlN19U=";
   };
 
   postPatch = ''
-    # In the nix store we trust
+    # NLTK's immutable-root model does not include the Nix store. Trust it for
+    # data roots and read-only symlinks produced by nltk-data-dir.
     substituteInPlace nltk/pathsec.py \
       --replace-fail 'if not (target == scoped_root or target.is_relative_to(scoped_root)):' \
                      'if not (target == scoped_root or target.is_relative_to(scoped_root) or target.is_relative_to("/nix/store")):' \
-      --replace-fail ' "/usr/share/nltk_data", ' ' "/usr/share/nltk_data", "/nix/store", '
+      --replace-fail 'candidate_locs = ["~/nltk_data", "/usr/share/nltk_data"]' \
+                     'candidate_locs = ["~/nltk_data", "/usr/share/nltk_data", "/nix/store"]' \
+      --replace-fail 'if ENFORCE and os.name == "posix":' \
+                     'if ENFORCE and os.name == "posix" and not (_is_readonly_mode(mode) and Path(os.path.abspath(raw_path)).is_relative_to("/nix/store")):'
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -122,6 +122,8 @@ buildPythonPackage (finalAttrs: {
     dataDir = pkgs.callPackage ./data-dir.nix { };
   };
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     changelog = "https://github.com/nltk/nltk/blob/${finalAttrs.src.tag}/ChangeLog";
     description = "Natural Language Processing ToolKit";

--- a/pkgs/tools/text/nltk-data/default.nix
+++ b/pkgs/tools/text/nltk-data/default.nix
@@ -7,7 +7,7 @@
 }:
 let
   base = {
-    version = "0-unstable-2024-07-29";
+    version = "0-unstable-2026-07-01";
     nativeBuildInputs = [ unzip ];
     dontBuild = true;
     dontFixup = true;
@@ -30,9 +30,10 @@ let
     }:
     let
       src = fetchFromGitHub {
+        name = "nltk-${location}";
         owner = "nltk";
         repo = "nltk_data";
-        rev = "cfe82914f3c2d24363687f1db3b05e8b9f687e2b";
+        rev = "550b6625bcef1f2abff2ff770a5a0d272c9c6b2a";
         inherit hash;
         sparseCheckout = [ "packages/${location}/${pname}.zip" ];
       };
@@ -60,7 +61,7 @@ let
     makeNltkDataPackage {
       inherit pname;
       location = "chunkers";
-      hash = "sha256-kemjqaCM9hlKAdMw8oVJnp62EAC9rMQ50dKg7wlAwEc=";
+      hash = "sha256-+n0TkS+/NHk0OqFZNQBLIcO/9uw56Mn7/AyNkRDGZEQ=";
     };
 
   makeCorpus =
@@ -68,7 +69,7 @@ let
     makeNltkDataPackage {
       inherit pname;
       location = "corpora";
-      hash = "sha256-8lMjW5YI8h6dHJ/83HVY2OYGDyKPpgkUAKPISiAKqqk=";
+      hash = "sha256-7uiTXZ+eMyBtH135NsYoAjLV6R/DG2hVV+RJwYDmu50=";
     };
 
   makeGrammar =
@@ -76,7 +77,7 @@ let
     makeNltkDataPackage {
       inherit pname;
       location = "grammars";
-      hash = "sha256-pyLEcX3Azv8j1kCGvVYonuiNgVJxtWt7veU0S/yNbIM=";
+      hash = "sha256-KoZ1q0F2X7bSFdbw1qK/jzZ3iuMJXTYHfogylO7nHEY=";
     };
 
   makeHelp =
@@ -84,7 +85,7 @@ let
     makeNltkDataPackage {
       inherit pname;
       location = "help";
-      hash = "sha256-97mYLNES5WujLF5gD8Ul4cJ6LqSzz+jDzclUsdBeHNE=";
+      hash = "sha256-2x3kemPdipHAj0TGYCm6Il5Aapx+fuo/jlNT9+XWbss=";
     };
 
   makeMisc =
@@ -92,7 +93,7 @@ let
     makeNltkDataPackage {
       inherit pname;
       location = "misc";
-      hash = "sha256-XtizfEsc8TYWqvvC/eSFdha2ClC5/ZiJM8nue0vXLb4=";
+      hash = "sha256-edBgrWM+eQgEGWq7oBHTebtvJPZcofCzzXSu3S9Fa1o=";
     };
 
   makeModel =
@@ -100,7 +101,7 @@ let
     makeNltkDataPackage {
       inherit pname;
       location = "models";
-      hash = "sha256-iq3weEgCci6rgLW2j28F2eRLprJtInGXKe/awJPSVG4=";
+      hash = "sha256-uTRr9pBfL1KZ7z8WTQPAiWlMn/os4ISa9tj/Si/RmtI=";
     };
 
   makeTagger =
@@ -108,7 +109,7 @@ let
     makeNltkDataPackage {
       inherit pname;
       location = "taggers";
-      hash = "sha256-tl3Cn2okhBkUtTXvAmFRx72Brez6iTGRdmFTwFmpk3M=";
+      hash = "sha256-V5bs0JUQgr4ijs2NaF5JXzVwT1e/ZYnlU0TZXeoqfM4=";
     };
 
   makeTokenizer =
@@ -116,7 +117,7 @@ let
     makeNltkDataPackage {
       inherit pname;
       location = "tokenizers";
-      hash = "sha256-OzMkruoYbFKqzuimOXIpE5lhHz8tmSqOFoLT+fjdTVg=";
+      hash = "sha256-V/Qs8wJbCZB8gp5pAAM1JK8aAfcHorNyvAkHUat56uY=";
     };
 
   makeStemmer =
@@ -124,7 +125,7 @@ let
     makeNltkDataPackage {
       inherit pname;
       location = "stemmers";
-      hash = "sha256-mNefwOPVJGz9kXV3LV4DuV7FJpNir/Nwg4ujd0CogEk=";
+      hash = "sha256-6sQQCA8r8jWRFImpiBovUt/IzHjh13W6X8yLpn61cs0=";
     };
 in
 lib.makeScope newScope (self: {
@@ -152,6 +153,7 @@ lib.makeScope newScope (self: {
   crubadan = makeCorpus "crubadan";
   dependency-treebank = makeCorpus "dependency_treebank";
   dolch = makeCorpus "dolch";
+  english_wordnet = makeCorpus "english_wordnet";
   europarl-raw = makeCorpus "europarl_raw";
   extended-omw = makeCorpus "extended_omw";
   floresta = makeCorpus "floresta";
@@ -170,6 +172,7 @@ lib.makeScope newScope (self: {
   mac-morpho = makeCorpus "mac_morpho";
   machado = makeCorpus "machado";
   masc-tagged = makeCorpus "masc_tagged";
+  mock_corpus = makeCorpus "mock_corpus";
   movie-reviews = makeCorpus "movie_reviews";
   mte-teip5 = makeCorpus "mte_teip5";
   names = makeCorpus "names";
@@ -178,6 +181,7 @@ lib.makeScope newScope (self: {
   nps-chat = makeCorpus "nps_chat";
   omw = makeCorpus "omw";
   omw-1-4 = makeCorpus "omw-1.4";
+  omw-2-0 = makeCorpus "omw-2.0";
   opinion-lexicon = makeCorpus "opinion_lexicon";
   panlex-swadesh = makeCorpus "panlex_swadesh";
   paradigms = makeCorpus "paradigms";


### PR DESCRIPTION
Backports #555442 together with the NLTK data update required by NLTK 3.10.0, the existing Darwin sandbox fix, and the `paperless-ngx` NLTK dependency relaxation from #545023.

Updates NLTK from 3.9.4 to 3.10.3, fixing [CVE-2026-72818](https://www.cve.org/CVERecord?id=CVE-2026-72818) and [CVE-2026-54293](https://www.cve.org/CVERecord?id=CVE-2026-54293).

[Upstream changes](https://redirect.github.com/nltk/nltk/compare/3.9.4...v3.10.3)

Closes #559530
Closes #534492

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
