### PR TITLE
windscribe: init at 2.24.12

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1504,6 +1504,7 @@
   ./services/networking/wg-quick.nix
   ./services/networking/wgautomesh.nix
   ./services/networking/whoogle-search.nix
+  ./services/networking/windscribe.nix
   ./services/networking/wireguard-networkd.nix
   ./services/networking/wireguard.nix
   ./services/networking/wpa_supplicant.nix

--- a/nixos/modules/services/networking/windscribe.nix
+++ b/nixos/modules/services/networking/windscribe.nix
@@ -1,0 +1,65 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.windscribe;
+in
+{
+  options.services.windscribe = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable the Windscribe VPN client daemon and system integration.
+
+        ::: {.note}
+        Users must be in the "windscribe" group to communicate with the helper socket:
+        `users.users.<name>.extraGroups = [ "windscribe" ];`
+        :::
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "windscribe" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    users.groups.windscribe = { };
+
+    users.users.windscribe = {
+      isSystemUser = true;
+      group = "windscribe";
+      description = "Windscribe daemon user";
+      home = "/var/lib/windscribe";
+    };
+
+    systemd.services.windscribe-helper = {
+      description = "Windscribe helper service";
+      before = [ "network-pre.target" ];
+      wants = [ "network-pre.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${lib.getExe' cfg.package "windscribe-helper"}";
+        ExecStopPost = "-${lib.getExe' cfg.package "windscribe-helper"} --reset-mac-addresses";
+        Restart = "on-failure";
+        RestartSec = 2;
+        Group = "windscribe";
+        RuntimeDirectory = "windscribe amneziawg";
+        RuntimeDirectoryMode = "0775";
+        LogsDirectory = "windscribe";
+        LogsDirectoryMode = "0775";
+        StateDirectory = "windscribe";
+        StateDirectoryMode = "0770";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ aliheidary1381 ];
+}

--- a/pkgs/by-name/ct/ctrld/package.nix
+++ b/pkgs/by-name/ct/ctrld/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "ctrld";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "Control-D-Inc";
+    repo = "ctrld";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-KrkEI07wfddDGmor2VT3I5gGmeZX75UGLZl++a6sE+c=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  vendorHash = "sha256-rsRlInNk6/C9DzJLbCoQSbV1exGfstbTxE8qitKmZ0c=";
+  subPackages = [ "cmd/ctrld" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/Control-D-Inc/ctrld/cmd/cli.version=v${finalAttrs.version}"
+  ];
+
+  meta = {
+    license = lib.licenses.mit;
+    description = "A highly configurable, multi-protocol DNS forwarding proxy";
+    homepage = "https://github.com/Control-D-Inc/ctrld";
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aliheidary1381 ];
+    mainProgram = "ctrld";
+  };
+})

--- a/pkgs/by-name/wi/windscribe-wstunnel/package.nix
+++ b/pkgs/by-name/wi/windscribe-wstunnel/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "windscribe-wstunnel";
+  version = "1.0.7";
+
+  src = fetchFromGitHub {
+    owner = "Windscribe";
+    repo = "wstunnel";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-m1vy6yQKE4PSAcYRvHIz0f3Mc08NB9OdZwhB0zk0LjA=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  proxyVendor = true;
+  vendorHash = "sha256-EChb+QiY4A1/XUnjCx9gAdrsNaSwiJ1r55gY/W74F5s=";
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    mv $out/bin/wstunnel $out/bin/windscribe-wstunnel
+  '';
+
+  meta = {
+    license = lib.licenses.gpl3Only;
+    description = "Tunnel proxy to wrap OpenVPN TCP traffic in to websocket or regular TCP traffic as a means to bypass OpenVPN blocks.";
+    homepage = "https://github.com/Windscribe/wstunnel";
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aliheidary1381 ];
+    mainProgram = "windscribe-wstunnel";
+  };
+})

