### PR TITLE
xla: add opt-in CUDA support and PJRT regression tests

### DIFF
--- a/pkgs/by-name/xl/xla/cuda-local.nix
+++ b/pkgs/by-name/xl/xla/cuda-local.nix
@@ -1,0 +1,71 @@
+# Assemble CUDA, cuDNN, and NCCL layouts from the selected nixpkgs package
+# outputs. XLA's Bazel configuration expects toolkit-style directory trees via
+# LOCAL_CUDA_PATH, LOCAL_CUDNN_PATH, and LOCAL_NCCL_PATH, rather than Nix's split
+# outputs. These layouts let it use packaged dependencies and generate its local
+# repositories offline instead of downloading them.
+{
+  lib,
+  symlinkJoin,
+  cudaPackages,
+}:
+let
+  # Read only the requested outputs, not propagated inputs (notably older CCCL
+  # and cuda_compat). Repeated single-output packages are deduplicated.
+  outputs = names: package: map (name: lib.getOutput name package) names;
+  components =
+    with cudaPackages;
+    [
+      cuda_nvcc
+      cuda_cudart
+      cuda_cupti
+      libcublas
+      libcufft
+      libcurand
+      libcusolver
+      libcusparse
+      cuda_nvrtc
+      libnvjitlink
+      cuda_nvml_dev
+      cuda_nvdisasm
+      cuda_nvprune
+      cuda_profiler_api
+      cuda_nvtx
+    ]
+    ++ lib.optional (lib.versionAtLeast cudaPackages.cuda_nvcc.version "13") cudaPackages.cuda_crt;
+  cudaRoots = lib.unique (
+    lib.concatMap (outputs [
+      "include"
+      "lib"
+      "bin"
+    ]) components
+    ++ [
+      (lib.getOutput "static" cudaPackages.cuda_cudart)
+      (lib.getOutput "stubs" cudaPackages.cuda_nvml_dev)
+    ]
+  );
+in
+{
+  inherit cudaRoots;
+  cuda = symlinkJoin {
+    name = "xla-local-cuda";
+    paths = cudaRoots;
+    # CCCL is supplied separately by XLA's pinned GitHub repository, never by
+    # propagated build inputs or a path selected by the standard join order.
+    postBuild = ''
+      for entry in include/cuda/std include/thrust include/cub include/nv/target; do
+        if test -e "$out/$entry"; then
+          echo "unexpected CCCL header in local CUDA view: $entry" >&2
+          exit 1
+        fi
+      done
+    '';
+  };
+  cudnn = symlinkJoin {
+    name = "xla-local-cudnn";
+    paths = lib.unique (outputs [ "include" "lib" ] cudaPackages.cudnn);
+  };
+  nccl = symlinkJoin {
+    name = "xla-local-nccl";
+    paths = lib.unique (outputs [ "dev" "lib" ] cudaPackages.nccl);
+  };
+}

--- a/pkgs/by-name/xl/xla/package.nix
+++ b/pkgs/by-name/xl/xla/package.nix
@@ -1,31 +1,137 @@
 {
+  autoAddDriverRunpath,
+  autoPatchelfHook,
   bazel_7,
   buildBazelPackage,
+  callPackage,
+  config,
+  cudaPackages,
+  cudaSupport ? config.cudaSupport,
+  elfutils,
   fetchFromGitHub,
+  file,
   gitMinimal,
+  glibc,
   lib,
-  llvmPackages_18,
+  libxml2,
+  ncurses,
+  ncurses5,
   patchelf,
   python3,
+  rdma-core,
   stdenv,
   which,
+  writeText,
+  zlib,
 }:
 
 let
-  # XLA requires clang 18 -- gcc and newer clang versions (e.g., 21) fail with
-  # stricter template syntax checks in xla/tsl/concurrency/async_value_ref.h
-  #
-  # ABI compatibility with other Nixpkgs stdenv-built packages can be confirmed
-  # by seeing that
-  #
-  #   ldd $(nix-build -A xla)/lib/libservice.so 2>/dev/null | grep -E '(libstdc\+\+|libc\+\+)'
-  #
-  # shows libstdc++ as being linked from gcc.
-  clangStdenv = llvmPackages_18.stdenv;
-
   pythonEnv = python3.withPackages (ps: with ps; [ numpy ]);
+
+  # XLA's compute_* spelling emits both SASS and PTX; sm_* emits only SASS.
+  # Keep the selected package set's ordering and forward-compatibility policy.
+  cudaCapabilities =
+    let
+      inherit (cudaPackages.flags) realArches virtualArches cudaForwardCompat;
+      arches =
+        if cudaForwardCompat then lib.init realArches ++ [ (lib.last virtualArches) ] else realArches;
+    in
+    assert lib.assertMsg
+      (lib.all (arch: builtins.match "(sm_|compute_)[0-9]{2,3}a?" arch != null) arches)
+      "xla: the pinned CUDA rules do not support these cudaCapabilities (including family-specific f suffixes)";
+    lib.concatStringsSep "," arches;
+
+  cudaManifests = { inherit (cudaPackages.manifests) cuda cudnn; };
+  cudaManifestHash = builtins.hashString "sha256" (builtins.toJSON cudaManifests);
+  cudaLocal = callPackage ./cuda-local.nix { inherit cudaPackages; };
+
+  # Keep a real build-only driver, not a toolkit stub, for CUDA-linked exec
+  # tools. CCCL has its own LOCAL_CCCL_PATH hook and stays pinned by XLA.
+  # The inner toJSON serializes manifest data for json.decode; the outer one
+  # quotes and escapes that text as a Starlark string literal.
+  cudaRedistributions = writeText "xla-cuda-redistributions.bzl" ''
+    load("@rules_ml_toolchain//gpu/cuda:cuda_redist_versions.bzl", "REDIST_VERSIONS_TO_BUILD_TEMPLATES")
+    CUDA_REDISTRIBUTIONS = json.decode(${builtins.toJSON (builtins.toJSON cudaManifests.cuda)})
+    CUDNN_REDISTRIBUTIONS = json.decode(${builtins.toJSON (builtins.toJSON cudaManifests.cudnn)})
+    NIX_CUDA_TEMPLATES = dict(REDIST_VERSIONS_TO_BUILD_TEMPLATES)
+    NIX_CUDA_TEMPLATES["nvidia_driver"] = dict(NIX_CUDA_TEMPLATES["nvidia_driver"])
+    NIX_CUDA_TEMPLATES["nvidia_driver"]["local"] = dict(NIX_CUDA_TEMPLATES["nvidia_driver"]["local"], local_path_env_var = "XLA_LOCAL_DRIVER_PATH")
+  '';
+
+  # Omit selected-output-backed repositories and generated CUDA configuration
+  # from the relocatable FOD. Bazel regenerates them offline with the real paths.
+  # Keep local_config_nccl: its path-independent aliases cannot be recreated by
+  # Bazel 7 from the restored archive, and resolve through regenerated cuda_nccl.
+  localCudaRepositories = [
+    "cuda_cublas"
+    "cuda_cudart"
+    "cuda_cufft"
+    "cuda_cupti"
+    "cuda_curand"
+    "cuda_cusolver"
+    "cuda_cusparse"
+    "cuda_nvjitlink"
+    "cuda_nvrtc"
+    "cuda_crt"
+    "cuda_nvcc"
+    "cuda_nvvm"
+    "cuda_nvdisasm"
+    "cuda_nvml"
+    "cuda_nvprune"
+    "cuda_profiler_api"
+    "cuda_nvtx"
+    "cuda_cudnn"
+    "cuda_nccl"
+    "local_config_cuda"
+  ];
+  removeLocalCudaRepositories = ''
+    for repository in ${lib.escapeShellArgs localCudaRepositories}; do
+      rm -rf "$bazelOut/external/$repository" "$bazelOut/external/@$repository.marker"
+    done
+  '';
+
+  configureCuda = capabilities: ''
+    ${lib.getExe pythonEnv} ./configure.py \
+      --backend=CUDA \
+      --host_compiler=CLANG \
+      --cuda_compiler=NVCC \
+      --cuda_compute_capabilities=${capabilities} \
+      --cuda_version=${cudaManifests.cuda.release_label} \
+      --cudnn_version=${cudaManifests.cudnn.release_label} \
+      --local_cuda_path=${cudaLocal.cuda} \
+      --local_cudnn_path=${cudaLocal.cudnn} \
+      --local_nccl_path=${cudaLocal.nccl} \
+      --nccl
+  '';
+
+  hostRpath = lib.makeLibraryPath [
+    glibc
+    stdenv.cc.cc.lib
+    zlib
+  ];
+
+  # Omit nixpkgs' NVSHMEM 3.6.5-0: its IBRC transport has SONAME 5, while
+  # the existing CUDA 12 build with NVSHMEM 3.2.5 needs SONAME 3 (host and
+  # bootstrap remain SONAME 3 in both versions). Install matching DSOs below;
+  # a coherent newer build/runtime migration has not been validated.
+  cudaRuntimeLibs = lib.optionals cudaSupport (
+    (with cudaPackages; [
+      (lib.getLib cuda_cudart)
+      (lib.getLib cuda_cupti)
+      (lib.getLib libcublas)
+      (lib.getLib libcufft)
+      (lib.getLib libcurand)
+      (lib.getLib libcusolver)
+      (lib.getLib libcusparse)
+      (lib.getLib cudnn)
+      (lib.getLib nccl)
+      (lib.getLib cuda_nvrtc)
+      (lib.getLib libnvjitlink)
+    ])
+    ++ [ (lib.getLib rdma-core) ]
+  );
 in
