### PR TITLE
mcap-cli: add passthru.tests.full

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27777,6 +27777,12 @@
     name = "Steve Streza";
     keys = [ { fingerprint = "DFED 4E42 34E7 348C 57D4  6568 C4DC 30F8 5ABC 6FA1"; } ];
   };
+  stfl = {
+    email = "nixpkgs@stfl.dev";
+    github = "stfl";
+    githubId = 1321542;
+    name = "Stefan Lendl";
+  };
   stianlagstad = {
     email = "stianlagstad@gmail.com";
     github = "stianlagstad";

--- a/pkgs/by-name/mc/mcap-cli/package.nix
+++ b/pkgs/by-name/mc/mcap-cli/package.nix
@@ -1,64 +1,52 @@
 {
-  stdenv,
   lib,
-  buildGoModule,
+  stdenv,
   buildPackages,
+  rustPlatform,
   fetchFromGitHub,
   installShellFiles,
   nix-update-script,
 }:
-let
-  version = "0.0.62";
-in
-buildGoModule {
 
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mcap-cli";
-
-  inherit version;
+  version = "0.3.0";
 
   src = fetchFromGitHub {
-    repo = "mcap";
     owner = "foxglove";
-    rev = "releases/mcap-cli/v${version}";
-    hash = "sha256-lVTL+pa+gTPQWj7+RmaJUIdfOlPhlGtHujBalR+GDsI=";
+    repo = "mcap";
+    tag = "releases/mcap-cli/v${finalAttrs.version}";
+    hash = "sha256-QVJA/RZPamkBYkFNJn9uB1/cok6lEF/U7ssmdmzp4og=";
   };
 
-  vendorHash = "sha256-Q1TjUlS7+fV2HBQk108c+o/9IRpDc9C8jzBk048Mkig=";
+  cargoHash = "sha256-7WsGJd+KNNCke9pmvwN6zi0bDXBGfQcEotIxyYdUWAo=";
 
-  nativeBuildInputs = [
-    installShellFiles
-  ];
+  # The repository root is a Cargo workspace of the `mcap` library and this CLI;
+  # build and test only the CLI member.
+  buildAndTestSubdir = "rust/cli";
 
-  modRoot = "go/cli/mcap";
-
-  tags = [
-    "sqlite_omit_load_extension"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    "netgo"
-    "osusergo"
-  ];
-
-  ldflags = [ "-X github.com/foxglove/mcap/go/cli/mcap/cmd.Version=${version}" ];
-
-  env = {
-    CGO_ENABLED = "1";
-    GOWORK = "off";
-  };
-
-  # copy the local versions of the workspace modules
-  postConfigure = ''
-    chmod -R u+w vendor
-    rm -rf vendor/github.com/foxglove/mcap/go/{mcap,ros}
-    cp -r ../../{mcap,ros} vendor/github.com/foxglove/mcap/go
-  '';
-
+  # The tests these skip read fixtures under testdata/ and tests/conformance/data/, which
+  # are Git LFS objects: a source tarball carries the pointer files, not the payload.
+  # https://github.com/foxglove/mcap/issues/895
   checkFlags = [
-    # requires git-lfs and network
-    # https://github.com/foxglove/mcap/issues/895
-    "-skip=TestCat|TestInfo|TestRequiresDuplicatedSchemasForIndexedMessages|TestPassesIndexedMessagesWithRepeatedSchemas|TestSortFile"
+    "--skip=commands::cat::tests::cat_falls_back_for_summary_channel_with_in_chunk_schema"
+    "--skip=commands::cat::tests::cat_indexed_applies_topic_filter_to_chunk_local_channels"
+    "--skip=commands::cat::tests::cat_indexed_reads_chunk_index_without_message_indexes_and_in_chunk_channels"
+    "--skip=commands::cat::tests::cat_indexed_reads_message_index_with_in_chunk_channels"
+    "--skip=commands::cat::tests::chunk_local_channels_keep_remote_topic_plan_conservative"
+    "--skip=commands::convert::ros1_bag::tests::convert_real_bz2_ros1_bag_fixture"
+    "--skip=commands::convert::ros1_bag::tests::convert_real_uncompressed_ros1_bag_fixture"
+    "--skip=commands::convert::ros2_db3::tests::converts_iron_talker_db3_with_embedded_schemas"
+    "--skip=commands::convert::ros2_db3::tests::rejects_humble_talker_db3_without_embedded_schemas"
+    "--skip=commands::convert::ros2_db3::tests::rejects_humble_talker_db3_without_truncating_existing_output"
+    "--skip=commands::convert::tests::convert_command_handles_noetic_generated_ros1_bags"
   ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
+  # Completions come out of the built binary, so a cross build needs an emulator to
+  # run it. Guarding on emulatorAvailable rather than canExecute keeps all three
+  # shells installed when one exists, and skips them only when none does.
   postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
     let
       emulator = stdenv.hostPlatform.emulator buildPackages;
@@ -70,18 +58,23 @@ buildGoModule {
         --zsh <(${emulator} $out/bin/mcap completion zsh)
     ''
   );
-  passthru = {
-    updateScript = nix-update-script { };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "releases/mcap-cli/v(.*)"
+    ];
   };
 
   meta = {
     description = "MCAP CLI tool to inspect and fix MCAP files";
     homepage = "https://github.com/foxglove/mcap";
+    changelog = "https://github.com/foxglove/mcap/releases/tag/releases/mcap-cli/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       therishidesai
+      stfl
     ];
     mainProgram = "mcap";
   };
-
-}
+})


### PR DESCRIPTION
Noticed while packaging #560364 that the tests using git-lfs artifacts were not enabled. This adds a `passthru` element to run the full test suite and simplifies the closure. The full test suite is run with `-v` so that the log shows individual outputs.

The PR is currently in a weird state that is actually based on top of https://github.com/NixOS/nixpkgs/pull/561410. This is a much nicer approach with a better tool.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
