### PR TITLE
octl: init at 0.0.31

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13584,6 +13584,13 @@
     githubId = 60272884;
     name = "Jonathan Jeppener-Haltenhoff";
   };
+  jobs62 = {
+    email = "charles-david.blot@outscale.com";
+    github = "jobs62";
+    githubId = 77263497;
+    name = "Ch.-David Blot";
+    keys = [ { fingerprint = "2734 2E8E E152 E071 F2A6  D894 0E69 3458 AFA2 6E99"; } ];
+  };
   jocelynthode = {
     email = "jocelyn.thode@gmail.com";
     github = "jocelynthode";

--- a/pkgs/by-name/oc/octl/package.nix
+++ b/pkgs/by-name/oc/octl/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  buildGo126Module,
+  fetchFromGitHub,
+  installShellFiles,
+  makeWrapper,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGo126Module (finalAttrs: {
+  pname = "octl";
+  version = "0.0.31";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "outscale";
+    repo = "octl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZXsQkbaKm2YQwDj3AeAez2UjwrlNSJoudBeSftI0maE=";
+  };
+
+  vendorHash = "sha256-Drmdk3s41UXd09s7EQr+5L1mZwwzhbPwBaGcNsqMDFI=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/outscale/octl/pkg/version.Version=v${finalAttrs.version}"
+    "-X=k8s.io/component-base/version.gitVersion=v1.36.2+octl"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  # Tests requires either network connection, OUTSCALE credentials, or writable home directory.
+  doCheck = false;
+
+  postInstall = ''
+    wrapProgram $out/bin/octl \
+      --add-flags "--no-upgrade"
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd octl \
+      --bash <($out/bin/octl completion bash) \
+      --fish <($out/bin/octl completion fish) \
+      --zsh <($out/bin/octl completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern CLI for Outscale";
+    homepage = "https://github.com/outscale/octl";
+    changelog = "https://github.com/outscale/octl/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jobs62 ];
+    mainProgram = "octl";
+  };
+})


### PR DESCRIPTION
octl is Outscale’s modern CLI for their cloud APIs. One binary covers most services (Iaas, Object storage and managed Kubernetes clusters)

This CLI is set to replace the old `osc-cli`. It still have rough edges around upgrade mechanism is managed environment.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