-(buildBazelPackage.override { stdenv = clangStdenv; }) {
+(buildBazelPackage {
   pname = "xla";
   version = "0-unstable-2026-02-21";
 
@@ -50,13 +156,6 @@ in
     ''
       rm -f .bazelversion
       patchShebangs .
-    ''
-    # Remove rules_ml_toolchain's hermetic CC toolchain registrations.
-    # These try to lazily download LLVM binaries (llvm18_linux_x86_64,
-    # sysroot_linux_x86_64_glibc_2_27) during analysis, which fails in the
-    # sandboxed build phase. We use our own clang from nixpkgs instead.
-    + ''
-      sed -i '/^register_toolchains("@rules_ml_toolchain/d' WORKSPACE
     ''
     # Remove @pypi//lit dependencies that trigger rules_python's hermetic
     # Python download for lit test targets (only needed for running lit tests,
@@ -86,9 +185,9 @@ in
     # rules_python's python_repository.bzl to run patchelf right after
     # extracting the binary, using NIX_DYNAMIC_LINKER from --repo_env.
     #
-    # In the build phase, fetchAttrs.preInstall normalizes all /nix/store
+    # In the build phase, fetchAttrs.installPhase normalizes all /nix/store
     # paths for reproducibility (breaking the patchelf), so
-    # buildAttrs.preConfigure re-patchelfs the binary for the actual build.
+    # buildAttrs.postConfigure re-patchelfs the binary for the actual build.
     + ''
       cp ${./rules-python-nix-patchelf.patch} third_party/py/rules_python_nix_patchelf.patch
       substituteInPlace third_party/py/python_init_rules.bzl \
@@ -109,19 +208,29 @@ in
             "//third_party/grpc:grpc.patch",
             "//third_party/grpc:grpc-pin-go-sdk.patch",
           ],'
+    ''
+    # Local hooks consume selected processed outputs, including downstream
+    # patches. Metadata still supplies the build-only driver and upstream extras;
+    # bypass the older JSON lookup without changing XLA's CCCL 3.2.0 override.
+    + lib.optionalString cudaSupport ''
+      cp ${cudaRedistributions} nix_cuda_redist.bzl
+      substituteInPlace WORKSPACE \
+        --replace-fail 'cuda_json_init_repository()' "" \
+        --replace-fail '"@cuda_redist_json//:distributions.bzl"' '"//:nix_cuda_redist.bzl", "NIX_CUDA_TEMPLATES"' \
+        --replace-fail 'REDIST_VERSIONS_TO_BUILD_TEMPLATES | CCCL_GITHUB_VERSIONS_TO_BUILD_TEMPLATES' \
+          'NIX_CUDA_TEMPLATES | CCCL_GITHUB_VERSIONS_TO_BUILD_TEMPLATES'
     '';
 
-  # Configure XLA for CPU-only build using the official configure.py script.
-  # This creates a xla_configure.bazelrc file with the appropriate options.
-  # Using clang which matches XLA CI environment.
-  # Note: --python_bin_path only sets PYTHON_BIN_PATH; it does not disable
-  # rules_python's hermetic Python download (triggered by python_init_toolchains).
-  preConfigure = ''
-    ${lib.getExe pythonEnv} ./configure.py \
-      --backend=CPU \
-      --host_compiler=CLANG \
-      --clang_path=${lib.getExe clangStdenv.cc}
-  '';
+  # Omitting --clang_path selects XLA's rules_ml_toolchain Clang 18 toolchain.
+  preConfigure =
+    if cudaSupport then
+      configureCuda cudaCapabilities
+    else
+      ''
+        ${lib.getExe pythonEnv} ./configure.py \
+          --backend=CPU \
+          --host_compiler=CLANG
+      '';
 
   bazelTargets = [
     "//xla/..."
@@ -131,82 +240,271 @@ in
   # filters and size constraints. See https://github.com/openxla/xla/issues/36756.
 
   bazelFlags = [
-    "-c opt"
-    # Use sandboxed strategy for most actions, but allow local for genrules
-    # and copy actions that have issues with strict sandboxing
-    "--spawn_strategy=sandboxed,local"
-    "--genrule_strategy=sandboxed,local"
+    "-c"
+    "opt"
+    # Bazel's nested sandbox cannot reliably execute downloaded hermetic tools;
+    # the outer Nix build sandbox still isolates local actions.
+    "--spawn_strategy=local"
+    "--genrule_strategy=local"
     # Disable bzlmod - XLA uses WORKSPACE for deps and bzlmod would try to
-    # access the Bazel Central Registry during the build phase
+    # access the Bazel Central Registry during the build phase.
     "--noenable_bzlmod"
-    # Work around missing includes in bundled LLVM headers
+    # Work around missing includes in bundled LLVM headers.
     "--cxxopt=-include"
     "--cxxopt=cstdint"
     "--host_cxxopt=-include"
     "--host_cxxopt=cstdint"
-    # Exclude targets that have incompatibilities
-    "--build_tag_filters=-mobile,-ios,-no_oss,-gpu"
-    # Dynamic linker path for patchelf in rules-python-nix-patchelf.patch
-    "--repo_env=NIX_DYNAMIC_LINKER=${clangStdenv.cc.libc}/lib/ld-linux-x86-64.so.2"
+    # Exec-configuration tools are linked against the hermetic Ubuntu sysroot;
+    # give them the NixOS dynamic linker so Bazel can execute them.
+    "--host_linkopt=-Wl,--dynamic-linker=${stdenv.cc.bintools.dynamicLinker}"
+    "--host_linkopt=-Wl,-rpath,${hostRpath}"
+    # Exclude targets that have incompatibilities.
+    "--build_tag_filters=-mobile,-ios,-no_oss${
+      if cudaSupport then ",-rocm-only,-oneapi-only" else ",-gpu"
+    }"
+    # Dynamic linker path for patchelf in rules-python-nix-patchelf.patch.
+    "--repo_env=NIX_DYNAMIC_LINKER=${stdenv.cc.bintools.dynamicLinker}"
+  ]
+  ++
+    lib.optional cudaSupport
+      # Bazel 7 resets Starlark flags for exec-configured tools. Use the legacy
+      # define that preConfigure maps to rules_ml_toolchain's CUDA settings.
+      "--define=using_cuda_nvcc=true";
 
-  ];
+  # The registered rules_ml toolchain provides its own compiler and sysroot.
+  dontAddBazelOpts = true;
 
   removeRulesCC = false;
-  # We need some local_config_* repos (CUDA, ROCm, TensorRT stubs) in the build
-  # phase.
   removeLocal = false;
 
   fetchAttrs = {
+    # nccl_archive is first requested after actions start, while the fixed-output
+    # fetch uses `build --nobuild`; force it into the offline repository archive.
+    bazelTargets = [ "//xla/..." ] ++ lib.optional cudaSupport "@nccl_archive//...";
+
     sha256 =
       {
-        x86_64-linux = "sha256-9L+oVq/yHqUGLhzSpwqxfYSJ1bIVcnaZgFVB3sjokXs=";
+        cpu.x86_64-linux = "sha256-wbLvzCLpFw4+QF86zIBroAeFrwqUTe31aJV7tcjhSZE=";
+        # This hash covers the selected manifests, not cudaCapabilities. Alternate
+        # manifests need a caller-supplied deps outputHash/outputHashAlgo override.
+        cuda.x86_64-linux =
+          if cudaManifestHash == "41d8c351dd9ceb95086c8fc2ebcb49b317c5082393220e5919372a7860487c60" then
+            "sha256-BXPlzvYSCOudbKgHU/IhHaHG5umNBGgD0hKl7jnOxcc="
+          else
+            throw "xla: no Bazel dependency hash for these CUDA/cuDNN manifests; overrideAttrs with deps.overrideAttrs { outputHash = ...; outputHashAlgo = \"sha256\"; } (see tests/README.md)";
       }
-      .${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
-    preInstall =
-      # Note: $bazelOut/external is the entire contents of the deps archive (see
-      # `deps.installPhase` in buildBazelPackage).
-      ''
-        chmod -R +w $bazelOut/external
-        rm -rf $bazelOut/external/{local_config_python,\@local_config_python.marker}
-        rm -rf $bazelOut/external/{local_config_sh,\@local_config_sh.marker}
-        rm -rf $bazelOut/external/{local_config_xcode,\@local_config_xcode.marker}
-        rm -rf $bazelOut/external/{local_execution_config_python,\@local_execution_config_python.marker}
-        rm -rf $bazelOut/external/{local_jdk,\@local_jdk.marker}
-      ''
-      # Normalize all /nix/store hashes to a fixed value so the deps archive is
-      # reproducible regardless of which nixpkgs revision built it. Somehow this
-      # does not break the build (yet).
-      + ''
-        find $bazelOut/external -type f -exec \
-          sed -i 's|/nix/store/[a-z0-9]\{32\}-|/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-|g' {} +
-      ''
-      # Delete non-deterministic Python bytecode (contains timestamps)
-      + ''
-        find $bazelOut/external -name '*.pyc' -delete
-      '';
+      .${if cudaSupport then "cuda" else "cpu"}.${stdenv.hostPlatform.system}
+        or (throw "unsupported system: ${stdenv.hostPlatform.system}");
+
+    # buildBazelPackage normally removes every top-level symlink. Preserve
+    # directory aliases used by hermetic LLVM, sysroot, and CUDA repositories.
+    # Repository archives can contain read-only directories and symlinks.
+    # Normalize the fully materialized archive tree only after repository
+    # aliases have been copied into it.
+    installPhase = ''
+      runHook preInstall
+
+      ${lib.optionalString cudaSupport removeLocalCudaRepositories}chmod -R +w "$bazelOut/external"
+
+      rm -rf $bazelOut/external/{bazel_tools,\@bazel_tools.marker}
+      rm -rf $bazelOut/external/{embedded_jdk,\@embedded_jdk.marker}
+      rm -rf $bazelOut/external/{local_config_cc,\@local_config_cc.marker}
+      rm -rf $bazelOut/external/{local_config_python,\@local_config_python.marker}
+      rm -rf $bazelOut/external/{local_config_sh,\@local_config_sh.marker}
+      rm -rf $bazelOut/external/{local_config_xcode,\@local_config_xcode.marker}
+      rm -rf $bazelOut/external/{local_execution_config_python,\@local_execution_config_python.marker}
+      rm -rf $bazelOut/external/{local_jdk,\@local_jdk.marker}
+
+      find $bazelOut/external -name '@*\.marker' -exec sh -c 'echo > {}' \;
+      rm -rf $(find $bazelOut/external -type d -name .git)
+      rm -rf $(find $bazelOut/external -type d -name .svn)
+      rm -rf $(find $bazelOut/external -type d -name .hg)
+
+      find $bazelOut/external -maxdepth 1 -type l | while read -r symlink; do
+        target="$(readlink -f "$symlink")"
+        if [ -d "$target" ]; then
+          rm "$symlink"
+          cp -rL "$target" "$symlink"
+        else
+          name="$(basename "$symlink")"
+          rm "$symlink"
+          test ! -f "$bazelOut/external/@$name.marker" || rm "$bazelOut/external/@$name.marker"
+        fi
+      done
+
+      find $bazelOut/external -type l | while read -r symlink; do
+        new_target="$(readlink "$symlink" | sed "s,$NIX_BUILD_TOP,NIX_BUILD_TOP,")"
+        rm "$symlink"
+        ln -sf "$new_target" "$symlink"
+      done
+
+      chmod -R +w "$bazelOut/external"
+      find "$bazelOut/external" -type f -exec \
+        sed -i 's|/nix/store/[a-z0-9]\{32\}-|/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-|g' {} +
+      find "$bazelOut/external" -name '*.pyc' -delete
+
+      remaining_store_refs="$(
+        {
+          find "$bazelOut/external" -type f -exec \
+            grep -aohE '/nix/store/[a-z0-9]{32}-' {} + \
+            || true
+          find "$bazelOut/external" -type l -exec readlink {} \; \
+            | grep -oE '/nix/store/[a-z0-9]{32}-' \
+            || true
+        } \
+          | grep -vFx '/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-' \
+          | sort -u \
+          || true
+      )"
+      if [ -n "$remaining_store_refs" ]; then
+        printf '%s\n' "$remaining_store_refs" >&2
+        echo "un-normalized Nix store reference in Bazel dependency archive" >&2
+        exit 1
+      fi
+
+      echo '${bazel_7.name}' > $bazelOut/external/.nix-bazel-version
+      (cd "$bazelOut" && \
+        tar cf "$out" \
+          --sort=name \
+          --mtime='@1' \
+          --owner=0 \
+          --group=0 \
+          --numeric-owner \
+          external/)
+
+      runHook postInstall
+    '';
+  }
+  // lib.optionalAttrs cudaSupport {
+    # Fetch a capability-independent archive. The build discards and regenerates
+    # local_config_cuda: Nix's Bazel otherwise trusts its fetch-time configuration.
+    preConfigure = configureCuda "sm_80";
   };
 
   buildAttrs = {
     outputs = [ "out" ];
 
-    preConfigure =
-      # Fix #!/usr/bin/env shebangs in rules_python -- Bazel-generated Python
-      # stubs use #!/usr/bin/env which doesn't exist in the nix sandbox
+    __structuredAttrs = cudaSupport;
+    strictDeps = cudaSupport;
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      file
+      gitMinimal
+      patchelf
+      pythonEnv
+      which
+    ]
+    ++ lib.optional cudaSupport autoAddDriverRunpath;
+
+    # Downloaded hermetic LLVM, Python, and CUDA tools are Ubuntu-built binaries.
+    buildInputs = [
+      elfutils
+      glibc
+      libxml2
+      ncurses5
+      ncurses
+      stdenv.cc.cc.lib
+      zlib
+    ]
+    ++ cudaRuntimeLibs;
+
+    # Runtime compilation needs ptxas, nvlink, and libdevice. Use the selected
+    # toolkit as XLA's default so clients need no toolkit PATH or XLA_FLAGS.
+    # Explicit flags still override this default.
+    # The pinned Bazel cannot propagate Starlark build settings through exec
+    # transitions. Its legacy --define setting does propagate, so use that for
+    # rules_ml_toolchain selection in both target and exec configurations.
+    # The include scanner records physical targets of the local view's symlinked
+    # headers. Treat immutable roots as compiler built-ins; compilation still
+    # reaches them through Bazel's declared repositories.
+    # CUDA-enabled exec tools link libcuda even when generating CPU artifacts.
+    # Use the hermetic driver while running them during the build.
+    postConfigure =
+      lib.optionalString cudaSupport ''
+        ${removeLocalCudaRepositories}
+
+        substituteInPlace xla/debug_options_flags.cc \
+          --replace-fail \
+            'opts.set_xla_gpu_cuda_data_dir("./cuda_sdk_lib");' \
+            'opts.set_xla_gpu_cuda_data_dir("${cudaPackages.cuda_nvcc}");'
+
+        substituteInPlace $bazelOut/external/rules_ml_toolchain/common/BUILD \
+          --replace-fail \
+            'flag_values = {":enable_cuda": "True"},' \
+            'define_values = {"using_cuda_nvcc": "true"},' \
+          --replace-fail \
+            'flag_values = {":enable_cuda": "False"},' \
+            'define_values = {"using_cuda_nvcc": "false"},'
+
+        substituteInPlace \
+          $bazelOut/external/rules_ml_toolchain/third_party/rules_cc_toolchain/toolchain_config.bzl \
+          --replace-fail \
+            'abi_libc_version = "unknown",' \
+            'abi_libc_version = "unknown",
+        cxx_builtin_include_directories = ${
+          builtins.toJSON (map (root: "${root}/include") cudaLocal.cudaRoots)
+        },'
+
+        echo \
+          "build --action_env=LD_LIBRARY_PATH=${hostRpath}:$bazelOut/external/cuda_driver/lib" \
+          >> xla_configure.bazelrc
       ''
+      # Avoid a repository-cache validation refetch after marker normalization.
+      + ''
+        if [ -d "$bazelOut/external/riegeli" ]; then
+          touch "$bazelOut/external/riegeli/WORKSPACE"
+        fi
+
         substituteInPlace $bazelOut/external/rules_python/python/private/py_runtime_info.bzl \
           --replace-fail '"#!/usr/bin/env python3"' '"#!${pythonEnv}/bin/python3"'
         substituteInPlace $bazelOut/external/rules_python/python/private/stage1_bootstrap_template.sh \
-          --replace-fail '#!/usr/bin/env bash' '#!${clangStdenv.shell}'
+          --replace-fail '#!/usr/bin/env bash' '#!${stdenv.shell}'
         substituteInPlace $bazelOut/external/rules_python/python/private/runtime_env_toolchain.bzl \
           --replace-fail '"#!/usr/bin/env python3"' '"#!${pythonEnv}/bin/python3"'
-      ''
-      # Re-patchelf hermetic Python binary with the nix dynamic linker
-      # (was normalized in fetchAttrs for reproducibility)
-      + ''
-        for py_dir in $bazelOut/external/python_3_*; do
-          if [ -d "$py_dir" ]; then
-            find "$py_dir" -type f -executable \
-              -exec patchelf --set-interpreter ${clangStdenv.cc.libc}/lib/ld-linux-x86-64.so.2 {} \; 2>/dev/null || true
+
+        patchShebangs "$bazelOut/external/rules_ml_toolchain"
+
+        nix_rpath="${
+          lib.makeLibraryPath [
+            elfutils
+            glibc
+            libxml2
+            ncurses5
+            ncurses
+            stdenv.cc.cc.lib
+            zlib
+          ]
+        }"
+        llvm_lib="$bazelOut/external/llvm18_linux_x86_64/lib"
+        nix_rpath="$llvm_lib:$nix_rpath"
+
+        for tool_dir in \
+          "$bazelOut/external/llvm18_linux_x86_64" \
+          "$bazelOut/external/llvm_linux_x86_64" \
+          "$bazelOut/external/cuda_nvcc" \
+          "$bazelOut/external/cuda_cupti" \
+          "$bazelOut/external/xxd" \
+          $bazelOut/external/python_3_*; do
+          ${lib.optionalString cudaSupport ''
+            case "$tool_dir" in
+              */cuda_nvcc|*/cuda_cupti) continue ;;
+            esac
+          ''}if [ -d "$tool_dir" ]; then
+            patchShebangs "$tool_dir"
+            find "$tool_dir" -type f -executable -print0 | while IFS= read -r -d "" tool; do
+              if file "$tool" | grep -q 'ELF.*dynamically linked'; then
+                if patchelf --print-interpreter "$tool" >/dev/null 2>&1; then
+                  patchelf --set-interpreter '${stdenv.cc.bintools.dynamicLinker}' "$tool"
+                fi
+                old_rpath="$(patchelf --print-rpath "$tool")"
+                if [ -z "$old_rpath" ]; then
+                  patchelf --set-rpath "$nix_rpath" "$tool"
+                elif [[ ":$old_rpath:" != *":$nix_rpath:"* ]]; then
+                  patchelf --set-rpath "$old_rpath:$nix_rpath" "$tool"
+                fi
+              fi
+            done
           fi
         done
       '';
@@ -215,10 +513,52 @@ in
       runHook preInstall
       mkdir -p $out/{bin,lib,include}
     ''
-    # Install built libraries
+    # Install built libraries. Preserve the existing flattened, last-copy-wins
+    # behavior, but make the winner reproducible and allow read-only replacement.
+    # libmlir_c_runner_utils.so records solib names for MLIR and LLVM dependencies
+    # outside bazel-bin/xla. Flattening also picks up unusable runfiles manifests.
     + ''
