### PR TITLE
[26.05] android-mic: init at 2.2.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11744,6 +11744,12 @@
     githubId = 157678;
     keys = [ { fingerprint = "E864 BDFA AB55 36FD C905  5195 DBF2 52AF FB26 19FD"; } ];
   };
+  irgendeinwer = {
+    name = "Irgendeinwer";
+    email = "irgendeinwer@proton.me";
+    github = "Irgendeinwer";
+    githubId = 175053643;
+  };
   ironicbadger = {
     email = "alexktz@gmail.com";
     github = "ironicbadger";

--- a/pkgs/by-name/an/android-mic/package.nix
+++ b/pkgs/by-name/an/android-mic/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  rustPlatform,
+  libcosmicAppHook,
+  pkg-config,
+  protobuf,
+  just,
+  alsa-lib,
+  libjack2,
+  pipewire,
+  android-tools,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+let
+  rnnoiseModel = fetchurl {
+    url = "https://media.xiph.org/rnnoise/models/rnnoise_data-0a8755f8e2d834eff6a54714ecc7d75f9932e845df35f8b59bc52a7cfe6e8b37.tar.gz";
+    hash = "sha256-CodV+OLYNO/2pUcU7MfXX5ky6EXfNfi1m8UqfP5uizc=";
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "android-mic";
+  version = "2.2.9";
+
+  src = fetchFromGitHub {
+    owner = "teamclouday";
+    repo = "AndroidMic";
+    tag = finalAttrs.version;
+    hash = "sha256-YhkHK795WeRaGUIaBNWNAkaL836muFRZAZRmP0FEC6g=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/RustApp";
+
+  postPatch = ''
+    substituteInPlace justfile \
+      --replace-fail '`git rev-parse --short HEAD`' '"${finalAttrs.version}"'
+  '';
+
+  cargoHash = "sha256-Ar7kdIXl/2H3c83x7uw977PwShYqV4e2O9HXEeiZeAM=";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    libcosmicAppHook
+    rustPlatform.bindgenHook
+    pkg-config
+    protobuf
+    just
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libjack2
+    pipewire
+  ];
+
+  env = {
+    PROTOC = lib.getExe protobuf;
+    ANDROID_MIC_COMMIT = finalAttrs.version;
+    RNNOISE_MODEL_PATH = "${rnnoiseModel}";
+  };
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "cargo-target-dir"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
+  ];
+
+  preFixup = ''
+    libcosmicAppWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ android-tools ]})
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Use your Android phone as a microphone for your PC";
+    homepage = "https://github.com/teamclouday/AndroidMic";
+    changelog = "https://github.com/teamclouday/AndroidMic/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ irgendeinwer ];
+    platforms = lib.platforms.linux;
+    mainProgram = "android-mic";
+  };
+})


### PR DESCRIPTION
Backport of #559842 to `release-26.05`.
Includes maintainer commit from #531990 so package evaluation passes.
Supersedes failing bot PR #560687.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
