### PR TITLE
avd-fw: init at 0.1

### DIFF
--- a/pkgs/by-name/av/avd-fw/package.nix
+++ b/pkgs/by-name/av/avd-fw/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  pkgsCross,
+  meson,
+  ninja,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "avd-fw";
+  version = "0.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "AsahiLinux";
+    repo = "avd-fw";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cq/gOgmbCg5IX0GSiS7Z5lBhpursB1Num8LSANw5fpI=";
+  };
+
+  nativeBuildInputs = [
+    pkgsCross.arm-embedded.stdenv.cc
+    ninja
+    meson
+  ];
+
+  mesonFlags = [
+    "--cross-file=arm-none-eabi-gcc.ini"
+    "--buildtype"
+    "release"
+  ];
+
+  meta = {
+    description = "Firmware for the Apple Video Decoder, found on M-Series Apple Silicon Devices";
+    homepage = "https://github.com/AsahiLinux/avd-fw";
+    license = lib.licenses.mit;
+    platforms = [ "aarch64-linux" ];
+    maintainers = with lib.maintainers; [
+      sempiternal-aurora
+      yuka
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the firmware required for the Apple Video Decoder on Asahi Linux. Thanks to @yuyuyureka for the original implementation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