-      find bazel-bin/xla -name "*.so*" -type f -exec cp {} $out/lib \;
-      find bazel-bin/xla -name "*.a" -type f -exec cp {} $out/lib \;
+      install_bazel_libraries() {
+        find bazel-bin/xla -name "$1" -type f -print0 \
+          | sort -z \
+          | while IFS= read -r -d "" library; do
+            cp --remove-destination "$library" "$out/lib/$(basename "$library")"
+          done
+      }
+      install_bazel_libraries "*.so*"
+      install_bazel_libraries "*.a"
+
+      mlir_runner_libs=(
+        libexternal_Sllvm-project_Smlir_Slib_Umlir_Uc_Urunner_Uutils.so
+        libexternal_Sllvm-project_Smlir_SlibSparseTensorRuntime.so
+        libexternal_Sllvm-project_Smlir_Slib_Umlir_Uapfloat_Uutils.so
+        libexternal_Sllvm-project_Smlir_Slib_Umlir_Ufloat16_Uutils.so
+        libexternal_Sllvm-project_Sllvm_SlibSupport.so
+        libexternal_Sllvm-project_Sllvm_SlibDemangle.so
+      )
+      for library in "''${mlir_runner_libs[@]}"; do
+        library_path="bazel-bin/_solib_x86_64/$library"
+        if [ ! -e "$library_path" ]; then
+          echo "missing Bazel runtime dependency $library_path" >&2
+          exit 1
+        fi
+        cp -L "$library_path" "$out/lib/$library"
+      done
+      find "$out/lib" -name '*.runfiles_manifest' -delete
+    ''
+    # Install the matching NVSHMEM 3.2.5 runtime DSOs for the tested CUDA 12
+    # build; its transport ABI predates nixpkgs' SONAME 5 NVSHMEM, which cannot
+    # be substituted or aliased to SONAME 3 without validation.
+    + lib.optionalString cudaSupport ''
+      nvshmem_lib="$bazelOut/external/nvidia_nvshmem/lib"
+      install -m755 \
+        "$nvshmem_lib/libnvshmem_host.so.3.2.5" \
+        "$nvshmem_lib/nvshmem_bootstrap_uid.so.3.0.0" \
+        "$nvshmem_lib/nvshmem_transport_ibrc.so.3.0.0" \
+        "$out/lib/"
+      ln -s libnvshmem_host.so.3.2.5 "$out/lib/libnvshmem_host.so.3"
+      ln -s nvshmem_bootstrap_uid.so.3.0.0 "$out/lib/nvshmem_bootstrap_uid.so.3"
+      ln -s nvshmem_transport_ibrc.so.3.0.0 "$out/lib/nvshmem_transport_ibrc.so.3"
     ''
     # Install CLI tools
     + ''
@@ -226,7 +566,7 @@ in
     ''
     # Install headers
     + ''
-      find xla -name "*.h" -type f | while read header; do
+      find xla -name "*.h" -type f | while read -r header; do
         target="$out/include/$header"
         mkdir -p "$(dirname "$target")"
         cp "$header" "$target"
@@ -234,6 +574,12 @@ in
 
       runHook postInstall
     '';
+  }
+  // lib.optionalAttrs cudaSupport {
+    # XLA and NVSHMEM load these libraries by bare soname rather than through
+    # DT_NEEDED. The NVIDIA driver itself is supplied by the host at runtime.
+    runtimeDependencies = cudaRuntimeLibs;
+    autoPatchelfIgnoreMissingDeps = [ "libcuda.so.1" ];
   };
 
   requiredSystemFeatures = [ "big-parallel" ];
@@ -241,11 +587,28 @@ in
   meta = {
     description = "Machine learning compiler for GPUs, CPUs, and ML accelerators";
     homepage = "https://github.com/openxla/xla";
-    license = lib.licenses.asl20;
+    license = [
+      lib.licenses.asl20
+    ]
+    ++ lib.optionals cudaSupport ([ lib.licenses.nvidiaCudaRedist ] ++ cudaPackages.cudnn.meta.license);
     maintainers = with lib.maintainers; [ samuela ];
-    platforms = [
-      "x86_64-linux"
-
-    ];
+    platforms = [ "x86_64-linux" ];
   };
-}
+}).overrideAttrs
+  # buildBazelPackage accepts only an attrset, not mkDerivation's finalAttrs callback.
+  # overrideAttrs supplies finalPackage so tests follow downstream package overrides.
+  (
+    finalAttrs: previousAttrs:
+    let
+      checks = callPackage ./tests {
+        xla = finalAttrs.finalPackage;
+        inherit cudaSupport cudaPackages cudaRuntimeLibs;
+      };
+    in
+    {
+      passthru = (previousAttrs.passthru or { }) // {
+        inherit cudaSupport;
+        inherit (checks) tests testers;
+      };
+    }
+  )

--- a/pkgs/by-name/xl/xla/tests/README.md
+++ b/pkgs/by-name/xl/xla/tests/README.md
@@ -1,0 +1,191 @@
+# Installed XLA regression suites
+
+Use the selected package's `passthru.tests` and `passthru.testers`, following
+[the CUDA testing convention](../../../../../doc/languages-frameworks/cuda.section.md).
+`tests` execute suites in derivations; `testers` build executables containing the
+same suites (`meta.mainProgram` is set). Building a tester alone is not a
+successful test run. These are package-local development interfaces, not stable APIs.
+
+## Commands (from the nixpkgs root)
+
+Evaluate the package and test contracts, including free-only discovery:
+
+```sh
+nix-instantiate --eval --strict pkgs/by-name/xl/xla/tests/eval.nix --arg nixpkgs ./.
+```
+
+Run CPU-only checks:
+
+```sh
+nix-build --no-out-link --expr '
+  let x = (import ./. {}).xla.override { cudaSupport = false; };
+  in [ x.tests.cpu x.tests.hlo x.tests.install x.tests.metadata ]
+'
+```
+
+Run the CUDA package's hardware-free installed-output checks, including its CPU
+plugin:
+
+```sh
+nix-build --no-out-link --expr '
+  let x = (import ./. { config.allowUnfree = true; }).xla.override { cudaSupport = true; };
+  in [ x.tests.cpu x.tests.cuda.install x.tests.cuda.metadata ]
+'
+```
+
+Run hardware-free CUDA build-configuration checks for default and custom
+capabilities:
+
+```sh
+nix-build --no-out-link --expr '
+  let
+    check = config: ((import ./. {
+      config = { allowUnfree = true; } // config;
+    }).xla.override { cudaSupport = true; }).tests.cuda.configure;
+  in [
+    (check {})
+    (check { cudaCapabilities = [ "8.0" "8.9" ]; cudaForwardCompat = false; })
+    ((import ./. { config.allowUnfree = true; }).xla.override {
+      cudaSupport = true;
+    }).tests.cuda.configureOverride
+  ]
+'
+```
+
+These checks share the dependency archive but independently regenerate
+`local_config_cuda`, resolve `local_config_nccl` aliases through the selected NCCL
+output, and verify recorded architectures and exact SASS/PTX flags. They compile
+one CUDA translation unit with packaged NVCC, pinned Clang 18.1.8, and pinned CCCL
+3.2.0. `configureOverride` modifies selected NVCC and NCCL outputs and verifies
+that both sentinel headers reach the generated repositories; the NVCC sentinel is
+also consumed by the compiler. The checks require `big-parallel`, substantial
+working storage, and may build selected NCCL, but do not require a GPU or compile XLA.
+
+The lightweight checker uses only Python and synthetic repository fixtures:
+
+```sh
+nix-build --no-out-link --expr '
+  ((import ./. { config.allowUnfree = true; }).xla.override { cudaSupport = true; }).tests.cuda.configureChecker
+'
+```
+
+Run GPU-host checks only on a builder advertising `cuda` and exposing a supported
+NVIDIA GPU and matching host driver:
+
+```sh
+nix-build --no-out-link --expr '
+  let x = (import ./. { config.allowUnfree = true; }).xla.override { cudaSupport = true; };
+  in [ x.tests.cuda.pjrt x.tests.cuda.nccl x.tests.cuda.hlo ]
+'
+```
+
+For an interactive run of the same PJRT suite, select its tester:
+
+```sh
+tester=$(nix-build --no-out-link --expr '
+  ((import ./. { config.allowUnfree = true; }).xla.override { cudaSupport = true; }).testers.cuda.pjrt
+')
+"$tester/bin/xla-pjrt-cuda" "$PWD/pjrt-logs"
+```
+
+Executable suites accept an optional log directory; test derivations retain logs
+in their output. Metadata checks are evaluation assertions rather than runtime
+suites. CUDA attributes are nested and empty for CPU-only packages so free-only
+test discovery does not evaluate unfree packages.
+
+## CUDA configuration and overrides
+
+`config.cudaCapabilities` and `config.cudaForwardCompat` are resolved through the
+selected `cudaPackages.flags`. For example, `[ "8.0" "8.9" ]` produces
+`sm_80,compute_89` with forward compatibility and `sm_80,sm_89` without it.
+`compute_*` emits SASS and PTX; only the final configured capability receives PTX.
+Repeated rendered architectures are deduplicated in insertion order. This XLA pin
+accepts accelerated `a` suffixes but not family-specific `f` suffixes.
+
+The dependency fetch uses a fixed `sm_80` analysis configuration. The build removes
+selected-output-backed CUDA, cuDNN, NCCL, and generated CUDA repositories from the
+archive and regenerates them offline from `symlinkJoin` layouts. The archive keeps
+the path-independent `local_config_nccl` aliases required by Bazel 7. The selected
+CUDA and cuDNN manifests determine template versions and guard the fixed-output
+archive hash; selected processed package outputs supply compiler, headers, runtime,
+static cudart, NVVM, NVML stubs, cuDNN, and NCCL. XLA's downloaded CCCL 3.2.0,
+Clang 18.1.8, NVSHMEM 3.2.5, and build-only real user-mode driver remain pinned.
+
+Capabilities may change the dependency derivation identity through selected NCCL,
+but the normalized fixed-output content and store path remain capability-independent.
+A different CUDA/cuDNN manifest requires an explicit dependency hash override:
+
+```nix
+let
+  pkgs = import ./. { config.allowUnfree = true; };
+  selected = pkgs.xla.override {
+    cudaSupport = true;
+    cudaPackages = pkgs.cudaPackages_12_8;
+  };
+in
+selected.overrideAttrs (previousAttrs: {
+  deps = previousAttrs.deps.overrideAttrs {
+    outputHash = pkgs.lib.fakeHash; # Replace with the measured dependency hash.
+    outputHashAlgo = "sha256";
+  };
+})
+```
+
+Both hash attributes must be overridden. This escape hatch is evaluation-tested;
+it is not a claim that alternate toolkit versions build or run. Package
+`overrideAttrs` changes remain linked into passthru tests, including dependency
+hash overrides.
+
+## GPU prerequisites
+
+A GPU builder needs supported NVIDIA device nodes and matching host userspace and
+kernel drivers. Advertising the `cuda` system feature alone does not expose them.
+On NixOS use the sandbox resource mechanism:
+
+```nix
+{
+  programs.nix-required-mounts = {
+    enable = true;
+    presets.nvidia-gpu.enable = true;
+  };
+}
+```
+
+See `nixos/modules/programs/nix-required-mounts.nix`. The host driver libraries
+normally live under `addDriverRunpath.driverLink` (`/run/opengl-driver/lib`). Do not
+substitute toolkit stubs, disable sandboxing in portable derivations, or add an
+entire distribution library directory to `LD_LIBRARY_PATH`. A missing GPU must
+prevent scheduling or fail the test, never skip as success.
+
+The installed CUDA package uses the selected `cudaPackages.cuda_nvcc` root as XLA's
+default CUDA data directory, supplying `ptxas`, `nvlink`, and libdevice without
+requiring clients to set `PATH`, `XLA_FLAGS`, `CUDA_HOME`, or `CUDA_PATH`. Explicit
+`--xla_gpu_cuda_data_dir` overrides remain supported. The full NVCC output and its
+transitive host GCC are intentional runtime dependencies; the NVIDIA driver remains
+host-supplied.
+
+## Test contracts and coverage
+
+| Area | Check | Contract |
+|---|---|---|
+| Public PJRT C API | `tests.cpu`, `tests.cuda.pjrt` | Compile installed CPU/GPU headers, load `GetPjrtApi`, and compare API version and structure size with header macros. |
+| CPU execution | `tests.cpu` for both package variants | Execute nonconstant `(x+y)*x`; check platform, devices, f32 `[2,3]` output, asynchronous completion, all values, and cleanup. |
+| GPU execution | `tests.cuda.pjrt` | In a toolkit-clean environment, execute nonconstant arithmetic and `stablehlo.sine`, read results back, and reject fallback or skipped execution. |
+| Negative controls | PJRT suites | Require the intentional numerical mismatch to exit 1 only after execution/readback; CPU also rejects requesting CUDA from the CPU plugin. |
+| HLO comparison | `tests.hlo`, `tests.cuda.hlo` | Run `smoke.hlo` on Host against Interpreter and require `0/1 runs failed`; the CUDA-built CLI still needs a GPU host for its direct driver dependency. |
+| ELF and RUNPATH audit | install suites | Inspect every regular ELF, resolve dynamic dependencies, permit only exact `libcuda.so.1` absence for CUDA, and verify declared driver/runtime RUNPATHs. |
+| Runtime closure | install suites | Require selected runtime roots and CUDA compiler artifacts; reject source, dependency archive, Bazel, build stdenv, and explicit CUDA package-name prefixes from CPU closure. |
+| Installed CUDA support files | CUDA install suite | Check `ptxas`, `nvlink`, libdevice, a compiled reference to the selected NVCC root, and pinned NVSHMEM DSOs/SONAMEs/symlinks. |
+| Stale install references | install suites | Reject runfiles manifests, binary-safe `/build/output` contents, and that string in symlink targets. |
+| Licensing and discovery | metadata checks, `eval.nix` | Check free/unfree licensing, free-only discovery, scheduling features, capabilities, selected package propagation, source/manifest consistency, and passthru override linkage. |
+| CUDA repository generation | configure suites | Regenerate repositories, resolve selected NCCL aliases, compile with exact Clang/CCCL assertions, validate SASS/PTX policy, and exercise selected-output sentinels. |
+| Checker behavior | `configureChecker` | Cover duplicate architecture handling, final PTX selection, stale/incorrect flag rejection, and missing/copied/linked driver-stub fixtures. |
+| NCCL | `tests.cuda.nccl` | Check header/runtime version agreement and perform a one-rank `ncclAllReduce` through device memory. |
+
+CPU-only builds may contain a GPU-named plugin without CUDA runtime support; the
+CPU contract is the runtime closure, not the absence of that filename.
+
+Not tested: upstream Bazel unit/integration suites, real CUDA matmul, cuDNN
+convolution, an actual `nvlink` invocation, GPU HLO execution, multi-GPU or
+multi-rank NCCL, NVSHMEM collectives, RDMA, NixOS sandbox integration, other GPU
+models, or bit-for-bit reproducibility.

--- a/pkgs/by-name/xl/xla/tests/cuda-compile.cu
+++ b/pkgs/by-name/xl/xla/tests/cuda-compile.cu
@@ -1,0 +1,20 @@
+#include <cuda_runtime.h>
+#include <cuda/std/version>
+#include <cuda/std/type_traits>
+#include <cub/version.cuh>
+#include <thrust/version.h>
+
+#if !defined(__clang__) || __clang_major__ != 18 || __clang_minor__ != 1 || __clang_patchlevel__ != 8
+#error "XLA requires the pinned Clang 18.1.8 host compiler"
+#endif
+#if CCCL_VERSION != 3002000 || CUB_VERSION != 300200 || THRUST_VERSION != 300200
+#error "The selected NVCC profile must not shadow XLA's CCCL 3.2.0 headers"
+#endif
+#ifdef XLA_TEST_SELECTED_OUTPUT
+#include <xla-selected-output.h>
+static_assert(XLA_SELECTED_OUTPUT == 964, "selected patched header was lost");
+#endif
+static_assert(cuda::std::is_same_v<int, int>);
+__global__ void xla_cuda_header_probe(float* values) {
+  values[threadIdx.x] = values[threadIdx.x] * 2.0f;
+}

