### PR TITLE
sub-batch: 1.0.1 -> 2.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14658,6 +14658,12 @@
     githubId = 56224949;
     name = "Mia Kanashi";
   };
+  kangazero = {
+    name = "Samuel Wai Weng Yong";
+    email = "samuelyongw@gmail.com";
+    github = "KangaZero";
+    githubId = 107836643;
+  };
   kaptcha0 = {
     name = "J'C Kabunga";
     github = "kaptcha0";

--- a/pkgs/by-name/su/sub-batch/package.nix
+++ b/pkgs/by-name/su/sub-batch/package.nix
@@ -3,26 +3,40 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sub-batch";
-  version = "1.0.1";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "kl";
     repo = "sub-batch";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-TOcK+l65iKON1kgBE4DYV/BXACnvqPCshavnVdpnGH4=";
+    sha256 = "sha256-L8Nw2HavLxwbJZ8WzrtJKZxfP77HCsVef9WrdhbdpqQ=";
   };
 
-  cargoHash = "sha256-eT4u/IHj+yqeLQZ7E4cWAJFMT503zHq7HYyIhsoaj6s=";
+  cargoHash = "sha256-sqXVlihZWEIP/Ea0kEtoyaLct9v0pWRq0imf+6cH8TM=";
+
+  checkFlags = [
+    # requires alass-cli / alass which is not packaged in nixpkgs
+    "--skip=can_run_alass_on_sub_file"
+    "--skip=can_show_confirm_without_panicking"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Match and rename subtitle files to video files and perform other batch operations on subtitle files";
+    changelog = "https://github.com/kl/sub-batch/blob/v${finalAttrs.version}/CHANGELOG";
     homepage = "https://github.com/kl/sub-batch";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ erictapen ];
+    maintainers = with lib.maintainers; [
+      erictapen
+      kangazero
+    ];
     broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "sub-batch";
   };


### PR DESCRIPTION
Bump `sub-batch` from 1.0.1 to 2.0.2

Added `checkFlags` to skip tests that require `alass` & `alass-cli` in PATH which is not currently in nixpkgs
Added `versionCheckHook`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
