### PR TITLE
boost191: fix loongarch64-linux build

### DIFF
--- a/pkgs/by-name/bo/boost-build/package.nix
+++ b/pkgs/by-name/bo/boost-build/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   bison,
   # boost derivation to use for the src and version.
   # This is used by the boost derivation to build
@@ -34,6 +35,22 @@ stdenv.mkDerivation {
 
   patches =
     useBoost.boostBuildPatches or [ ]
+    ++
+      lib.optional
+        (
+          useBoost ? version
+          && lib.versionAtLeast useBoost.version "1.91"
+          && lib.versionOlder useBoost.version "1.92"
+          && stdenv.hostPlatform.isLoongArch64
+        )
+        # Fix crash in var_defines when define string is empty
+        # https://github.com/boostorg/boost/issues/1141
+        (
+          fetchpatch {
+            url = "https://github.com/boostorg/build/commit/708353cdeb6006757e7c6971283efb53f718ae25.patch";
+            hash = "sha256-9WWgQPyiKrvQY1ox6sdWoeksgNPDIy0DAbDOfQKJ5y0=";
+          }
+        )
     ++ lib.optional (
       useBoost ? version
       && lib.versionAtLeast useBoost.version "1.81"

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -269,7 +269,23 @@ stdenv.mkDerivation {
             hash = "sha256-0IHK55JSujYcwEVOuLkwOa/iPEkdAKQlwVWR42p/X2U=";
           }
         )
-
+    ++
+      lib.optional
+        (
+          lib.versionAtLeast version "1.91"
+          && lib.versionOlder version "1.92"
+          && stdenv.hostPlatform.isLoongArch64
+        )
+        # Fix crash in var_defines when define string is empty
+        # https://github.com/boostorg/boost/issues/1141
+        (
+          fetchpatch {
+            url = "https://github.com/boostorg/build/commit/708353cdeb6006757e7c6971283efb53f718ae25.patch";
+            stripLen = 1;
+            extraPrefix = "tools/build/";
+            hash = "sha256-uFdxuL3DXvr/jmz7jv/q76/S8JaNF//2ogTMwG/D2nY=";
+          }
+        )
     ++ lib.optionals (version == "1.87.0") [
       # Fix operator<< for shared_ptr and intrusive_ptr
       # https://github.com/boostorg/smart_ptr/issues/115


### PR DESCRIPTION
The failure occurs as early as `boost-build` on staging-next: https://hydra.nix4loong.cn/build/34645/nixlog/3

As a result, I patched both `boost-build` and `boost191` (`boost` after #560469).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