--- a/pkgs/by-name/xl/xla/tests/cuda-configure-check-test.py
+++ b/pkgs/by-name/xl/xla/tests/cuda-configure-check-test.py
@@ -1,0 +1,122 @@
+"""Exercise the configure checker with independent generated-repository fixtures."""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+CHECKER = Path(sys.argv.pop(1)).resolve()
+
+
+class CudaConfigureCheckTest(unittest.TestCase):
+    def check_fixture(self, real, forward, architectures, sass, ptx, *, valid=True):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "cuda").mkdir()
+            (root / "cuda" / "cuda_config.py").write_text(
+                f"config = {{'cuda_compute_capabilities': {architectures!r}}}\n"
+            )
+            (root / "build_defs.bzl").write_text(
+                f"def cuda_gpu_architectures():\n    return {architectures!r}\n"
+                f"cuda_copts = {[f'--cuda-gpu-arch=sm_{arch}' for arch in sass] + [f'--cuda-include-ptx=sm_{arch}' for arch in ptx]!r}\n"
+            )
+            expected = root / "expected.json"
+            expected.write_text(
+                json.dumps(
+                    {
+                        "realArches": [f"sm_{arch}" for arch in real],
+                        "virtualArches": [f"compute_{arch}" for arch in real],
+                        "cudaForwardCompat": forward,
+                    }
+                )
+            )
+            result = subprocess.run(
+                [sys.executable, str(CHECKER), str(root), str(expected)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if valid:
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("PASS regenerated config", result.stdout)
+            else:
+                self.assertEqual(result.returncode, 1, result.stderr)
+                self.assertIn("AssertionError", result.stderr)
+
+    def test_duplicate_capabilities(self):
+        # Literal outputs follow the pinned rules, not checker normalization.
+        # Distinct sm_80/compute_80 entries intentionally emit SASS twice.
+        fixtures = [
+            (["80", "80"], False, ["sm_80"], ["80"], []),
+            (["80", "80"], True, ["sm_80", "compute_80"], ["80", "80"], ["80"]),
+            (["80", "80", "80"], True, ["sm_80", "compute_80"], ["80", "80"], ["80"]),
+            (["80", "89", "80"], False, ["sm_80", "sm_89"], ["80", "89"], []),
+            (
+                ["80", "89", "80"],
+                True,
+                ["sm_80", "sm_89", "compute_80"],
+                ["80", "89", "80"],
+                ["80"],
+            ),
+            (
+                ["80", "89", "80", "90"],
+                False,
+                ["sm_80", "sm_89", "sm_90"],
+                ["80", "89", "90"],
+                [],
+            ),
+            (
+                ["80", "89", "80", "90"],
+                True,
+                ["sm_80", "sm_89", "compute_90"],
+                ["80", "89", "90"],
+                ["90"],
+            ),
+        ]
+        for fixture in fixtures:
+            with self.subTest(real=fixture[0], forward=fixture[1]):
+                self.check_fixture(*fixture)
+
+    def test_reject_stale_configuration(self):
+        self.check_fixture(["80", "89"], True, ["sm_80"], ["80"], [], valid=False)
+
+    def test_reject_incorrect_ptx(self):
+        for ptx in ([], ["89"], ["80", "80"]):
+            with self.subTest(ptx=ptx):
+                self.check_fixture(
+                    ["80", "89", "80"],
+                    True,
+                    ["sm_80", "sm_89", "compute_80"],
+                    ["80", "89", "80"],
+                    ptx,
+                    valid=False,
+                )
+
+    def test_reject_unwanted_ptx(self):
+        self.check_fixture(["80", "80"], False, ["sm_80"], ["80"], ["80"], valid=False)
+
+    def test_reject_deduplicated_sass(self):
+        self.check_fixture(
+            ["80", "89", "80"],
+            True,
+            ["sm_80", "sm_89", "compute_80"],
+            ["80", "89"],
+            ["80"],
+            valid=False,
+        )
+
+    def test_reject_ptx_selected_after_raw_deduplication(self):
+        self.check_fixture(
+            ["80", "89", "80"],
+            True,
+            ["sm_80", "compute_89"],
+            ["80", "89"],
+            ["89"],
+            valid=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkgs/by-name/xl/xla/tests/cuda-configure-check.py
+++ b/pkgs/by-name/xl/xla/tests/cuda-configure-check.py
@@ -1,0 +1,43 @@
+"""Check regenerated XLA CUDA configuration against the selected nixpkgs flags."""
+
+import ast
+import json
+import re
+import runpy
+import sys
+from pathlib import Path
+
+
+def main():
+    root = Path(sys.argv[1])
+    flags = json.loads(Path(sys.argv[2]).read_text())
+    architectures = flags["realArches"].copy()
+    if flags["cudaForwardCompat"]:
+        architectures[-1] = flags["virtualArches"][-1]
+    # The pinned rules deduplicate rendered capabilities, after PTX selection.
+    # Distinct sm_* and compute_* entries can still emit the same SASS flag.
+    architectures = list(dict.fromkeys(architectures))
+    sass = [arch.replace("compute_", "sm_") for arch in architectures]
+    ptx = [
+        arch.replace("compute_", "sm_")
+        for arch in architectures
+        if arch.startswith("compute_")
+    ]
+
+    config = runpy.run_path(str(root / "cuda" / "cuda_config.py"))["config"]
+    assert config["cuda_compute_capabilities"] == architectures, config
+    defs = (root / "build_defs.bzl").read_text()
+    match = re.search(
+        r"def cuda_gpu_architectures\(\):.*?return (\[[^\n]*\])", defs, re.DOTALL
+    )
+    assert match is not None, "missing generated cuda_gpu_architectures definition"
+    assert ast.literal_eval(match.group(1)) == architectures, match.group(1)
+    actual_sass = re.findall(r"--cuda-gpu-arch=(sm_[0-9a-z]+)", defs)
+    actual_ptx = re.findall(r"--cuda-include-ptx=(sm_[0-9a-z]+)", defs)
+    assert actual_sass == sass, (actual_sass, sass)
+    assert actual_ptx == ptx, (actual_ptx, ptx)
+    print(f"PASS regenerated config, SASS {sass}, PTX {ptx}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/by-name/xl/xla/tests/cuda-configure.nix
+++ b/pkgs/by-name/xl/xla/tests/cuda-configure.nix
@@ -1,0 +1,73 @@
+{
+  pkgs,
+  xla,
+  cudaPackages,
+  expectSelectedOutput ? false,
+}:
+let
+  inherit (pkgs) lib;
+  local = pkgs.callPackage ../cuda-local.nix { inherit cudaPackages; };
+  expected = pkgs.writeText "xla-cuda-configure-expected.json" (
+    builtins.toJSON {
+      inherit (cudaPackages.flags) realArches virtualArches cudaForwardCompat;
+    }
+  );
+in
+xla.overrideAttrs {
+  name = "${xla.name}-cuda-configure";
+  # Regenerate repositories and compile one real CUDA translation unit, not XLA.
+  # Local repository inputs include selected NCCL, possibly requiring its build.
+  # Keep the layout views out of autoPatchelf's search path.
+  buildInputs = with pkgs; [
+    elfutils
+    glibc
+    libxml2
+    ncurses5
+    ncurses
+    stdenv.cc.cc.lib
+    zlib
+  ];
+  runtimeDependencies = [ ];
+  buildPhase = ''
+    runHook preBuild
+    concatTo bazelFlagsArray bazelFlags
+    BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 USER=homeless-shelter bazel --batch \
+      --output_base="$bazelOut" --output_user_root="$bazelUserRoot" \
+      build --nobuild --curses=no "''${bazelFlagsArray[@]}" @local_config_cuda//... @local_config_nccl//:nccl @cuda_nccl//:nccl || {
+        ls -la "$bazelOut/external/local_config_nccl" >&2 || true
+        exit 1
+      }
+    test "$(readlink -f "$bazelOut/external/cuda_nvcc/bin/nvcc")" = "$(readlink -f '${local.cuda}/bin/nvcc')"
+    test "$(readlink "$bazelOut/external/cuda_cudnn/include")" = '${local.cudnn}/include'
+    test "$(readlink "$bazelOut/external/cuda_nccl/include")" = '${local.nccl}/include'
+    test "$(readlink -f "$bazelOut/external/cuda_nccl/lib/libnccl.so")" = "$(readlink -f '${lib.getLib cudaPackages.nccl}/lib/libnccl.so')"
+    test ! -L "$bazelOut/external/cuda_cccl/libcudacxx"
+    ${pkgs.bash}/bin/bash ${./cuda-driver-check.sh} \
+      "$bazelOut/external/cuda_driver" '${local.cuda}/lib/stubs/libcuda.so'
+    ${lib.optionalString expectSelectedOutput ''
+      test -e "$bazelOut/external/cuda_nccl/include/xla-selected-nccl-output.h"
+    ''}
+    cp ${./cuda-compile.cu} build_tools/configure/assert_nvcc.cu.cc
+    BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 USER=homeless-shelter bazel --batch \
+      --output_base="$bazelOut" --output_user_root="$bazelUserRoot" \
+      build --subcommands --curses=no "''${bazelFlagsArray[@]}" \
+      ${lib.optionalString expectSelectedOutput "--copt=-DXLA_TEST_SELECTED_OUTPUT"} \
+      //build_tools/configure:assert_nvcc
+    ${lib.getExe pkgs.python3} ${./cuda-configure-check.py} \
+      "$bazelOut/external/local_config_cuda/cuda" ${expected}
+    runHook postBuild
+  '';
+  installPhase = ''
+    mkdir -p "$out"
+    cp "$bazelOut/external/local_config_cuda/cuda/cuda/cuda_config.py" "$out/"
+    cp "$bazelOut/external/local_config_cuda/cuda/build_defs.bzl" "$out/"
+    cp xla_configure.bazelrc "$out/"
+    cp ${expected} "$out/expected.json"
+    cp "$bazelOut/external/cuda_nccl/BUILD" "$out/nccl.BUILD"
+    cp "$bazelOut/external/cuda_nccl/version.bzl" "$out/nccl-version.bzl"
+    cp bazel-bin/build_tools/configure/libassert_nvcc.a "$out/cuda-compile-probe.a"
+  '';
+  dontFixup = true;
+  # This is a build-configuration check, not another package to test recursively.
+  passthru = { };
+}

--- a/pkgs/by-name/xl/xla/tests/cuda-driver-check.sh
+++ b/pkgs/by-name/xl/xla/tests/cuda-driver-check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository=$1
+toolkit_stub=$2
+driver_directory="$repository/lib"
+driver="$driver_directory/libcuda.so.1"
+
+if [[ ! -d "$driver_directory" ]]; then
+  echo "missing CUDA driver repository directory: $driver_directory" >&2
+  exit 1
+fi
+if [[ -L "$driver_directory" ]]; then
+  echo "CUDA driver repository directory is a symlink: $driver_directory" >&2
+  exit 1
+fi
+if [[ ! -e "$driver" ]]; then
+  echo "missing CUDA driver artifact: $driver" >&2
+  exit 1
+fi
+if [[ ! -e "$toolkit_stub" ]]; then
+  echo "missing selected toolkit driver stub: $toolkit_stub" >&2
+  exit 1
+fi
+
+resolved_driver=$(readlink -f "$driver")
+resolved_stub=$(readlink -f "$toolkit_stub")
+if [[ "$resolved_driver" == "$resolved_stub" ]]; then
+  echo "CUDA driver repository resolves to the selected toolkit stub" >&2
+  exit 1
+fi
+if cmp -s "$resolved_driver" "$resolved_stub"; then
+  echo "CUDA driver repository contains a copy of the selected toolkit stub" >&2
+  exit 1
+fi

--- a/pkgs/by-name/xl/xla/tests/default.nix
+++ b/pkgs/by-name/xl/xla/tests/default.nix
@@ -1,0 +1,284 @@
+{
+  pkgs,
+  xla ? pkgs.xla.override { cudaSupport = false; },
+  cudaSupport ? xla.cudaSupport or false,
+  cudaPackages ? pkgs.cudaPackages,
+  cudaRuntimeLibs ? [ ],
+}:
+let
+  inherit (pkgs) lib;
+  runner = pkgs.stdenv.mkDerivation {
+    pname = "xla-pjrt-execute";
+    inherit (xla) version;
+    dontUnpack = true;
+    buildPhase = ''
+      runHook preBuild
+      $CXX -std=c++17 -Wall -Wextra -Werror -O2 \
+        -I${xla}/include ${./pjrt-execute.cc} -ldl -o pjrt-execute
+      for platform in cpu ${lib.optionalString cudaSupport "gpu"}; do
+        printf '#include "xla/pjrt/c/pjrt_c_api_%s.h"\n' "$platform" > header.cc
+        $CXX -std=c++17 -Wall -Wextra -Werror -I${xla}/include -fsyntax-only header.cc
+      done
+      runHook postBuild
+    '';
+    installPhase = ''
+      runHook preInstall
+      install -Dm755 pjrt-execute $out/bin/pjrt-execute
+      runHook postInstall
+    '';
+    meta.mainProgram = "pjrt-execute";
+  };
+
+  pjrtTester =
+    platform:
+    pkgs.writeShellApplication {
+      name = "xla-pjrt-${platform}";
+      runtimeInputs = [
+        pkgs.coreutils
+        pkgs.gnugrep
+      ];
+      text = ''
+        ${lib.optionalString (platform == "cuda") ''
+          # Exercise the installed package's compiled-in toolkit discovery.
+          # The host driver remains available through the plugin's RUNPATH.
+          export PATH=${
+            lib.makeBinPath [
+              pkgs.coreutils
+              pkgs.gnugrep
+            ]
+          }
+          unset XLA_FLAGS CUDA_HOME CUDA_PATH LD_LIBRARY_PATH
+        ''}
+        exec ${pkgs.bash}/bin/bash ${./pjrt-check.sh} \
+          ${lib.getExe runner} \
+          ${xla}/lib/pjrt_c_api_${if platform == "cuda" then "gpu" else "cpu"}_plugin.so \
+          ${platform} "$@"
+      '';
+    };
+
+  ncclRunner = pkgs.stdenv.mkDerivation {
+    pname = "xla-nccl-smoke";
+    inherit (xla) version;
+    dontUnpack = true;
+    buildPhase = ''
+      runHook preBuild
+      $CXX -std=c++17 -Wall -Wextra -Werror -O2 \
+        -I${lib.getInclude cudaPackages.cuda_cudart}/include \
+        -I${cudaPackages.cuda_nvcc}/include \
+        -I${lib.getInclude cudaPackages.cccl}/include \
+        -I${lib.getDev cudaPackages.nccl}/include \
+        ${./nccl-smoke.cc} \
+        -L${lib.getLib cudaPackages.cuda_cudart}/lib \
+        -L${lib.getLib cudaPackages.nccl}/lib \
+        -lcudart -lnccl -o nccl-smoke
+      runHook postBuild
+    '';
+    installPhase = ''
+      runHook preInstall
+      install -Dm755 nccl-smoke $out/bin/nccl-smoke
+      runHook postInstall
+    '';
+    meta.mainProgram = "nccl-smoke";
+  };
+
+  ncclTester = pkgs.writeShellApplication {
+    name = "xla-nccl";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+    ];
+    text = ''
+      logs=''${1:-$(mktemp -d -t xla-nccl.XXXXXXXX)}
+      mkdir -p "$logs"
+      export LD_LIBRARY_PATH="${pkgs.addDriverRunpath.driverLink}/lib:${lib.getLib cudaPackages.cuda_cudart}/lib:${lib.getLib cudaPackages.nccl}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      ${lib.getExe ncclRunner} 2>&1 | tee "$logs/nccl.log"
+      grep -E '^PASS NCCL [0-9]+ one-rank all-reduce: 7$' "$logs/nccl.log"
+    '';
+  };
+
+  hloTester = pkgs.writeShellApplication {
+    name = "xla-hlo";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+    ];
+    text = ''
+      logs=''${1:-$(mktemp -d -t xla-hlo.XXXXXXXX)}
+      mkdir -p "$logs"
+      ${lib.optionalString cudaSupport ''
+        # Even Host/Interpreter need the CUDA CLI's direct libcuda dependency.
+        export LD_LIBRARY_PATH="${pkgs.addDriverRunpath.driverLink}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      ''}
+      ${xla}/bin/run_hlo_module --platform=Host --reference_platform=Interpreter \
+        ${./smoke.hlo} 2>&1 | tee "$logs/hlo.log"
+      grep -F 'Results on Host and Interpreter are close enough.' "$logs/hlo.log"
+      grep -Fx '0/1 runs failed.' "$logs/hlo.log"
+    '';
+  };
+
+  runtimeClosure = pkgs.closureInfo { rootPaths = [ xla ]; };
+  installConfig = pkgs.writeText "xla-install-check.json" (
+    builtins.toJSON {
+      package = xla;
+      inherit cudaSupport;
+      closure = "${runtimeClosure}/store-paths";
+      driverRunpath = "${pkgs.addDriverRunpath.driverLink}/lib";
+      runtimeRunpaths = map (p: "${p}/lib") cudaRuntimeLibs;
+      pluginRunpaths = lib.optionals cudaSupport (
+        map (p: "${lib.getLib p}/lib") [
+          cudaPackages.cuda_cudart
+          cudaPackages.cudnn
+          cudaPackages.nccl
+        ]
+      );
+      cudaToolRoot = lib.optionalString cudaSupport (toString cudaPackages.cuda_nvcc);
+      cudaToolArtifacts = lib.optionals cudaSupport [
+        "bin/ptxas"
+        "bin/nvlink"
+        "nvvm/libdevice/libdevice.10.bc"
+      ];
+      # The full selected nvcc output intentionally retains its wrapped host GCC.
+      # Keep excluding unrelated build roots, including the build stdenv wrapper;
+      # comparing names must not realize the forbidden inputs themselves.
+      forbiddenPaths = map (p: builtins.unsafeDiscardStringContext (toString p)) [
+        xla.src
+        xla.deps
+        pkgs.bazel_7
+        pkgs.stdenv.cc
+      ];
+    }
+  );
+  installTester = pkgs.writeShellApplication {
+    name = "xla-install";
+    runtimeInputs = [
+      pkgs.python3
+      pkgs.binutils
+      pkgs.patchelf
+      pkgs.glibc.bin
+    ];
+    text = ''
+      exec python3 ${./install-check.py} ${installConfig} "$@"
+    '';
+  };
+
+  check =
+    name: tester: features:
+    pkgs.runCommand "xla-${name}"
+      {
+        requiredSystemFeatures = features;
+      }
+      ''
+        ${lib.getExe tester} "$out"
+      '';
+  metadata =
+    assert lib.elem lib.licenses.asl20 xla.meta.license;
+    assert cudaSupport == lib.any (license: !(license.free or true)) xla.meta.license;
+    assert
+      !cudaSupport
+      || (
+        lib.elem lib.licenses.nvidiaCudaRedist xla.meta.license
+        && lib.all (license: lib.elem license xla.meta.license) cudaPackages.cudnn.meta.license
+      );
+    pkgs.runCommand "xla-metadata" { } ''touch "$out"'';
+in
+{
+  inherit runner;
+  testers = {
+    pjrt = pjrtTester "cpu";
+  }
+  // lib.optionalAttrs (!cudaSupport) {
+    hlo = hloTester;
+    install = installTester;
+  }
+  // {
+    cuda = lib.optionalAttrs cudaSupport {
+      pjrt = pjrtTester "cuda";
+      nccl = ncclTester;
+      hlo = hloTester;
+      install = installTester;
+    };
+  };
+
+  tests = {
+    cpu = check "pjrt-cpu" (pjrtTester "cpu") [ ];
+  }
+  // lib.optionalAttrs (!cudaSupport) {
+    hlo = check "hlo" hloTester [ ];
+    install = check "install" installTester [ ];
+    inherit metadata;
+  }
+  // {
+    cuda = lib.optionalAttrs cudaSupport {
+      pjrt = check "pjrt-cuda" (pjrtTester "cuda") [ "cuda" ];
+      nccl = check "nccl-cuda" ncclTester [ "cuda" ];
+      hlo = check "hlo-cuda" hloTester [ "cuda" ];
+      install = check "install-cuda" installTester [ ];
+      configure = pkgs.callPackage ./cuda-configure.nix { inherit xla cudaPackages; };
+      configureOverride =
+        let
+          selectedCudaPackages = cudaPackages // {
+            cuda_nvcc = cudaPackages.cuda_nvcc.overrideAttrs (previousAttrs: {
+              postInstall = (previousAttrs.postInstall or "") + ''
+                echo '#define XLA_SELECTED_OUTPUT 964' > "$out/include/xla-selected-output.h"
+              '';
+            });
+            nccl = cudaPackages.nccl.overrideAttrs (previousAttrs: {
+              postInstall = (previousAttrs.postInstall or "") + ''
+                echo '#define XLA_SELECTED_NCCL_OUTPUT 1' > "$out/include/xla-selected-nccl-output.h"
+              '';
+            });
+          };
+          # finalAttrs.finalPackage keeps downstream overrideAttrs linked into
+          # passthru tests, but it cannot expose callPackage's outer `override`.
+          # Update only the selected-package paths while retaining that linkage.
+          local = pkgs.callPackage ../cuda-local.nix { inherit cudaPackages; };
+          selectedLocal = pkgs.callPackage ../cuda-local.nix { cudaPackages = selectedCudaPackages; };
+          replaceSelectedPaths =
+            lib.replaceStrings
+              [
+                (toString local.cuda)
+                (toString local.nccl)
+                (toString cudaPackages.cuda_nvcc)
+              ]
+              [
+                (toString selectedLocal.cuda)
+                (toString selectedLocal.nccl)
+                (toString selectedCudaPackages.cuda_nvcc)
+              ];
+          selectedXla = xla.overrideAttrs (previousAttrs: {
+            preConfigure = replaceSelectedPaths previousAttrs.preConfigure;
+            postConfigure = replaceSelectedPaths previousAttrs.postConfigure;
+          });
+        in
+        pkgs.callPackage ./cuda-configure.nix {
+          xla = selectedXla;
+          cudaPackages = selectedCudaPackages;
+          expectSelectedOutput = true;
+        };
+      configureChecker = pkgs.runCommand "xla-cuda-configure-checker" { } ''
+        ${lib.getExe pkgs.python3} ${./cuda-configure-check-test.py} ${./cuda-configure-check.py} -v \
+          > "$out" 2>&1
+
+        mkdir -p driver-valid/lib driver-copied-stub/lib driver-linked-stub/lib
+        printf 'real driver fixture' > driver-valid/lib/libcuda.so.1
+        printf 'toolkit stub fixture' > toolkit-stub.so
+        cp toolkit-stub.so driver-copied-stub/lib/libcuda.so.1
+        ln -s "$PWD/toolkit-stub.so" driver-linked-stub/lib/libcuda.so.1
+        ${pkgs.bash}/bin/bash ${./cuda-driver-check.sh} driver-valid toolkit-stub.so
+        if ${pkgs.bash}/bin/bash ${./cuda-driver-check.sh} driver-missing toolkit-stub.so; then
+          echo "missing driver repository passed validation" >&2
+          exit 1
+        fi
+        if ${pkgs.bash}/bin/bash ${./cuda-driver-check.sh} driver-copied-stub toolkit-stub.so; then
+          echo "copied toolkit stub passed as a real driver" >&2
+          exit 1
+        fi
+        if ${pkgs.bash}/bin/bash ${./cuda-driver-check.sh} driver-linked-stub toolkit-stub.so; then
+          echo "linked toolkit stub passed as a real driver" >&2
+          exit 1
+        fi
+      '';
+      inherit metadata;
+    };
+  };
+}

