### PR TITLE
wayvr: Fix OpenVR compatibility 

### DIFF
--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -30,6 +30,9 @@
   wayland,
   wayvr,
   xwayland-satellite,
+  makeWrapper,
+  libGL,
+  libuuid,
   withOpenVR ? !stdenv.hostPlatform.isAarch64,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -53,8 +56,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    rustPlatform.bindgenHook
+    makeWrapper
     autoPatchelfHook
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = [
@@ -78,7 +82,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wayland
     vulkan-loader
   ]
-  ++ lib.optionals withOpenVR [ openvr ];
+  ++ lib.optionals withOpenVR [
+    libGL
+    openvr
+    libuuid
+  ];
 
   env.SHADERC_LIB_DIR = "${lib.getLib shaderc}/lib";
 
@@ -103,8 +111,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     install -D wayvr/wayvr.desktop -t $out/share/applications
     install -D wayvr/wayvr.svg -t $out/share/icons/hicolor/scalable/apps
-
     rm $out/bin/prost_build
+
+    # This really is not optimal but wayvr will complain about missing libraries and refuse to start with --openvr.
+    # steam-run *should* provide most of these libraries but for some whatever reason it doesnt, this is a workaround for now.
+    wrapProgram $out/bin/wayvr \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs}
   '';
 
   preFixup = ''

--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -149,6 +149,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       Scrumplex
       ImSapphire
+      ShyAssassin
     ];
     platforms = lib.platforms.linux;
     broken = stdenv.hostPlatform.isAarch64 && withOpenVR;

--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -91,7 +91,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env.SHADERC_LIB_DIR = "${lib.getLib shaderc}/lib";
 
   postPatch = ''
-    substituteAllInPlace dash-frontend/src/util/pactl_wrapper.rs \
+    substituteInPlace dash-frontend/src/util/pactl_wrapper.rs \
       --replace-fail '"pactl"' '"${lib.getExe' pulseaudio "pactl"}"'
 
     # steam_utils also calls xdg-open as well as steam. Those should probably be pulled from the environment


### PR DESCRIPTION
Currently when attempting to use WayVR with SteamVR at launch it will complain about missing libraries and quit primarily it complains about missing `vulkan-loader`, `libGL` and `libuuid`. launching with `steam-run` should provide *some* of these libs but for some reason it isnt currently, This PR adds these libraries and edits `LD_LIBRARY_PATH` to make WayVR work with SteamVR.

(If SteamVR is not running and you attempt to launch WayVR it will also complain about missing SDL libs since WayVR seems to try launch SteamVR itself, but this isnt an issue once SteamVR is already running)

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