--- a/pkgs/by-name/wi/windscribe/nixos.patch
+++ b/pkgs/by-name/wi/windscribe/nixos.patch
@@ -1,0 +1,274 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index db7cd90..6f2b8b4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -122,9 +122,7 @@ endif()
+ # ------------------------------------------------------------------------------
+ 
+ # vcpkg integration (only needed for build operations, must be before project())
+-if(BUILD_APP OR BUILD_INSTALLER OR BUILD_BOOTSTRAP)
+-    include(cmake/vcpkg.cmake)
+-endif()
++# vcpkg disabled for Nix
+ 
+ project(WS LANGUAGES CXX C)
+ 
+@@ -135,9 +133,7 @@ project(WS LANGUAGES CXX C)
+ # wsnet ahead of the install only fails on CI.  The macro depends solely on state established before
+ # project() (VCPKG_ROOT, VCPKG_TARGET_TRIPLET, CMAKE_BUILD_TYPE, the manifest root), so hoisting it
+ # here is safe.
+-if(BUILD_APP OR BUILD_INSTALLER OR BUILD_BOOTSTRAP)
+-    install_vcpkg_dependencies()
+-endif()
++# vcpkg install disabled for Nix
+ 
+ # Fetch wsnet here, in a pristine directory scope, BEFORE any project-wide compile/link options
+ # exist: the Objective-C ARC option and the Windows hardening flags below, the AUTOMOC/AUTOUIC/
+@@ -213,13 +209,13 @@ endif()
+ # leaving VCPKG_ROOT unset. Defined only here so an unguarded use fails to compile rather than
+ # silently getting "".
+ if(BUILD_APP)
+-    ws_resolve_openvpn_version(WS_OPENVPN_VERSION)
++    set(WS_OPENVPN_VERSION "@OPENVPN_VERSION@")
+     add_compile_definitions(WS_OPENVPN_VERSION="${WS_OPENVPN_VERSION}")
+ 
+     # Resolved here rather than next to ws_resolve_shared_libs() below, because the names are needed
+     # by the branding definitions that follow and by the subdirectories those definitions reach.
+     if(NOT WIN32)
+-        ws_resolve_openssl_libs()
++        # ws_resolve_openssl_libs skipped
+         if(APPLE)
+             # Not in the branding block below: the value is platform-specific, so a WS_MAC_ name must
+             # not be defined anywhere it would hold something other than the macOS one.
+@@ -342,8 +338,10 @@ if(NOT EXISTS "${WINDSCRIBE_BUILD_LIBS_PATH}")
+ endif()
+ 
+ # ------------------------------------------------------------------------------
+-ws_resolve_bundled_helpers()
+-ws_resolve_shared_libs()
++if(BUILD_INSTALLER)
++    ws_resolve_bundled_helpers()
++    ws_resolve_shared_libs()
++endif()
+ 
+ # ------------------------------------------------------------------------------
+ # Code Signing Configuration
+diff --git a/cmake/fetch_wsnet.cmake b/cmake/fetch_wsnet.cmake
+index 11afc32..d04e584 100644
+--- a/cmake/fetch_wsnet.cmake
++++ b/cmake/fetch_wsnet.cmake
+@@ -1,9 +1,8 @@
+ if(NOT TARGET wsnet::wsnet)
+-    include(FetchContent)
+-    FetchContent_Declare(wsnet
+-        GIT_REPOSITORY https://github.com/Windscribe/wsnet.git
+-        GIT_TAG        1.5.32
++    add_library(wsnet SHARED IMPORTED GLOBAL)
++    set_target_properties(wsnet PROPERTIES
++        IMPORTED_LOCATION "${WSNET_DIR}/lib/libwsnet.so"
++        INTERFACE_INCLUDE_DIRECTORIES "${WSNET_DIR}/include;${WSNET_DIR}/include/wsnet_internal"
+     )
+-    set(IS_BUILD_TESTS OFF)
+-    FetchContent_MakeAvailable(wsnet)
++    add_library(wsnet::wsnet ALIAS wsnet)
+ endif()
+diff --git a/src/client/CMakeLists.txt b/src/client/CMakeLists.txt
+index cada3aa..e21d1ee 100644
+--- a/src/client/CMakeLists.txt
++++ b/src/client/CMakeLists.txt
+@@ -183,7 +183,7 @@ if (WIN32)
+     target_link_options(${WS_APP_TARGET} PRIVATE "/IGNORE:4099")
+ endif()
+ 
+-target_link_libraries(${WS_APP_TARGET} PRIVATE ${FRONTEND_TYPE} frontend-common ${WS_CLIENT_EXTRA_LIBS} engine client-common wsnet::wsnet spdlog::spdlog Qt6::Network ${OS_SPECIFIC_LIBRARIES})
++target_link_libraries(${WS_APP_TARGET} PRIVATE ${FRONTEND_TYPE} frontend-common ${WS_CLIENT_EXTRA_LIBS} engine client-common wsnet::wsnet cares spdlog::spdlog Qt6::Network ${OS_SPECIFIC_LIBRARIES})
+ 
+ if (UNIX AND (NOT APPLE))
+     qt_import_plugins(${WS_APP_TARGET} INCLUDE Qt6::QWaylandIntegrationPlugin Qt6::QXcbIntegrationPlugin)
+diff --git a/src/client/client-common/types/proxysettings.cpp b/src/client/client-common/types/proxysettings.cpp
+index d51c3d9..f97a0bc 100644
+--- a/src/client/client-common/types/proxysettings.cpp
++++ b/src/client/client-common/types/proxysettings.cpp
+@@ -94,7 +94,7 @@ QString ProxySettings::curlAddress() const
+     if (option_ == PROXY_OPTION_HTTP)
+         return "http://" + address_ + ":" + QString::number(port_);
+     else if (option_ == PROXY_OPTION_SOCKS)
+-        return "socks5://" + address_ + ":" + QString::number(port_);
++        return "socks5h://" + address_ + ":" + QString::number(port_);
+     else
+         return "";
+ }
+@@ -185,14 +185,14 @@ bool ProxySettings::isProxyEnabled() const
+ void ProxySettings::validate()
+ {
+     option_ = enumFromInt<PROXY_OPTION>(static_cast<int>(option_));
+-    if (option_ == PROXY_OPTION_AUTODETECT || option_ == PROXY_OPTION_SOCKS) {
++    if (option_ == PROXY_OPTION_AUTODETECT) {
+         qCWarning(LOG_BASIC) << "ProxySettings: unsupported proxy option, resetting";
+         option_ = PROXY_OPTION_NONE;
+     }
+ 
+     bool needsReset = false;
+-    if (option_ == PROXY_OPTION_HTTP) {
+-        if (!NetworkingValidation::isIp(address_)) {
++    if (option_ == PROXY_OPTION_HTTP || option_ == PROXY_OPTION_SOCKS) {
++        if (!NetworkingValidation::isIpOrDomain(address_)) {
+             qCWarning(LOG_BASIC) << "ProxySettings: invalid address, disabling proxy";
+             needsReset = true;
+         } else if (!NetworkingValidation::isValidPort(static_cast<int>(port_))) {
+diff --git a/src/client/client-common/utils/linuxutils.cpp b/src/client/client-common/utils/linuxutils.cpp
+index cfeb2ef..784c17c 100644
+--- a/src/client/client-common/utils/linuxutils.cpp
++++ b/src/client/client-common/utils/linuxutils.cpp
+@@ -131,7 +131,7 @@ QMap<QString, QString> enumerateInstalledPrograms()
+     // On Linux, we are looking for desktop entries. These are located under the applications dir at ~/.local/share, and each dir in $XDG_DATA_DIRS
+     QByteArray xdgDataDirs = qgetenv("XDG_DATA_DIRS");
+     if (xdgDataDirs.isEmpty()) {
+-        xdgDataDirs = "/usr/local/share/:/usr/share/";
++        xdgDataDirs = "/run/current-system/sw/share:/usr/share/";
+     }
+     QStringList dirs = QString::fromLocal8Bit(xdgDataDirs).split(":");
+     QByteArray xdgDataHome = qgetenv("XDG_DATA_HOME");
+@@ -275,7 +275,7 @@ static QHash<QString, QString> enumerateFlatpakCommandMap()
+ 
+     QByteArray xdgDataDirs = qgetenv("XDG_DATA_DIRS");
+     if (xdgDataDirs.isEmpty()) {
+-        xdgDataDirs = "/usr/local/share/:/usr/share/";
++        xdgDataDirs = "/run/current-system/sw/share:/usr/share/";
+     }
+     QStringList dirs = QString::fromLocal8Bit(xdgDataDirs).split(":");
+     QByteArray xdgDataHome = qgetenv("XDG_DATA_HOME");
+diff --git a/src/client/frontend/cli/main.cpp b/src/client/frontend/cli/main.cpp
+index e60f3af..55f14d9 100644
+--- a/src/client/frontend/cli/main.cpp
++++ b/src/client/frontend/cli/main.cpp
+@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
+     }
+     QStringList pluginsPath;
+     pluginsPath << QString::fromStdString(path) + "/plugins";
+-    QCoreApplication::setLibraryPaths(pluginsPath);
++    // QCoreApplication::setLibraryPaths disabled for Nix
+ #endif
+ 
+     qSetMessagePattern("[{gmt_time} %{time process}] [%{category}]\t %{message}");
+diff --git a/src/client/frontend/gui/main.cpp b/src/client/frontend/gui/main.cpp
+index b32ddf7..b8291f1 100644
+--- a/src/client/frontend/gui/main.cpp
++++ b/src/client/frontend/gui/main.cpp
+@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
+         }
+         QStringList pluginsPath;
+         pluginsPath << QString::fromStdString(path) + "/plugins";
+-        QCoreApplication::setLibraryPaths(pluginsPath);
++        QCoreApplication::addLibraryPath(QString::fromStdString(path) + "/plugins");
+     #endif
+ #endif
+ 
+@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
+     // Must precede the gid drop: some loaders (e.g. Mesa) re-honor these once egid == gid.
+     // GL is disabled (pure Widgets, no GL context); QT_QPA_PLATFORM_PLUGIN_PATH is read separately
+     // from setLibraryPaths above, so unset it to keep the platform plugin in the bundled dir.
+-    if (!qputenv("QT_XCB_GL_INTEGRATION", "none") || !qunsetenv("QT_QPA_PLATFORM_PLUGIN_PATH")) {
++    if (!qputenv("QT_XCB_GL_INTEGRATION", "none")) {
+         qCCritical(LOG_BASIC) << "Could not neutralize environment";
+         return -1;
+     }
+diff --git a/src/client/frontend/gui/preferenceswindow/proxysettingswindow/proxysettingsgroup.cpp b/src/client/frontend/gui/preferenceswindow/proxysettingswindow/proxysettingsgroup.cpp
+index 589b038..21f853d 100644
+--- a/src/client/frontend/gui/preferenceswindow/proxysettingswindow/proxysettingsgroup.cpp
++++ b/src/client/frontend/gui/preferenceswindow/proxysettingswindow/proxysettingsgroup.cpp
+@@ -11,8 +11,7 @@ namespace PreferencesWindow {
+ 
+ static bool IsProxyOptionAllowed(int option_number) {
+     // Temporarily hide Auto-detect and SOCKS proxy options in the GUI.
+-    return option_number != PROXY_OPTION_AUTODETECT &&
+-           option_number != PROXY_OPTION_SOCKS;
++    return option_number != PROXY_OPTION_AUTODETECT;
+ }
+ 
+ ProxySettingsGroup::ProxySettingsGroup(ScalableGraphicsObject *parent, const QString &desc, const QString &descUrl)
+diff --git a/src/helper/linux/installer_verifier.cpp b/src/helper/linux/installer_verifier.cpp
+index 5cba132..b50ba7f 100644
+--- a/src/helper/linux/installer_verifier.cpp
++++ b/src/helper/linux/installer_verifier.cpp
+@@ -24,7 +24,7 @@
+ namespace {
+ 
+ constexpr const char *kStagingDir = "/var/lib/windscribe/update";
+-constexpr const char *kGpgvPath = "/usr/bin/gpgv";
++constexpr const char *kGpgvPath = "gpgv";
+ 
+ constexpr off_t kMaxPubBytes = 64 * 1024;
+ constexpr off_t kMaxSigBytes = 8 * 1024;
+diff --git a/src/helper/linux/split_tunneling/hostnames_manager/dns_resolver.h b/src/helper/linux/split_tunneling/hostnames_manager/dns_resolver.h
+index 7df7fa0..891c208 100644
+--- a/src/helper/linux/split_tunneling/hostnames_manager/dns_resolver.h
++++ b/src/helper/linux/split_tunneling/hostnames_manager/dns_resolver.h
+@@ -5,6 +5,7 @@
+ #include <optional>
+ #include <wsnet/WSNet.h>
+ #include <boost/asio.hpp>
++#include <boost/asio/deadline_timer.hpp>
+ 
+ // measuring time in ms helper
+ template <
+diff --git a/src/helper/linux/utils.cpp b/src/helper/linux/utils.cpp
+index f9c6ac2..4ecdd90 100644
+--- a/src/helper/linux/utils.cpp
++++ b/src/helper/linux/utils.cpp
+@@ -102,9 +102,13 @@ bool resolveExePath(const std::string &exePath, const std::string &executable, s
+ 
+ // check only for non-dev builds
+ #ifndef WINDSCRIBE_DEV_MODE
+-    if (strcmp(canonicalPath, WS_LINUX_INSTALL_DIR) != 0 && strcmp(canonicalPath, "/usr/lib" WS_LINUX_INSTALL_DIR) != 0) {
+-        // Don't execute arbitrary commands, only executables that are in our application directory
+-        spdlog::warn("Executable not in correct path, ignoring.");
++    char *expectedCanonical = realpath(WS_LINUX_INSTALL_DIR, NULL);
++    bool valid = (strcmp(canonicalPath, WS_LINUX_INSTALL_DIR) == 0) ||
++                 (strcmp(canonicalPath, "/usr/lib" WS_LINUX_INSTALL_DIR) == 0) ||
++                 (expectedCanonical && strcmp(canonicalPath, expectedCanonical) == 0);
++    if (expectedCanonical) free(expectedCanonical);
++    if (!valid) {
++        spdlog::warn("Executable not in correct path, ignoring: {}", canonicalPath);
+         free(canonicalPath);
+         return false;
+     }
+diff --git a/src/installer/windscribe/linux/opt/windscribe/scripts/update-systemd-resolved b/src/installer/windscribe/linux/opt/windscribe/scripts/update-systemd-resolved
+index d4aacc3..7f1ce43 100755
+--- a/src/installer/windscribe/linux/opt/windscribe/scripts/update-systemd-resolved
++++ b/src/installer/windscribe/linux/opt/windscribe/scripts/update-systemd-resolved
+@@ -28,7 +28,7 @@
+ # Define what needs to be called via DBus
+ DBUS_DEST="org.freedesktop.resolve1"
+ DBUS_NODE="/org/freedesktop/resolve1"
+-WINDSCRIBE_SYSTEMD_CONFIG_DIR="/usr/local/lib/systemd/resolved.conf.d"
++WINDSCRIBE_SYSTEMD_CONFIG_DIR="/etc/systemd/resolved.conf.d"
+ WINDSCRIBE_SYSTEMD_CONFIG_FILE="$WINDSCRIBE_SYSTEMD_CONFIG_DIR/windscribe.conf"
+ 
+ SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
+diff --git a/src/windscribe-cli/main.cpp b/src/windscribe-cli/main.cpp
+index 563f6b5..4163692 100644
+--- a/src/windscribe-cli/main.cpp
++++ b/src/windscribe-cli/main.cpp
+@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
+ 
+     // clear Qt plugin library paths for release build
+ #ifndef QT_DEBUG
+-    QCoreApplication::setLibraryPaths(QStringList());
++    // QCoreApplication::setLibraryPaths disabled for Nix
+ #endif
+ 
+     QCoreApplication::setApplicationName(WS_SETTINGS_APP);
+diff --git a/src/helper/linux/main.cpp b/src/helper/linux/main.cpp
+index 8873e7d..004e1fb 100644
+--- a/src/helper/linux/main.cpp
++++ b/src/helper/linux/main.cpp
+@@ -21,7 +21,7 @@ int main(int argc, const char *argv[])
+     // Pin before anything can spawn a child: every command we run as root goes through a shell,
+     // and the packages invoke us outside systemd (--reset-mac-addresses from prerm/preun), where
+     // the unit's Environment=PATH does not apply and dpkg hands us /usr/local/{sbin,bin} first.
+-    setenv("PATH", "/usr/sbin:/usr/bin:/sbin:/bin", 1);
++    setenv("PATH", "/usr/sbin:/usr/bin:/sbin:/bin", 0);
+
+     // Initialize logger
+     std::string path = WS_LINUX_LOG_DIR;

--- a/pkgs/by-name/wi/windscribe/package.nix
+++ b/pkgs/by-name/wi/windscribe/package.nix
@@ -1,0 +1,402 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ctrld,
+  windscribe-wstunnel,
+  cmake,
+  ninja,
+  pkg-config,
+  makeBinaryWrapper,
+  qt6,
+  boost,
+  miniaudio,
+  libnl,
+  libcap_ng,
+  nftables,
+  iptables,
+  iproute2,
+  networkmanager,
+  procps,
+  spdlog,
+  fmt,
+  c-ares,
+  openssl_4_0,
+  curl,
+  amneziawg-go,
+  tl-expected,
+  range-v3,
+  nlohmann_json,
+  acl,
+  autoreconfHook,
+  lzo,
+  lz4,
+  python3Packages,
+  cmakerc,
+  gtest,
+  rapidjson,
+  e2fsprogs,
+  util-linux,
+  kmod,
+  iw,
+  systemd,
+  bash,
+  coreutils,
+  gnused,
+  gnugrep,
+  gawk,
+  gnupg,
+  ethtool,
+}:
+
+let
+  # Upstream Windscribe vcpkg port registry (contains custom crypto/tunnel patches)
+  ws-vcpkg-registry = fetchFromGitHub {
+    owner = "Windscribe";
+    repo = "ws-vcpkg-registry";
+    rev = "ef9b1277cc637891ca2b17638e21aa5d71f8f379";
+    hash = "sha256-ZjXPjt1Hv8lXB39v6c50OAfnosKUdpHuzgnbt7d0SUE=";
+  };
+
+  # 1. Skyr URL
+  skyr-url = stdenv.mkDerivation {
+    pname = "skyr-url";
+    version = "1.13.0";
+    src = fetchFromGitHub {
+      owner = "cpp-netlib";
+      repo = "url";
+      rev = "v1.13.0";
+      hash = "sha256-f+WcXdvsIGfXUIIK039DP3GS/BzOMbx9lH0G2ZM9NOg=";
+    };
+    nativeBuildInputs = [ cmake ];
+    propagatedBuildInputs = [
+      nlohmann_json
+      range-v3
+      tl-expected
+    ];
+    cmakeFlags = [
+      "-Dskyr_BUILD_TESTS=OFF"
+      "-Dskyr_BUILD_DOCS=OFF"
+      "-Dskyr_BUILD_EXAMPLES=OFF"
+      "-Dskyr_WARNINGS_AS_ERRORS=OFF"
+      "-Dskyr_ENABLE_FILESYSTEM_FUNCTIONS=OFF"
+    ]; # matches https://github.com/Windscribe/ws-vcpkg-registry/blob/main/ports/skyr-url/portfile.cmake
+  };
+
+  # 2. OpenSSL with TLS Padding Support
+  openssl-custom = openssl_4_0.overrideAttrs (old: {
+    patches = (old.patches or [ ]) ++ [
+      "${ws-vcpkg-registry}/ports/openssl/tls-padding.patch"
+    ];
+  });
+
+  # 3. cURL with Super-Large Padding & Legacy EC Point Formats
+  curl-custom = (curl.override { openssl = openssl-custom; }).overrideAttrs (old: {
+    patches = (old.patches or [ ]) ++ [
+      "${ws-vcpkg-registry}/ports/curl/super-large-padding-extension.patch"
+      "${ws-vcpkg-registry}/ports/curl/Export-SSL_OP_LEGACY_EC_POINT_FORMATS-OpenSSL-option.patch"
+    ];
+  });
+
+  # 4. Inlined Header Dependencies for wsnet
+  cpp-base64 = stdenv.mkDerivation {
+    pname = "cpp-base64";
+    version = "V2.rc.08";
+
+    src = fetchFromGitHub {
+      owner = "ReneNyffenegger";
+      repo = "cpp-base64";
+      rev = "V2.rc.08";
+      hash = "sha256-6O0nmrC4pnzN4R3TOLCd+8cyje/n8mpCXX4lDYlXnHE=";
+    };
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/include/cpp-base64
+      cp base64.* $out/include/cpp-base64/
+      runHook postInstall
+    '';
+  };
+
+  advobfuscatorSrc = fetchFromGitHub {
+    owner = "andrivet";
+    repo = "ADVobfuscator";
+    rev = "1852a0eb75b03ab3139af7f938dfb617c292c600"; # legacy branch
+    hash = "sha256-qleFYWPmCYHHtBO3Op3e8T6fxmC/3KwpatcQ8keiiz8=";
+  };
+
+  # 5. wsnet Library
+  wsnet = stdenv.mkDerivation (finalAttrs: {
+    pname = "wsnet";
+    version = "1.5.32";
+    src = fetchFromGitHub {
+      owner = "Windscribe";
+      repo = "wsnet";
+      rev = "1.5.32";
+      hash = "sha256-W4qArEGc5Vk9HXoZlZxD8JEl9NRadJzZsKBYf5zZyOI=";
+    };
+    nativeBuildInputs = [
+      cmake
+      pkg-config
+    ];
+    buildInputs = [
+      c-ares
+      curl-custom
+      openssl-custom
+      spdlog
+      rapidjson
+      skyr-url
+      boost
+      cmakerc
+      gtest
+    ];
+    postPatch = ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "find_package(CURL CONFIG REQUIRED)" "find_package(CURL REQUIRED)" \
+        --replace-fail 'set(WSNET_VERSION_FALLBACK "0.0.0")' 'set(WSNET_VERSION_FALLBACK "${finalAttrs.version}")' \
+        --replace-fail 'set(WSNET_GIT_DESCRIBE "unknown")' 'set(WSNET_GIT_DESCRIBE "v${finalAttrs.version}")'
+    '';
+    cmakeFlags = [
+      "-DCPP_BASE64_INCLUDE_DIRS=${cpp-base64}/include"
+      "-DADVOBFUSCATOR_INCLUDE_DIRS=${advobfuscatorSrc}"
+    ];
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib $out/include $out/include/wsnet_internal
+      install -m 755 libwsnet.so $out/lib/
+      cp -r $src/include/* $out/include/
+
+      cp wsnet_version.h $out/include/
+      cp wsnet_version.h $out/include/wsnet_internal/
+
+      cp -r $src/src/* $out/include/wsnet_internal/
+
+      runHook postInstall
+    '';
+  });
+
+  # 6. OpenVPN 2.7.5 with DCO & Anti-Censorship Patches
+  windscribeopenvpn = stdenv.mkDerivation {
+    pname = "windscribeopenvpn";
+    version = "2.7.5";
+    src = fetchFromGitHub {
+      owner = "OpenVPN";
+      repo = "openvpn";
+      rev = "b25bb2a8bda814edab39b4246d4e296330a7a29e";
+      hash = "sha256-oyKidDw+3PRmHezyftfYXqe8pIwF0Bnr4ue1Alq5zKc=";
+    };
+    nativeBuildInputs = [
+      autoreconfHook
+      pkg-config
+    ];
+    buildInputs = [
+      openssl-custom
+      lzo
+      lz4
+      libcap_ng
+      libnl
+    ];
+    patches = [
+      "${ws-vcpkg-registry}/ports/openvpn/anti-censorship.patch"
+      "${ws-vcpkg-registry}/ports/openvpn/0002-Anti-censorship-add-support-for-Amnezia-s-Jc-Jmin-Jm.patch"
+      "${ws-vcpkg-registry}/ports/openvpn/0003-Anti-censorship-introduce-junk-first-option-Jc-befor.patch"
+    ];
+    configureFlags = [
+      "--with-crypto-library=openssl"
+      "--disable-plugin-auth-pam"
+      "--disable-plugin-down-root"
+      "--enable-dco"
+    ];
+    installTargets = [ "install-exec" ];
+    postInstall = ''
+      mkdir -p $out/bin
+      mv $out/sbin/openvpn $out/bin/openvpn
+    '';
+  };
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "windscribe";
+  version = "2.24.12";
+
+  src = fetchFromGitHub {
+    owner = "Windscribe";
+    repo = "Desktop-App";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-RiSpysVSrzhWtTgkQmspQ/Hj2cFQLIyjEtfoT7YhM1Q=";
+  };
+
+  patches = [
+    ./nixos.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '@OPENVPN_VERSION@' "${windscribeopenvpn.version}"
+    substituteInPlace cmake/integrations/windscribe.cmake \
+      --replace-fail 'set(WS_POSIX_CONFIG_DIR "/etc/windscribe")' 'set(WS_POSIX_CONFIG_DIR "'"$out"'/etc/windscribe")' \
+      --replace-fail 'set(WS_LINUX_INSTALL_DIR "/opt/windscribe")' 'set(WS_LINUX_INSTALL_DIR "'"$out"'/opt/windscribe")' \
+      --replace-fail 'set(WS_LINUX_RUN_DIR "/var/run/windscribe")' 'set(WS_LINUX_RUN_DIR "/run/windscribe")'
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+    makeBinaryWrapper
+    bash
+    python3Packages.python
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qtwayland
+    qt6.qttools
+    boost
+    miniaudio.dev
+    libnl
+    libcap_ng
+    nftables
+    spdlog
+    fmt
+    c-ares
+    openssl-custom
+    tl-expected
+    range-v3
+    nlohmann_json
+    acl
+    skyr-url
+    wsnet
+  ];
+
+  NIX_CFLAGS_COMPILE = "-isystem ${miniaudio.dev}/include/miniaudio";
+
+  cmakeFlags = [
+    "-DBUILD_INSTALLER=OFF"
+    "-DBUILD_DEB=OFF"
+    "-DWSNET_DIR=${wsnet}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt/windscribe/lib $out/bin $out/share/applications $out/share/icons/hicolor $out/etc/windscribe/autostart
+
+    # 1. Main Binaries & Shared Libraries
+    install -m 755 src/client/Windscribe $out/opt/windscribe/Windscribe
+    install -m 755 src/windscribe-cli/windscribe-cli $out/opt/windscribe/windscribe-cli
+    install -m 755 src/helper/linux/helper $out/opt/windscribe/helper
+    ln -s helper $out/opt/windscribe/windscribe-helper
+    install -m 755 ${wsnet}/lib/libwsnet.so $out/opt/windscribe/lib/libwsnet.so
+
+    # 2. Bundled Helper Executables
+    install -m 755 ${ctrld}/bin/ctrld $out/opt/windscribe/windscribectrld
+    ln -s ${amneziawg-go}/bin/amneziawg-go $out/opt/windscribe/windscribeamneziawg
+    install -m 755 ${windscribe-wstunnel}/bin/windscribe-wstunnel $out/opt/windscribe/windscribewstunnel
+    install -m 755 ${windscribeopenvpn}/bin/openvpn $out/opt/windscribe/windscribeopenvpn
+
+    # 3. Scripts
+    mkdir -p $out/opt/windscribe/scripts
+    cp -r ../src/installer/windscribe/linux/opt/windscribe/scripts/* $out/opt/windscribe/scripts/
+
+    cat > $out/opt/windscribe/scripts/install-update << 'EOF'
+    #!${lib.getExe bash}
+    echo "Windscribe on NixOS is managed declaratively."
+    echo "Update your flake inputs and run: rebuild"
+    exit 0
+    EOF
+
+    chmod -R u+w $out/opt/windscribe/scripts
+    chmod -R +x $out/opt/windscribe/scripts
+
+    for script in $out/opt/windscribe/scripts/*; do
+      substituteInPlace "$script" \
+        --replace-quiet '#!/bin/bash' '#!${lib.getExe bash}' \
+        --replace-quiet '#!/usr/bin/env bash' '#!${lib.getExe bash}'
+    done
+
+    for script in $out/opt/windscribe/scripts/*; do
+      wrapProgram "$script" \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            bash
+            coreutils
+            iproute2
+            systemd
+            util-linux
+            kmod
+            gnused
+            gnugrep
+            e2fsprogs
+          ]
+        }
+    done
+
+    # 4. Desktop Entries & Icons
+    install -m 644 ../src/installer/gui/linux/overlay/usr/share/applications/windscribe.desktop $out/share/applications/windscribe.desktop
+    substituteInPlace $out/share/applications/windscribe.desktop \
+      --replace-fail "Exec=/opt/windscribe/Windscribe" "Exec=windscribe"
+
+    install -m 644 ../src/installer/gui/linux/overlay/etc/windscribe/autostart/windscribe.desktop $out/etc/windscribe/autostart/windscribe.desktop
+    substituteInPlace $out/etc/windscribe/autostart/windscribe.desktop \
+      --replace-fail "Exec=/opt/windscribe/Windscribe" "Exec=windscribe"
+
+    for size in 16x16 24x24 32x32 48x48 64x64 128x128 256x256; do
+      iconDir="$out/share/icons/hicolor/$size/apps"
+      mkdir -p "$iconDir"
+      install -m 644 "../src/installer/gui/linux/png_icons/$size/windscribe.png" "$iconDir/Windscribe.png"
+      ln -sf Windscribe.png "$iconDir/windscribe.png"
+    done
+
+    # 5. CLI & GUI Wrappers
+    mkdir -p $out/bin
+    ln -sf ../opt/windscribe/windscribe-cli $out/bin/windscribe-cli
+    ln -sf ../opt/windscribe/helper $out/bin/windscribe-helper
+    ln -sf ../opt/windscribe/Windscribe $out/bin/windscribe
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapQtApp "$out/opt/windscribe/Windscribe"
+    wrapQtApp "$out/opt/windscribe/windscribe-cli"
+    wrapProgram "$out/opt/windscribe/helper" --prefix PATH : ${
+      lib.makeBinPath [
+        iproute2
+        iptables
+        nftables
+        procps
+        systemd
+        networkmanager
+        coreutils
+        util-linux
+        kmod
+        ethtool
+        iw
+        e2fsprogs
+        gnused
+        gnugrep
+        gnupg
+        gawk
+      ]
+    }
+  '';
+
+  meta = {
+    description = "Windscribe Desktop VPN Client and Helper Suite";
+    homepage = "https://windscribe.com";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ aliheidary1381 ];
+    platforms = with lib.platforms; linux ++ darwin;
+    broken = stdenv.hostPlatform.isDarwin;
+    mainProgram = "windscribe";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Windscribe is a paid VPN service, with a FOSS client. The package includes custom versions of OpenVPN, WireGuard, and Stealth protocols, with patches to circumvent DPI and censorship. It also includes their dedicated DNS forwarding proxy, etc.

The project was a mess, with a lot of hardcoded references to `/usr/bin`, `/usr/local`, etc. This PR patches all, and builds everything from source. This solves [https://github.com/NixOS/nixpkgs/issues/158368](https://github.com/NixOS/nixpkgs/issues/158368) and [https://github.com/NixOS/nixpkgs/issues/214732](https://github.com/NixOS/nixpkgs/issues/214732). Recently, [#507477](https://github.com/NixOS/nixpkgs/pull/507477) has also tried to build Windscribe, but it needs nix-ld, and it uses a prebuilt debian package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