--- a/pkgs/by-name/xl/xla/tests/eval.nix
+++ b/pkgs/by-name/xl/xla/tests/eval.nix
@@ -1,0 +1,136 @@
+# Run with: nix-instantiate --eval --strict pkgs/by-name/xl/xla/tests/eval.nix --arg nixpkgs ./.
+# Keep the independent free-only import outside passthru to avoid recursive
+# package-set evaluation in a build or test-discovery traversal.
+{ nixpkgs }:
+let
+  free = import nixpkgs {
+    config = {
+      allowUnfree = false;
+      allowUnfreePredicate = _: false;
+      cudaSupport = false;
+    };
+  };
+  unfree = import nixpkgs { config.allowUnfree = true; };
+  cpu = free.xla.override { cudaSupport = false; };
+  gpu = unfree.xla.override { cudaSupport = true; };
+  rejected = builtins.tryEval ((free.xla.override { cudaSupport = true; }).drvPath);
+  configured =
+    capabilities: forwardCompat:
+    (import nixpkgs {
+      config = {
+        allowUnfree = true;
+        cudaCapabilities = capabilities;
+        cudaForwardCompat = forwardCompat;
+      };
+    }).xla.override
+      { cudaSupport = true; };
+  forward = configured [ "8.0" "8.9" ] true;
+  noForward = configured [ "8.0" "8.9" ] false;
+  ordered = configured [ "9.0" "8.0" ] true;
+  accelerated = configured [ "9.0a" ] true;
+  familyRejected = forwardCompat: builtins.tryEval (configured [ "10.0f" ] forwardCompat).drvPath;
+  selected = gpu.override { cudaPackages = unfree.cudaPackages_12_8; };
+  selectedWithHash = selected.overrideAttrs (previousAttrs: {
+    deps = previousAttrs.deps.overrideAttrs {
+      outputHash = unfree.lib.fakeHash;
+      outputHashAlgo = "sha256";
+    };
+  });
+  selectedExpected = unfree.callPackage ./default.nix {
+    xla = selectedWithHash;
+    cudaSupport = true;
+    cudaPackages = unfree.cudaPackages_12_8;
+  };
+  selectedConfigureOverride = builtins.tryEval selectedWithHash.tests.cuda.configureOverride.drvPath;
+  hasCapabilities =
+    value: package: unfree.lib.hasInfix "--cuda_compute_capabilities=${value} \\" package.preConfigure;
+  containsPath =
+    path: text:
+    unfree.lib.hasInfix (builtins.unsafeDiscardStringContext (toString path)) (
+      builtins.unsafeDiscardStringContext text
+    );
+  hasCompiledDefault =
+    root: package:
+    unfree.lib.hasInfix ''opts.set_xla_gpu_cuda_data_dir("${builtins.unsafeDiscardStringContext (toString root)}");'' (
+      builtins.unsafeDiscardStringContext package.postConfigure
+    );
+  overridden = cpu.overrideAttrs (previousAttrs: {
+    postInstall = (previousAttrs.postInstall or "") + ''touch "$out/override-linkage-test"'';
+    passthru = previousAttrs.passthru // {
+      overrideLinkageSentinel = true;
+    };
+  });
+  expected = unfree.callPackage ./default.nix {
+    xla = overridden;
+    cudaSupport = false;
+  };
+  gpuOverridden = gpu.overrideAttrs { postInstall = ''touch "$out/override-linkage-test"''; };
+  gpuExpected = unfree.callPackage ./default.nix {
+    xla = gpuOverridden;
+    cudaSupport = true;
+  };
+in
+assert (builtins.tryEval cpu.drvPath).success;
+assert !rejected.success;
+assert builtins.all (license: license.free) cpu.meta.license;
+assert builtins.elem unfree.lib.licenses.nvidiaCudaRedist gpu.meta.license;
+assert builtins.all (
+  license: builtins.elem license gpu.meta.license
+) unfree.cudaPackages.cudnn.meta.license;
+assert cpu.tests.cuda == { } && cpu.testers.cuda == { };
+assert gpu.tests.cuda.pjrt.requiredSystemFeatures == [ "cuda" ];
+assert gpu.tests.cuda.hlo.requiredSystemFeatures == [ "cuda" ];
+assert gpu.tests.cuda.nccl.requiredSystemFeatures == [ "cuda" ];
+assert gpu.tests.cuda.install.requiredSystemFeatures == [ ];
+assert gpu.tests.cuda.configure.requiredSystemFeatures == [ "big-parallel" ];
+assert gpu.tests.cuda.configureOverride.requiredSystemFeatures == [ "big-parallel" ];
+assert gpu.tests.cuda.configure.deps.drvPath == gpu.deps.drvPath;
+assert noForward.tests.cuda.configure.deps.drvPath == noForward.deps.drvPath;
+assert gpu.tests.cuda.configure.passthru == { };
+assert hasCapabilities "sm_75,sm_80,sm_86,sm_89,sm_90,sm_100,sm_103,sm_120,compute_121" gpu;
+assert hasCapabilities "sm_80,compute_89" forward;
+assert hasCapabilities "sm_80,sm_89" noForward;
+assert hasCapabilities "sm_90,compute_80" ordered;
+assert hasCapabilities "compute_90a" accelerated;
+assert hasCapabilities "sm_75,sm_80,sm_86,sm_89,sm_90,sm_100,compute_120" selected;
+assert !(familyRejected false).success && !(familyRejected true).success;
+assert unfree.lib.hasInfix "--cuda_version=12.9.1" gpu.preConfigure;
+assert unfree.lib.hasInfix "--cudnn_version=9.22.0" gpu.preConfigure;
+assert hasCompiledDefault unfree.cudaPackages.cuda_nvcc gpu;
+assert !(containsPath unfree.cudaPackages.cuda_nvcc cpu.postConfigure);
+assert !(builtins.tryEval selected.drvPath).success;
+assert (builtins.tryEval selectedWithHash.drvPath).success;
+assert selectedConfigureOverride.success;
+assert selectedWithHash.tests.cuda.configureOverride.deps.drvPath == selectedWithHash.deps.drvPath;
+assert selectedWithHash.testers.cuda.pjrt.drvPath == selectedExpected.testers.cuda.pjrt.drvPath;
+assert unfree.lib.hasInfix "--cuda_version=12.8.1" selectedWithHash.preConfigure;
+assert hasCompiledDefault unfree.cudaPackages_12_8.cuda_nvcc selectedWithHash;
+assert forward.deps.outPath == gpu.deps.outPath;
+assert noForward.deps.outPath == gpu.deps.outPath;
+assert forward.deps.outputHash == gpu.deps.outputHash;
+assert noForward.deps.outputHash == gpu.deps.outputHash;
+assert overridden.drvPath != cpu.drvPath;
+assert overridden.deps.drvPath == cpu.deps.drvPath;
+assert overridden.overrideLinkageSentinel;
+assert overridden.tests.cpu.drvPath == expected.tests.cpu.drvPath;
+assert overridden.tests.hlo.drvPath == expected.tests.hlo.drvPath;
+assert overridden.tests.install.drvPath == expected.tests.install.drvPath;
+assert gpuOverridden.tests.cuda.pjrt.drvPath == gpuExpected.tests.cuda.pjrt.drvPath;
+assert gpuOverridden.tests.cuda.nccl.drvPath == gpuExpected.tests.cuda.nccl.drvPath;
+assert gpuOverridden.tests.cuda.hlo.drvPath == gpuExpected.tests.cuda.hlo.drvPath;
+{
+  cpuChecks = builtins.mapAttrs (_: check: check.drvPath) (builtins.removeAttrs cpu.tests [ "cuda" ]);
+  cpuTesters = builtins.mapAttrs (_: tester: tester.meta.mainProgram) (
+    builtins.removeAttrs cpu.testers [ "cuda" ]
+  );
+  cpuDrvPath = cpu.drvPath;
+  cudaDrvPath = gpu.drvPath;
+  unfreeRejected = !rejected.success;
+  capabilitiesAndOverrideLinkage = true;
+  cudaDepsDrvPath = gpu.deps.drvPath;
+  cudaConfigureChecks = {
+    default = gpu.tests.cuda.configure.drvPath;
+    noForward = noForward.tests.cuda.configure.drvPath;
+    override = gpu.tests.cuda.configureOverride.drvPath;
+  };
+}

