### PR TITLE
chameleos: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/by-name/ch/chameleos/package.nix
+++ b/pkgs/by-name/ch/chameleos/package.nix
@@ -8,28 +8,26 @@
   wayland-protocols,
   libGL,
   vulkan-loader,
+  git,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "chameleos";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "Treeniks";
     repo = "chameleos";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jF4szo4+f7K+luhHVw4DQYte7E9S3A4qfnEzhN9uYyM=";
+    hash = "sha256-iIFUEUdnX+PtYAs5KRMn5c0vCuHRAkOxhP/PuveLC74=";
   };
 
-  cargoHash = "sha256-6LPu5Lvr9Gieu1l78RtsKr4WzxuPQEE3DPnR+01Luew=";
-
-  postPatch = ''
-    substituteInPlace build.rs --replace-fail '"git"' '"echo"'
-  '';
+  cargoHash = "sha256-3gy8X9QUIVFBpCtLDXL/7eDBEQHtRO8v1t8WnkzPyj4=";
 
   nativeBuildInputs = [
     pkg-config
     makeWrapper
+    git
   ];
 
   buildInputs = [
@@ -52,7 +50,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Screen annotation tool for niri and Hyprland";
     homepage = "https://github.com/Treeniks/chameleos";
-    license = lib.licenses.mit;
+    license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ lonerOrz ];
     mainProgram = "chameleos";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Upgrade chameleos from 0.2.0 to 0.2.1
- Fix license: upstream switched to GPLv3+, see [nixpkgs#558954 (comment)](https://github.com/NixOS/nixpkgs/pull/558954#issuecomment-5562601635)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
