### PR TITLE
paseo: init at 0.8.0

### DIFF
--- a/pkgs/by-name/pa/paseo-relay/package.nix
+++ b/pkgs/by-name/pa/paseo-relay/package.nix
@@ -1,0 +1,45 @@
+{
+  beamMinimal29Packages,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+let
+  beamPackages = beamMinimal29Packages.overrideScope (
+    final: prev: {
+      elixir = final.elixir_1_20;
+    }
+  );
+in
+beamPackages.mixRelease (finalAttrs: {
+  pname = "paseo-relay";
+  version = "0-unstable-2026-08-22";
+
+  src = fetchFromGitHub {
+    owner = "getpaseo";
+    repo = "paseo-relay";
+    rev = "3fc41c96c8c63f3a7109e832899cc57d473c4531";
+    hash = "sha256-53r3Mz1GCv5Vozbg02YfiGABn8HTvoao5R+4CxTKj3w=";
+  };
+
+  mixFodDeps = beamPackages.fetchMixDeps {
+    pname = "mix-deps-${finalAttrs.pname}";
+    inherit (finalAttrs) src version;
+    hash = "sha256-3J2C4XGqjdM0TYf+Vkv5/AY59tiKLVX81Gxrs9pvKuY=";
+  };
+
+  postInstall = ''
+    mv $out/bin/paseo_relay $out/bin/paseo-relay
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "A distributed, protocol-compatible relay for Paseo";
+    homepage = "https://github.com/getpaseo/paseo-relay";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ adamcstephens ];
+    mainProgram = "paseo-relay";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/pa/paseo/package.nix
+++ b/pkgs/by-name/pa/paseo/package.nix
@@ -1,0 +1,104 @@
+{
+  autoPatchelfHook,
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+  libuv,
+  makeWrapper,
+  nix-update-script,
+  nodejs_22,
+  python3,
+  stdenv,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "paseo";
+  version = "0.8.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "getpaseo";
+    repo = "paseo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zYUj7CGz+i+w0elysbU+Sup+NACsBoIEqCu8WHA24PE=";
+  };
+
+  nodejs = nodejs_22;
+
+  npmDepsHash = "sha256-gDB48rHd0K1VOAblaQlPP4XnKGHI8cAt9S09aRxx6b4=";
+
+  npmRebuildFlags = [ "--ignore-scripts" ];
+
+  nativeBuildInputs = [
+    python3
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libuv
+    stdenv.cc.cc.lib
+  ];
+
+  dontNpmBuild = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Rebuild only node-pty (native addon for terminal emulation)
+    npm rebuild node-pty
+
+    npm run build:server
+    npm run build:daemon-web-ui
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Compute the daemon's runtime closure by static module-graph tracing
+    mkdir -p $out/lib/paseo
+    node scripts/trace-daemon.mjs > daemon-files.txt
+
+    while IFS= read -r path; do
+      [ -z "$path" ] && continue
+      mkdir -p "$out/lib/paseo/$(dirname "$path")"
+      cp -a "$path" "$out/lib/paseo/$path"
+    done < daemon-files.txt
+
+    # Root package.json lets node resolve the workspace layout when the
+    # CLI/server bin starts from $out.
+    cp package.json $out/lib/paseo/
+
+    cp -r packages/server/dist/server/web-ui $out/lib/paseo/packages/server/dist/server/
+
+    mkdir -p $out/bin
+
+    makeWrapper ${finalAttrs.nodejs}/bin/node $out/bin/paseo-server \
+      --add-flags "$out/lib/paseo/packages/server/dist/scripts/supervisor-entrypoint.js" \
+      --set PASEO_NODE_ENV production
+
+    makeWrapper ${finalAttrs.nodejs}/bin/node $out/bin/paseo \
+      --add-flags "$out/lib/paseo/packages/cli/dist/index.js" \
+      --set NODE_PATH "$out/lib/paseo/node_modules"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Orchestrate multiple coding agents from desktop and mobile";
+    homepage = "https://github.com/getpaseo/paseo";
+    changelog = "https://github.com/getpaseo/paseo/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ adamcstephens ];
+    mainProgram = "paseo";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The deps and phase code is taken from https://github.com/getpaseo/paseo/blob/main/nix/package.nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