--- a/pkgs/by-name/xl/xla/tests/install-check.py
+++ b/pkgs/by-name/xl/xla/tests/install-check.py
@@ -1,0 +1,183 @@
+"""Audit the selected installed output without a Nix daemon or GPU access."""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def require(condition, message):
+    if not condition:
+        raise RuntimeError(message)
+
+
+def command(*args):
+    result = subprocess.run(
+        args, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
+    )
+    require(
+        result.returncode == 0, f"{args}: exit {result.returncode}\n{result.stdout}"
+    )
+    return result.stdout
+
+
+def main():
+    config = json.loads(Path(sys.argv[1]).read_text())
+    require(len(sys.argv) <= 3, "Usage: xla-install [LOG_DIRECTORY]")
+    logs = Path(
+        sys.argv[2] if len(sys.argv) == 3 else tempfile.mkdtemp(prefix="xla-install-")
+    )
+    logs.mkdir(parents=True, exist_ok=True)
+    package = Path(config["package"])
+    cuda = config["cudaSupport"]
+    cuda_tool_root = Path(config["cudaToolRoot"]) if cuda else None
+    cuda_root_needle = str(cuda_tool_root).encode() if cuda else None
+    cuda_root_reference = False
+    # Do not let a caller's search path hide broken installed RUNPATHs.
+    os.environ.pop("LD_LIBRARY_PATH", None)
+    os.environ.pop("LD_PRELOAD", None)
+    dynamic_count = 0
+    allowed_driver_count = 0
+    with (logs / "elf.log").open("w") as log:
+        for path in sorted(package.rglob("*")):
+            require(
+                not path.name.endswith(".runfiles_manifest"), f"stale manifest: {path}"
+            )
+            if path.is_symlink():
+                require(
+                    "/build/output" not in os.readlink(path), f"stale symlink: {path}"
+                )
+                continue
+            if not path.is_file():
+                continue
+            # Stream large archives, retaining enough overlap to find split matches.
+            with path.open("rb") as file:
+                magic = file.read(4)
+                file.seek(0)
+                tail = b""
+                while chunk := file.read(1024 * 1024):
+                    window = tail + chunk
+                    require(
+                        b"/build/output" not in window,
+                        f"stale build path: {path}",
+                    )
+                    if cuda and cuda_root_needle in window:
+                        cuda_root_reference = True
+                    tail = chunk[-max(12, len(cuda_root_needle or b"")) :]
+            if magic != b"\x7fELF":
+                continue
+            dynamic = command("readelf", "-d", str(path))
+            if "(NEEDED)" not in dynamic:
+                # Relocatable objects/static executables have no dynamic dependencies.
+                continue
+            dynamic_count += 1
+            linkage = command("ldd", str(path))
+            log.write(f"{path}\n{linkage}\n")
+            for line in linkage.splitlines():
+                if "not found" in line:
+                    require(
+                        cuda
+                        and re.fullmatch(r"\s*libcuda\.so\.1 => not found\s*", line),
+                        f"unresolved dependency: {path}: {line}",
+                    )
+                    allowed_driver_count += 1
+    require(dynamic_count > 0, "no dynamic ELF files audited")
+
+    for platform in ["cpu"] + (["gpu"] if cuda else []):
+        plugin = package / "lib" / f"pjrt_c_api_{platform}_plugin.so"
+        symbols = command("nm", "-D", "--defined-only", str(plugin))
+        require(
+            any(
+                line.split()[-1].split("@", 1)[0] == "GetPjrtApi"
+                for line in symbols.splitlines()
+                if line.split()
+            ),
+            f"missing GetPjrtApi export: {plugin}",
+        )
+    if cuda:
+        require(
+            cuda_root_reference,
+            f"installed files do not reference packaged CUDA tools: {cuda_tool_root}",
+        )
+        for relative in config["cudaToolArtifacts"]:
+            artifact = cuda_tool_root / relative
+            require(artifact.is_file(), f"missing packaged CUDA tool: {artifact}")
+            if relative.startswith("bin/"):
+                require(
+                    os.access(artifact, os.X_OK),
+                    f"CUDA tool is not executable: {artifact}",
+                )
+        runpaths = command("patchelf", "--print-rpath", str(plugin)).strip().split(":")
+        for expected in [config["driverRunpath"], *config["pluginRunpaths"]]:
+            require(expected in runpaths, f"missing GPU RUNPATH: {expected}")
+        for name, version, soname in [
+            ("libnvshmem_host", "3.2.5", "3"),
+            ("nvshmem_bootstrap_uid", "3.0.0", "3"),
+            ("nvshmem_transport_ibrc", "3.0.0", "3"),
+        ]:
+            library = package / "lib" / f"{name}.so.{version}"
+            link = package / "lib" / f"{name}.so.{soname}"
+            require(library.is_file(), f"missing NVSHMEM runtime: {library}")
+            require(
+                link.is_symlink() and link.resolve() == library,
+                f"wrong SONAME link: {link}",
+            )
+            require(
+                command("patchelf", "--print-soname", str(library)).strip()
+                == link.name,
+                f"wrong SONAME: {library}",
+            )
+        # autoPatchelf's runtimeDependencies apply to the executable. In
+        # particular, rdma-core here does NOT establish IBRC dlopen resolution.
+        cli_runpaths = (
+            command("patchelf", "--print-rpath", str(package / "bin/run_hlo_module"))
+            .strip()
+            .split(":")
+        )
+        for expected in config["runtimeRunpaths"]:
+            require(
+                expected in cli_runpaths, f"missing CLI runtime RUNPATH: {expected}"
+            )
+
+    closure_text = Path(config["closure"]).read_text()
+    (logs / "closure.txt").write_text(closure_text)
+    closure = set(closure_text.splitlines())
+    if cuda:
+        require(
+            str(cuda_tool_root) in closure,
+            f"packaged CUDA tools absent from closure: {cuda_tool_root}",
+        )
+        for runpath in config["runtimeRunpaths"]:
+            require(
+                str(Path(runpath).parent) in closure,
+                f"declared runtime absent from closure: {runpath}",
+            )
+    for forbidden in config["forbiddenPaths"]:
+        require(
+            forbidden not in closure,
+            f"build-only input in runtime closure: {forbidden}",
+        )
+    if not cuda:
+        # Package-name predicate is deliberately explicit; do not ban generic
+        # compiler runtime libraries or compare historical closure/file counts.
+        cuda_name = re.compile(
+            r"(?:cuda[0-9.-]*-|cudnn-|libcu(?:blas|fft|rand|solver|sparse)-|nccl-|nvshmem-)"
+        )
+        for store_path in closure:
+            name = Path(store_path).name.split("-", 1)[1]
+            require(
+                not cuda_name.match(name), f"CUDA runtime in CPU closure: {store_path}"
+            )
+    summary = f"PASS: install audit; dynamic ELF files={dynamic_count}, allowed host-driver misses={allowed_driver_count}\n"
+    (logs / "summary.log").write_text(summary)
+    print(summary, end="")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (RuntimeError, OSError) as error:
+        sys.exit(f"FAIL: {error}")

--- a/pkgs/by-name/xl/xla/tests/nccl-smoke.cc
+++ b/pkgs/by-name/xl/xla/tests/nccl-smoke.cc
@@ -1,0 +1,105 @@
+#include <cuda_runtime_api.h>
+#include <nccl.h>
+
+#include <cmath>
+#include <cstdio>
+
+namespace {
+
+bool CheckCuda(cudaError_t result, const char* operation) {
+  if (result == cudaSuccess) return true;
+  std::fprintf(stderr, "%s: %s\n", operation, cudaGetErrorString(result));
+  return false;
+}
+
+bool CheckNccl(ncclResult_t result, const char* operation) {
+  if (result == ncclSuccess) return true;
+  std::fprintf(stderr, "%s: %s\n", operation, ncclGetErrorString(result));
+  return false;
+}
+
+bool Cleanup(ncclComm_t communicator, float* device_output,
+             float* device_input, bool abort_communicator) {
+  bool success = true;
+  if (communicator != nullptr) {
+    const ncclResult_t result = abort_communicator
+                                    ? ncclCommAbort(communicator)
+                                    : ncclCommDestroy(communicator);
+    if (!CheckNccl(result, abort_communicator ? "ncclCommAbort"
+                                              : "ncclCommDestroy")) {
+      success = false;
+    }
+  }
+  if (device_output != nullptr &&
+      !CheckCuda(cudaFree(device_output), "cudaFree output")) {
+    success = false;
+  }
+  if (device_input != nullptr &&
+      !CheckCuda(cudaFree(device_input), "cudaFree input")) {
+    success = false;
+  }
+  return success;
+}
+
+}  // namespace
+
+int main() {
+  int device_count = 0;
+  if (!CheckCuda(cudaGetDeviceCount(&device_count), "cudaGetDeviceCount")) {
+    return 1;
+  }
+  if (device_count < 1) {
+    std::fputs("no CUDA device available\n", stderr);
+    return 1;
+  }
+  if (!CheckCuda(cudaSetDevice(0), "cudaSetDevice")) return 1;
+
+  int runtime_version = 0;
+  if (!CheckNccl(ncclGetVersion(&runtime_version), "ncclGetVersion")) {
+    return 1;
+  }
+  if (runtime_version != NCCL_VERSION_CODE) {
+    std::fprintf(stderr, "NCCL header/runtime version mismatch: %d != %d\n",
+                 NCCL_VERSION_CODE, runtime_version);
+    return 1;
+  }
+
+  constexpr float input = 7.0f;
+  float output = 0.0f;
+  float* device_input = nullptr;
+  float* device_output = nullptr;
+  ncclComm_t communicator = nullptr;
+  ncclUniqueId id;
+
+  if (!CheckCuda(cudaMalloc(&device_input, sizeof(input)), "cudaMalloc input") ||
+      !CheckCuda(cudaMalloc(&device_output, sizeof(output)),
+                 "cudaMalloc output") ||
+      !CheckCuda(cudaMemcpy(device_input, &input, sizeof(input),
+                            cudaMemcpyHostToDevice),
+                 "cudaMemcpy input") ||
+      !CheckNccl(ncclGetUniqueId(&id), "ncclGetUniqueId") ||
+      !CheckNccl(ncclCommInitRank(&communicator, 1, id, 0),
+                 "ncclCommInitRank") ||
+      !CheckNccl(ncclAllReduce(device_input, device_output, 1, ncclFloat,
+                               ncclSum, communicator, nullptr),
+                 "ncclAllReduce") ||
+      !CheckCuda(cudaDeviceSynchronize(), "cudaDeviceSynchronize") ||
+      !CheckCuda(cudaMemcpy(&output, device_output, sizeof(output),
+                            cudaMemcpyDeviceToHost),
+                 "cudaMemcpy output")) {
+    Cleanup(communicator, device_output, device_input, true);
+    return 1;
+  }
+
+  const bool result_ok = std::fabs(output - input) < 1e-6f;
+  const bool cleanup_ok =
+      Cleanup(communicator, device_output, device_input, false);
+  if (!result_ok) {
+    std::fprintf(stderr, "unexpected one-rank all-reduce result: %.9g\n", output);
+  }
+  if (!cleanup_ok || !result_ok) return 1;
+
+  std::printf("PASS NCCL %d one-rank all-reduce: %.9g\n", runtime_version,
+              output);
+  return 0;
+}

