### PR TITLE
rustfetch: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/by-name/ru/rustfetch/package.nix
+++ b/pkgs/by-name/ru/rustfetch/package.nix
@@ -2,18 +2,31 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  libxcb,
+  stdenv,
+  versionCheckHook,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustfetch";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "lemuray";
     repo = "rustfetch";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-iGcxDKl36kbEi+OiH4gB2+HxP37bpqAMZguIXDzq3Jw=";
+    hash = "sha256-7+25SYYpOwbJM3UofTjk8hAuDVQ33tUge+2k1oSRvvY=";
   };
-  cargoHash = "sha256-87wfFczmgCft4ke/RQKi54wvqFKGRJMtqhkwQgDCedg=";
+  cargoHash = "sha256-/D6y6h86V7qUfJqXW6XXTHAyiqwNJAfSQOLHxNfajv8=";
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libxcb ];
+
+  checkFlags = [
+    # requires os calls which will error out to "Permission denied" in the sandbox
+    "--skip=test_no_pretty_name"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "CLI tool designed to fetch system information in the fastest and safest way possible";


### PR DESCRIPTION
Bump `rustfetch` from 0.2.0 to 0.3.0

Added `buildInputs` to add needed package `libxcb` for linux platforms 
Added `checkFlags` to skip test that requires os calls 
Added `versionCheckHook`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