--- a/pkgs/by-name/xl/xla/tests/pjrt-check.sh
+++ b/pkgs/by-name/xl/xla/tests/pjrt-check.sh
@@ -1,0 +1,41 @@
+# Invoked by the Nix-built tester with the selected package and platform.
+set -euo pipefail
+runner=$1
+plugin=$2
+platform=$3
+shift 3
+if (( $# > 1 )); then
+  echo 'Usage: xla-pjrt-PLATFORM [LOG_DIRECTORY]' >&2
+  exit 2
+fi
+logs=${1:-$(mktemp -d -t "xla-pjrt-$platform.XXXXXXXX")}
+mkdir -p "$logs"
+echo "PJRT plugin: $plugin"
+echo "Logs: $logs"
+"$runner" "$plugin" "$platform" 2>&1 | tee "$logs/positive.log"
+grep -F 'Transcendental result transferred: f32[2,3]' "$logs/positive.log"
+grep -F "PASS: $platform StableHLO compile/execute/readback" "$logs/positive.log"
+if "$runner" "$plugin" "$platform" --wrong-expected > "$logs/wrong-expected.log" 2>&1; then
+  echo 'incorrect expected value unexpectedly passed' >&2
+  exit 1
+else
+  status=$?
+fi
+cat "$logs/wrong-expected.log"
+echo "wrong-expected exit=$status"
+test "$status" -eq 1
+grep -F 'Execution completed' "$logs/wrong-expected.log"
+grep -F 'Result transferred: f32[2,3] 3 -6 6 1 4 48' "$logs/wrong-expected.log"
+grep -F 'FAIL: value mismatch at element 0' "$logs/wrong-expected.log"
+if [[ $platform == cpu ]]; then
+  if "$runner" "$plugin" cuda > "$logs/wrong-platform.log" 2>&1; then
+    echo 'CPU plugin unexpectedly satisfied CUDA request' >&2
+    exit 1
+  else
+    status=$?
+  fi
+  cat "$logs/wrong-platform.log"
+  echo "wrong-platform exit=$status"
+  test "$status" -eq 1
+  grep -F 'FAIL: requested platform cuda, got cpu' "$logs/wrong-platform.log"
+fi

--- a/pkgs/by-name/xl/xla/tests/pjrt-execute.cc
+++ b/pkgs/by-name/xl/xla/tests/pjrt-execute.cc
@@ -1,0 +1,303 @@
+// Exercise the installed plugin through the C ABI, without linking XLA or JAX.
+#include <dlfcn.h>
+
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "xla/pjrt/c/pjrt_c_api.h"
+
+#define ARGS(type, name)                                                       \
+  type name{};                                                                 \
+  name.struct_size = type##_STRUCT_SIZE
+#define CALL(name, args) check(api, api->name(&args), #name)
+
+static bool cleanup_failed = false;
+
+static void require(bool condition, const std::string &message) {
+  if (!condition)
+    throw std::runtime_error(message);
+}
+
+static void check(const PJRT_Api *api, PJRT_Error *error,
+                  const char *operation) {
+  if (!error)
+    return;
+  ARGS(PJRT_Error_Message_Args, message);
+  message.error = error;
+  api->PJRT_Error_Message(&message);
+  std::string text(message.message, message.message_size);
+  ARGS(PJRT_Error_Destroy_Args, destroy);
+  destroy.error = error;
+  api->PJRT_Error_Destroy(&destroy);
+  throw std::runtime_error(std::string(operation) + ": " + text);
+}
+
+// Keep plugin resources alive until their asynchronous users have completed.
+// Destruction errors must fail the test too, but must not throw during
+// unwinding.
+template <typename T, typename Args>
+static auto own(const PJRT_Api *api, T *object, PJRT_Error *(*destroy)(Args *),
+                size_t struct_size) {
+  return std::unique_ptr<T, std::function<void(T *)>>(object, [=](T *value) {
+    Args args{struct_size, nullptr, value};
+    try {
+      check(api, destroy(&args), "resource destruction");
+    } catch (const std::exception &error) {
+      std::cerr << "FAIL: " << error.what() << '\n';
+      cleanup_failed = true;
+    }
+  });
+}
+#define OWN(kind, object)                                                      \
+  own(api, object, api->kind##_Destroy, kind##_Destroy_Args_STRUCT_SIZE)
+
+static void await(const PJRT_Api *api, PJRT_Event *event) {
+  require(event != nullptr, "missing asynchronous completion event");
+  auto owned = OWN(PJRT_Event, event);
+  ARGS(PJRT_Event_Await_Args, args);
+  args.event = event;
+  CALL(PJRT_Event_Await, args);
+}
+
+static auto upload(const PJRT_Api *api, PJRT_Client *client,
+                   PJRT_Device *device, const std::array<float, 6> &data) {
+  const int64_t dims[] = {2, 3};
+  ARGS(PJRT_Client_BufferFromHostBuffer_Args, args);
+  args.client = client;
+  args.device = device;
+  args.data = data.data();
+  args.type = PJRT_Buffer_Type_F32;
+  args.dims = dims;
+  args.num_dims = 2;
+  args.host_buffer_semantics =
+      PJRT_HostBufferSemantics_kImmutableOnlyDuringCall;
+  CALL(PJRT_Client_BufferFromHostBuffer, args);
+  auto buffer = OWN(PJRT_Buffer, args.buffer);
+  await(api, args.done_with_host_buffer);
+  return buffer;
+}
+
+static void run(const char *plugin, const std::string &platform,
+                bool wrong_expected) {
+  auto close_plugin = [](void *handle) { dlclose(handle); };
+  // XLA retains process-global thread pools and exit hooks after client
+  // destruction. Release the dlopen handle, but do not unmap their code.
+  std::unique_ptr<void, decltype(close_plugin)> handle(
+      dlopen(plugin, RTLD_NOW | RTLD_LOCAL | RTLD_NODELETE), close_plugin);
+  if (!handle)
+    throw std::runtime_error(std::string("dlopen: ") + dlerror());
+  auto get_api = reinterpret_cast<const PJRT_Api *(*)()>(
+      dlsym(handle.get(), "GetPjrtApi"));
+  require(get_api != nullptr, "GetPjrtApi not exported");
+  const PJRT_Api *api = get_api();
+  require(api != nullptr, "GetPjrtApi returned null");
+  require(api->pjrt_api_version.major_version == PJRT_API_MAJOR &&
+              api->pjrt_api_version.minor_version >= PJRT_API_MINOR &&
+              api->struct_size >= PJRT_Api_STRUCT_SIZE,
+          "plugin C API is older than or incompatible with the test headers");
+  std::cout << "Loaded PJRT API " << api->pjrt_api_version.major_version << '.'
+            << api->pjrt_api_version.minor_version << '\n';
+
+  ARGS(PJRT_Plugin_Initialize_Args, initialize);
+  CALL(PJRT_Plugin_Initialize, initialize);
+  std::cout << "Plugin initialized\n";
+  ARGS(PJRT_Client_Create_Args, create);
+  CALL(PJRT_Client_Create, create);
+  auto client = OWN(PJRT_Client, create.client);
+  require(client != nullptr, "null client");
+  std::cout << "Client created\n";
+
+  ARGS(PJRT_Client_PlatformName_Args, name);
+  name.client = client.get();
+  CALL(PJRT_Client_PlatformName, name);
+  std::string actual_platform(name.platform_name, name.platform_name_size);
+  std::cout << "Platform: " << actual_platform << '\n';
+  require(actual_platform == platform,
+          "requested platform " + platform + ", got " + actual_platform);
+  ARGS(PJRT_Client_AddressableDevices_Args, devices);
+  devices.client = client.get();
+  CALL(PJRT_Client_AddressableDevices, devices);
+  require(devices.num_addressable_devices > 0, "no addressable devices");
+  std::cout << "Addressable devices: " << devices.num_addressable_devices
+            << '\n';
+
+  // Inputs are host buffers, not constants in the compiled module.
+  char module[] = R"mlir(
+module @pjrt_execute {
+  func.func @main(%x: tensor<2x3xf32>, %y: tensor<2x3xf32>) -> (tensor<2x3xf32>, tensor<2x3xf32>) {
+    %sum = stablehlo.add %x, %y : tensor<2x3xf32>
+    %result = stablehlo.multiply %sum, %x : tensor<2x3xf32>
+    %transcendental = stablehlo.sine %sum : tensor<2x3xf32>
+    return %result, %transcendental : tensor<2x3xf32>, tensor<2x3xf32>
+  }
+}
+)mlir";
+  ARGS(PJRT_Program, program);
+  program.code = module;
+  program.code_size = std::strlen(module);
+  program.format = "mlir";
+  program.format_size = 4;
+  // CompileOptionsProto.executable_build_options (field 3), containing
+  // ExecutableBuildOptionsProto.num_replicas=1 (4), num_partitions=1 (5).
+  // Use the wire format to avoid linking protobuf or XLA C++ libraries.
+  const char compile_options[] = "\x1a\x04\x20\x01\x28\x01";
+  ARGS(PJRT_Client_Compile_Args, compile);
+  compile.client = client.get();
+  compile.program = &program;
+  compile.compile_options = compile_options;
+  compile.compile_options_size = sizeof(compile_options) - 1;
+  CALL(PJRT_Client_Compile, compile);
+  auto executable = OWN(PJRT_LoadedExecutable, compile.executable);
+  require(executable != nullptr, "null executable");
+  std::cout << "StableHLO compiled\n";
+
+  ARGS(PJRT_LoadedExecutable_AddressableDevices_Args, placement);
+  placement.executable = executable.get();
+  CALL(PJRT_LoadedExecutable_AddressableDevices, placement);
+  require(placement.num_addressable_devices == 1,
+          "expected single-device executable");
+  PJRT_Device *device = placement.addressable_devices[0];
+  bool addressable = false;
+  for (size_t i = 0; i < devices.num_addressable_devices; ++i)
+    addressable |= device == devices.addressable_devices[i];
+  require(addressable, "executable device is not addressable by this client");
+  ARGS(PJRT_Device_GetDescription_Args, description);
+  description.device = device;
+  CALL(PJRT_Device_GetDescription, description);
+  ARGS(PJRT_DeviceDescription_Kind_Args, kind);
+  kind.device_description = description.device_description;
+  CALL(PJRT_DeviceDescription_Kind, kind);
+  std::cout << "Execution device: "
+            << std::string(kind.device_kind, kind.device_kind_size) << '\n';
+
+  const std::array<float, 6> x = {1, -2, 3, 0.5, -4, 8};
+  const std::array<float, 6> y = {2, 5, -1, 1.5, 3, -2};
+  auto input_x = upload(api, client.get(), device, x);
+  auto input_y = upload(api, client.get(), device, y);
+  std::cout << "Nonconstant inputs transferred\n";
+  PJRT_Buffer *inputs[] = {input_x.get(), input_y.get()};
+  PJRT_Buffer *const *input_lists[] = {inputs};
+  PJRT_Buffer *outputs[] = {nullptr, nullptr};
+  PJRT_Buffer **output_lists[] = {outputs};
+  PJRT_Event *events[] = {nullptr};
+  ARGS(PJRT_ExecuteOptions, options);
+  // Inputs remain ours and must not be donated to the executable.
+  const int64_t non_donatable[] = {0, 1};
+  options.non_donatable_input_indices = non_donatable;
+  options.num_non_donatable_input_indices = 2;
+  ARGS(PJRT_LoadedExecutable_Execute_Args, execute);
+  execute.executable = executable.get();
+  execute.options = &options;
+  execute.argument_lists = input_lists;
+  execute.num_devices = 1;
+  execute.num_args = 2;
+  execute.output_lists = output_lists;
+  execute.device_complete_events = events;
+  CALL(PJRT_LoadedExecutable_Execute, execute);
+  auto output = OWN(PJRT_Buffer, outputs[0]);
+  auto transcendental_output = OWN(PJRT_Buffer, outputs[1]);
+  await(api, events[0]);
+  require(output != nullptr, "null arithmetic output buffer");
+  require(transcendental_output != nullptr,
+          "null transcendental output buffer");
+  std::cout << "Execution completed\n";
+
+  ARGS(PJRT_Buffer_ElementType_Args, type);
+  type.buffer = output.get();
+  CALL(PJRT_Buffer_ElementType, type);
+  require(type.type == PJRT_Buffer_Type_F32, "output type is not f32");
+  ARGS(PJRT_Buffer_Dimensions_Args, shape);
+  shape.buffer = output.get();
+  CALL(PJRT_Buffer_Dimensions, shape);
+  require(shape.num_dims == 2 && shape.dims[0] == 2 && shape.dims[1] == 3,
+          "output shape is not [2,3]");
+  ARGS(PJRT_Buffer_Device_Args, output_device);
+  output_device.buffer = output.get();
+  CALL(PJRT_Buffer_Device, output_device);
+  require(output_device.device == device, "output is on the wrong device");
+
+  std::array<float, 6> result{};
+  ARGS(PJRT_Buffer_ToHostBuffer_Args, download);
+  download.src = output.get();
+  download.dst = result.data();
+  download.dst_size = sizeof(result);
+  CALL(PJRT_Buffer_ToHostBuffer, download);
+  await(api, download.event);
+  std::cout << "Result transferred: f32[2,3]";
+  for (float value : result)
+    std::cout << ' ' << value;
+  std::cout << '\n';
+  std::array<float, 6> expected = {3, -6, 6, 1, 4, 48};
+  if (wrong_expected)
+    expected[0] += 1;
+  for (size_t i = 0; i < result.size(); ++i)
+    require(
+        std::isfinite(result[i]) && std::abs(result[i] - expected[i]) < 1e-5f,
+        "value mismatch at element " + std::to_string(i) + ": expected " +
+            std::to_string(expected[i]) + ", got " + std::to_string(result[i]));
+
+  ARGS(PJRT_Buffer_ElementType_Args, transcendental_type);
+  transcendental_type.buffer = transcendental_output.get();
+  CALL(PJRT_Buffer_ElementType, transcendental_type);
+  require(transcendental_type.type == PJRT_Buffer_Type_F32,
+          "transcendental output type is not f32");
+  ARGS(PJRT_Buffer_Dimensions_Args, transcendental_shape);
+  transcendental_shape.buffer = transcendental_output.get();
+  CALL(PJRT_Buffer_Dimensions, transcendental_shape);
+  require(transcendental_shape.num_dims == 2 &&
+              transcendental_shape.dims[0] == 2 &&
+              transcendental_shape.dims[1] == 3,
+          "transcendental output shape is not [2,3]");
+  ARGS(PJRT_Buffer_Device_Args, transcendental_device);
+  transcendental_device.buffer = transcendental_output.get();
+  CALL(PJRT_Buffer_Device, transcendental_device);
+  require(transcendental_device.device == device,
+          "transcendental output is on the wrong device");
+
+  std::array<float, 6> transcendental_result{};
+  ARGS(PJRT_Buffer_ToHostBuffer_Args, transcendental_download);
+  transcendental_download.src = transcendental_output.get();
+  transcendental_download.dst = transcendental_result.data();
+  transcendental_download.dst_size = sizeof(transcendental_result);
+  CALL(PJRT_Buffer_ToHostBuffer, transcendental_download);
+  await(api, transcendental_download.event);
+  std::cout << "Transcendental result transferred: f32[2,3]";
+  for (float value : transcendental_result)
+    std::cout << ' ' << value;
+  std::cout << '\n';
+  for (size_t i = 0; i < transcendental_result.size(); ++i) {
+    const float transcendental_expected = std::sin(x[i] + y[i]);
+    require(std::isfinite(transcendental_result[i]) &&
+                std::abs(transcendental_result[i] - transcendental_expected) <
+                    1e-5f,
+            "transcendental value mismatch at element " + std::to_string(i) +
+                ": expected " + std::to_string(transcendental_expected) +
+                ", got " + std::to_string(transcendental_result[i]));
+  }
+}
+
+int main(int argc, char **argv) {
+  std::cout << std::unitbuf;
+  if ((argc != 3 && argc != 4) ||
+      (std::string(argv[2]) != "cpu" && std::string(argv[2]) != "cuda") ||
+      (argc == 4 && std::string(argv[3]) != "--wrong-expected")) {
+    std::cerr
+        << "Usage: pjrt-execute PLUGIN.so {cpu|cuda} [--wrong-expected]\n";
+    return 2;
+  }
+  try {
+    run(argv[1], argv[2], argc == 4);
+    require(!cleanup_failed, "resource destruction failed");
+    std::cout << "PASS: " << argv[2] << " StableHLO compile/execute/readback\n";
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << "FAIL: " << error.what() << '\n';
+    return 1;
+  }
+}

--- a/pkgs/by-name/xl/xla/tests/smoke.hlo
+++ b/pkgs/by-name/xl/xla/tests/smoke.hlo
@@ -1,0 +1,6 @@
+HloModule smoke
+ENTRY main {
+  a = f32[2] constant({1, 2})
+  b = f32[2] constant({3, 4})
+  ROOT add = f32[2] add(a, b)
+}


### PR DESCRIPTION
## Why

Remove XLA's dependency on nixpkgs `llvmPackages_18` in preparation for its retirement, as raised in https://github.com/NixOS/nixpkgs/issues/558504. Following the alternative discussed there after newer-Clang builds failed, use XLA's pinned hermetic Clang 18.1.8 while keeping the existing XLA source revision. This PR also adds opt-in CUDA support and PJRT regression tests; the default remains CPU-only. CUDA is opt-in (`xla.override { cudaSupport = true; }`, or the usual `config.cudaSupport`); the default remains CPU-only and free of CUDA runtime dependencies. Both variants keep the existing XLA source revision/version.

## Approach

- Replace the `llvmPackages_18` dependency with XLA's pinned hermetic Clang 18.1.8.
- Preserve `configure.py`, make downloaded hermetic tools executable on Nix, normalize fixed-output Bazel repositories for offline builds, and propagate CUDA settings into Bazel exec configurations. Keep dependency preparation focused on actual repairs instead of duplicating downstream build failures with generic tool and shebang diagnostics.
- Derive ordered SASS/PTX targets from the selected `cudaPackages.flags` and `config.cudaCapabilities` / `config.cudaForwardCompat`, rather than hardcoding architectures.
- Build standard `symlinkJoin` local layouts, with ordinary join-order semantics, from explicitly selected nixpkgs CUDA, cuDNN, and NCCL outputs. Retain the narrow guard against the four packaged CCCL header trees, then regenerate Bazel's local repositories offline through `LOCAL_CUDA_PATH`, `LOCAL_CUDNN_PATH`, and `LOCAL_NCCL_PATH`. Exclude those generated repositories from the fixed-output dependency archive; keep only the path-independent `local_config_nccl` scaffolding required by Bazel 7 while routing selected NCCL bindings through `cuda_nccl`.
- Separate the build-time driver from the host-provided NVIDIA runtime driver. Retain XLA's pinned CCCL 3.2.0 and NVSHMEM 3.2.5 as compatibility exceptions while using the selected nixpkgs CUDA, cuDNN, and NCCL packages directly.
- Compile the full selected `cudaPackages.cuda_nvcc` output into XLA's default CUDA data directory so standalone PJRT clients can find `ptxas`, `nvlink`, and libdevice without toolkit discovery variables. Retaining nvcc and its normal transitive host GCC is an intentional simplicity tradeoff; explicit data-directory flags still override the default.
- Keep the flattened installation, but order copies deterministically and remove stale runfiles manifests. Keep reader-facing explanations outside generated Starlark and shell strings; the final cleanup changes only comments and one blank line in evaluated scripts.
- Add reusable selected-package `passthru.tests` and matching `passthru.testers`: installed-header compilation, actual PJRT compilation/execution/readback and numerical negatives, HLO Host/Interpreter comparison, one-rank NCCL all-reduce, ELF/closure/install assertions, licensing, and GPU scheduling. Retain the targeted selected-package reconstruction because `finalAttrs.finalPackage` keeps downstream `overrideAttrs` linkage but does not expose the outer callPackage `.override`. The package-local README documents durable commands and the coverage matrix.
- Add configure-only checks sharing the cached dependency archive and an inexpensive literal-fixture checker regression suite. Match upstream insertion-ordered deduplication after original-last PTX selection, without incorrectly deduplicating repeated emitted SASS.

## Important limitations

- **Packaged CUDA stack with retained compatibility exceptions:** Bazel now consumes explicitly selected nixpkgs CUDA, cuDNN, and NCCL package outputs through standard `symlinkJoin` layouts with a narrow four-path packaged-CCCL guard. XLA still retains its pinned CCCL 3.2.0 and NVSHMEM 3.2.5, and a real driver remains a controlled build-only input while the host supplies the runtime NVIDIA driver. Alternate selected packages and dependency hashes have evaluation/configuration and override-propagation coverage, not full-build or GPU-runtime validation.
- **Standalone installed-plugin compiler discovery is fixed for the tested CUDA configuration.** The rebuilt package directly retains the full selected nvcc output and its normal transitive host GCC as intentional runtime dependencies. PJRT passed with toolkit `PATH`, `XLA_FLAGS`, `CUDA_HOME`, and `CUDA_PATH` absent. The validation exercised compilation plus a libdevice-intended sine operation, but did not prove an actual `nvlink` invocation.
- **NVSHMEM IBRC bare-soname/RDMA discovery is an uncovered potential gap.** CLI rdma-core RUNPATH and ELF linkage checks do not prove transport loading or communication.
- The pre-cleanup full-nvcc package and checks passed on an RTX 3060 with toolkit discovery variables cleared: PJRT arithmetic and `stablehlo.sine` readback, the deliberate numerical negative, Host-versus-Interpreter HLO, and one-rank NCCL all passed. The final comment/whitespace cleanup changed the CPU and CUDA package derivation identities without changing evaluated executable scripts beyond comment-only lines and one blank line; the new derivations were not rebuilt. The validation container denied mount namespaces, so those remote commands used `sandbox=false`. **NixOS sandbox GPU mount-hook integration is unverified**; portable checks still require the `cuda` system feature and contain no sandbox escape or successful skip. The GPU run remains pre-cleanup evidence and is not evidence for the new derivation identities.
- The CUDA-built HLO check compares CPU Host with Interpreter; only its loader dependency requires a GPU host. Actual CUDA computation coverage is PJRT nonconstant arithmetic and `stablehlo.sine`, not the HLO fixture.
- No broad matmul, cuDNN convolution, multi-rank collectives, RDMA, multi-GPU, other GPU models, GPU HLO execution, upstream XLA suite, identical-derivation reproducibility, or execution of every installed binary is claimed.

## Validation

<details>
<summary>Validation details</summary>

The four complexity reductions were validated as a frozen five-file delta:
- Pre-cleanup CPU package: `/nix/store/rvn3r76c3akn2d9cmjz7fpr38w0v1izb-xla-0-unstable-2026-02-21.drv` → `/nix/store/0ham1cynq1gn604a6b8fj5ka0avc0dzv-xla-0-unstable-2026-02-21`; build https://nixbuild.net/builds/11928229 passed. The final cleanup evaluates to `/nix/store/7ryzq2v3x6if8flxn7cwr0xjzpwbdg9f-xla-0-unstable-2026-02-21.drv` → `/nix/store/6zlaqdwngwljh4igr5m0gq366bm8nlcd-xla-0-unstable-2026-02-21`, which was not built.
- Pre-cleanup CUDA package: `/nix/store/n8rj1wwg8cwx7xxmb5bljcd0p9hxn9pf-xla-0-unstable-2026-02-21.drv` → `/nix/store/jzns1mlhhwjwqjv1jniwx5vymll62r00-xla-0-unstable-2026-02-21`; build https://nixbuild.net/builds/11928323 passed. The final cleanup evaluates to `/nix/store/zam3vr1gxpx0s575j3y7r6r1lbzqsrac-xla-0-unstable-2026-02-21.drv` → `/nix/store/38z5m71nh0mgsmwd1zi1n5dgv9naqv1h-xla-0-unstable-2026-02-21`, which was not built.
- Both pre-cleanup package variants rebuilt successfully. Their fixed-output dependency archives were reused at the expected output identities and passed content verification. The final cleanup changed those fixed-output derivation identities because builder comments moved, while their fixed outputs remained unchanged; the new fixed-output derivations were not built.
- Pre-cleanup physical-GPU checks used PJRT `/nix/store/ysqy90zncmq04wvhc6dgr7qlcbh0ixq1-xla-pjrt-cuda.drv`, HLO `/nix/store/rdsws6i74imnwg9x30g6yrj763cwg9mk-xla-hlo-cuda.drv`, and NCCL `/nix/store/j206r6xncab3021ak7n1d8jjckknvspn-xla-nccl-cuda.drv`.
- Before the cleanup, hardware-free checks passed for both standalone and CUDA-package CPU PJRT semantics, HLO Host/Interpreter, install/ELF/closure boundaries, metadata, default/custom/override configuration, selected full-nvcc propagation, and local prerequisite/tester builds.
- Fresh RTX 3060 execution of the pre-cleanup checks passed nonconstant PJRT CUDA arithmetic and `stablehlo.sine` readback plus its intended numerical negative, Host-versus-Interpreter HLO (`0/1 runs failed`), and NCCL 23102 one-rank all-reduce (`7`). HLO is not a GPU computation, and NCCL coverage is one rank on one GPU, not multi-GPU or RDMA.
- Applicable scoped checks on the final cleanup passed: strict XLA evaluation, Nix parsing, nixfmt, CI-pinned scoped treefmt, `git diff --check`, and six evaluated CPU/CUDA script comparisons. Each script equals its pre-cleanup form after removing comment-only lines and the one requested blank line. The pre-cleanup head had also passed `nixpkgs-vet` and checker fixtures.

GitHub CI for the final amended head https://github.com/samuela/nixpkgs/commit/4f535dcf4c48aafd82e77b1e82e23b8ca290e106 had not yet been observed; no additional snapshot, wait, or polling was performed. The successful workflow https://github.com/NixOS/nixpkgs/actions/runs/34697414381 validated the previous source head https://github.com/samuela/nixpkgs/commit/d00e2f3ebf4c386e59721e2cef0981a0ffabd6ef only, not the final amended head. These CI jobs do not establish an XLA build or runtime test on Darwin or aarch64. The earlier runs https://github.com/NixOS/nixpkgs/actions/runs/34672471430 and https://github.com/NixOS/nixpkgs/actions/runs/34544382461 validated still earlier heads only and are historical.

The following builds have different derivation identities from the current combined implementation. They tested earlier implementations and are historical context, not current evidence:
- CPU build before the complexity reductions: https://nixbuild.net/builds/11814008
- CUDA `symlinkJoin` build before the complexity reductions: https://nixbuild.net/builds/11917754
- CUDA full-nvcc build before the `symlinkJoin` simplification: https://nixbuild.net/builds/11862233
- CUDA minimal runtime-tools build: https://nixbuild.net/builds/11864590
- CUDA packaged-dependency build: https://nixbuild.net/builds/11847375
- CUDA, with the selected manifest-fed cuDNN: https://nixbuild.net/builds/11828582
- Correct-hash shared Bazel dependency archive: https://nixbuild.net/builds/11826043
- Updated installed-output checks, including https://nixbuild.net/builds/11832839

The following commands passed against the earlier implementation. Their package and test outputs are not reused as evidence for the current implementation:

```sh
nix-instantiate --eval --strict --json pkgs/by-name/xl/xla/tests/eval.nix --arg nixpkgs ./.

nix-build --builders '' --no-out-link --expr '
  let p = import ./. {}; x = p.xla.override { cudaSupport = false; };
  in [ x.tests.cpu x.tests.hlo x.tests.install x.tests.metadata ]
'
nix-build --builders '' --no-out-link --expr '
  let p = import ./. { config.allowUnfree = true; };
      x = p.xla.override { cudaSupport = true; };
  in [ x.tests.cpu x.tests.cuda.install x.tests.cuda.metadata ]
'
```

In that earlier implementation, both CPU-plugin variants compiled/executed/read back `(x+y)*x`, verified `f32[2,3]` values `3 -6 6 1 4 48`, and rejected the intended numerical and wrong-platform negatives. Its install checks audited 1644/1854 dynamic ELFs respectively, with zero missing CPU libraries and only four permitted host `libcuda.so.1` misses for CUDA. These test and install results are historical, not evidence for the current derivations.

The earlier implementation's configure-only derivations passed for default capabilities (SASS 75,80,86,89,90,100,103,120,121; PTX 121), custom `[8.0,8.9]` without PTX, and duplicate `[8.0,8.0]` without PTX (SASS 80 once): https://nixbuild.net/builds/11833651, https://nixbuild.net/builds/11833652, https://nixbuild.net/builds/11833654. No XLA/NCCL/dependency archive rebuild was needed for those checks. `tests.cuda.configureChecker` also passed six test methods / 14 independent literal fixtures covering duplicate ordering, both forwarding policies, original-last PTX selection, repeated SASS, and stale/incorrect PTX rejection. These results describe the earlier implementation rather than the current derivations.

GPU checks can normally be scheduled with:

```sh
nix-build --no-out-link --expr '
  let x = (import ./. { config.allowUnfree = true; }).xla.override { cudaSupport = true; };
  in [ x.tests.cuda.pjrt x.tests.cuda.hlo x.tests.cuda.nccl ]
'
```

The pre-cleanup full-nvcc GPU checks were executed from these derivations:

```sh
NIX_REMOTE=local nix-store -r \
  /nix/store/ysqy90zncmq04wvhc6dgr7qlcbh0ixq1-xla-pjrt-cuda.drv \
  /nix/store/rdsws6i74imnwg9x30g6yrj763cwg9mk-xla-hlo-cuda.drv \
  /nix/store/j206r6xncab3021ak7n1d8jjckknvspn-xla-nccl-cuda.drv \
  --option sandbox false --option system-features cuda
```

CUDA PJRT compiled and executed nonconstant arithmetic and `stablehlo.sine` with toolkit discovery variables cleared, read both results back, and rejected the intended post-readback numerical negative with exit 1. The arithmetic result was `f32[2,3] 3 -6 6 1 4 48`; the sine result was `f32[2,3] 0.14112 0.14112 0.909297 0.909297 -0.841471 -0.279415`. HLO reported `0/1 runs failed` for Host/Interpreter, not CUDA HLO. NCCL's selected header/runtime agreement and one-rank all-reduce passed with version 23102 and result `7`. The unsigned remote result outputs were intentionally not imported into the local Nix store; their exported archive and hashes were integrity-checked without bypassing trust.

Earlier CI-related checks also passed treefmt, `nixpkgs-vet`, Nix/Lix parsing and restricted evaluation, Ruff/Python checks, `git diff --check`, clang-format, and shellcheck. The corresponding current local checks are summarized above.

Whole-repository/multi-platform evaluation, shell/manual/tarball/lib builds, CI-infrastructure tests, and GitHub-only automation were not reproduced locally: their sources are unchanged and this validation is scoped to XLA. `nixpkgs-review` was not run. The branch retains its tested base to avoid gratuitous XLA rebuilds. GitHub successfully evaluated the previous source head's test merge; CI for the final amended head had not yet been observed without waiting.

</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy] (draft exemption; disclosure above): gpt-6-astra

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test




