### PR TITLE
yaziPlugins: detect updates by directory; update

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/chmod/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/chmod/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "chmod.yazi";
-  version = "0-unstable-2026-08-19";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "213f300c234499e580b139e18321f7ce989d0bae";
-    hash = "sha256-tpIaEus7E9ELs+GBNBEklzADtjaPETuxYtzZqQhwMCI=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/diff/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/diff/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "diff.yazi";
-  version = "0-unstable-2026-08-18";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "6af9bf23be808db4a86e89d2fc32d488dcafdd34";
-    hash = "sha256-LzIM/X2+/KLo/TO7XhFEBtgkzP7g5O98haOUb1wUCdU=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/full-border/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/full-border/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "full-border.yazi";
-  version = "0-unstable-2026-08-18";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "e1031c618c6b8333df9b50dbfff515c483920d25";
-    hash = "sha256-Uk4KhZdQFOwuOsjH7Z81POBfkvgkYoYx2F8HcXe3l7I=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/git/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/git/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "git.yazi";
-  version = "0-unstable-2026-08-19";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "efa4d79da8ada35380ede5788d3f3b0ee9f70306";
-    hash = "sha256-uRjuzA58DtxKW8kpTpe0pM54cAnyu5zQoPxJUeiSKL0=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/jump-to-char/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/jump-to-char/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "jump-to-char.yazi";
-  version = "0-unstable-2025-06-18";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
-    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/lsar/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/lsar/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "lsar.yazi";
-  version = "0-unstable-2026-01-24";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "6c71385af67c71cb3d62359e94077f2e940b15df";
-    hash = "sha256-+akz8E6Fmk6KwmeZOePEm/KqfbDaKeL4wiUgtm12SAE=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mactag.yazi";
-  version = "0-unstable-2026-08-18";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "6f26ae04ba2e4763faada6a7997ae8b57c158cdb";
-    hash = "sha256-pySI+LxiGmGEp/cvVXtuOuNzvy3c2QC6zuoTjActPbw=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mime-ext.yazi";
-  version = "0-unstable-2026-08-07";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "0be29a913ad61c6d119abfaaf253e96e6af5db67";
-    hash = "sha256-IDmmXzQKFx3QZ9u5lMwcTOeWeMPWzIBeKBXkGAgJMaI=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mount/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mount/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mount.yazi";
-  version = "0-unstable-2026-05-09";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "16e8ed382db5fc5ea9d179a2803d86859803fae0";
-    hash = "sha256-ALSuXdAGGcscQmGL2d6cDv6MzNiuzl52f9i1b3t+b1I=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/no-status/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/no-status/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "no-status.yazi";
-  version = "25.2.7-unstable-2025-03-02";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "b44c245500b34e713732a9130bf436b13b4777e9";
-    hash = "sha256-nZ8yfnKvNLM5aA+mmQ3PkfM5lwSKwWnkQewcg9GwseI=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/piper/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/piper/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "piper.yazi";
-  version = "0-unstable-2026-08-18";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "6af9bf23be808db4a86e89d2fc32d488dcafdd34";
-    hash = "sha256-LzIM/X2+/KLo/TO7XhFEBtgkzP7g5O98haOUb1wUCdU=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/smart-enter/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/smart-enter/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "smart-enter.yazi";
-  version = "0-unstable-2025-06-18";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
-    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/smart-filter/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/smart-filter/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "smart-filter.yazi";
-  version = "0-unstable-2026-07-04";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "5d461d85908338371b9433ab6c29707bee3a813b";
-    hash = "sha256-vRElXxEe2Am7p6SoxJ7g8GSaka7/4/yZ2zfiOOqUR2I=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/smart-paste/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/smart-paste/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "smart-paste.yazi";
-  version = "0-unstable-2025-06-18";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
-    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/toggle-pane/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/toggle-pane/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "toggle-pane.yazi";
-  version = "0-unstable-2026-08-18";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "6af9bf23be808db4a86e89d2fc32d488dcafdd34";
-    hash = "sha256-LzIM/X2+/KLo/TO7XhFEBtgkzP7g5O98haOUb1wUCdU=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/update.py
+++ b/pkgs/by-name/ya/yazi/plugins/update.py
@@ -103,31 +103,93 @@ def github_get(
         raise RuntimeError(f"Error fetching {api_url}: {e}")
 
 
-def fetch_plugin_content(
+def plugin_source_dirs(owner: str, plugin_pname: str) -> list[str]:
+    """Directories that may contain a plugin's source files."""
+    if owner == "yazi-rs":
+        return [plugin_pname, "."]
+    return [".", plugin_pname]
+
+
+def contents_api_path(dir_path: str) -> str:
+    """Map a repository directory to a GitHub contents API path."""
+    if dir_path in ("", "."):
+        return "contents"
+    return f"contents/{dir_path}"
+
+
+def decode_github_file(content_data: dict) -> str | None:
+    """Decode a GitHub contents API file payload."""
+    if "content" not in content_data:
+        return None
+    return base64.b64decode(content_data["content"]).decode("utf-8")
+
+
+def list_plugin_lua_paths(
     owner: str,
     repo: str,
     plugin_pname: str,
     ref: str,
     headers: dict[str, str],
-) -> str:
-    """Fetch the plugin's main.lua content from GitHub"""
-    paths = [f"{plugin_pname}/main.lua", "main.lua"] if owner == "yazi-rs" else [
-        "main.lua",
-        f"{plugin_pname}/main.lua",
-    ]
+) -> list[str]:
+    """List top-level *.lua files for a plugin at a given ref."""
+    for dir_path in plugin_source_dirs(owner, plugin_pname):
+        listing = github_get(owner, repo, contents_api_path(dir_path), headers, {"ref": ref}, allow_404=True)
+        if not isinstance(listing, list):
+            continue
 
-    for path in paths:
+        lua_paths = [
+            item["path"]
+            for item in listing
+            if item.get("type") == "file" and str(item.get("name", "")).endswith(".lua")
+        ]
+        if lua_paths:
+            return sorted(lua_paths)
+
+    return []
+
+
+def fetch_plugin_lua_contents(
+    owner: str,
+    repo: str,
+    plugin_pname: str,
+    ref: str,
+    headers: dict[str, str],
+) -> list[str]:
+    """Fetch a plugin's *.lua files from GitHub."""
+    lua_paths = list_plugin_lua_paths(owner, repo, plugin_pname, ref, headers)
+    if not lua_paths:
+        raise RuntimeError(f"Could not find *.lua at {ref}")
+
+    contents = []
+    for path in lua_paths:
         content_data = github_get(owner, repo, f"contents/{path}", headers, {"ref": ref}, allow_404=True)
-        if isinstance(content_data, dict) and "content" in content_data:
-            return base64.b64decode(content_data["content"]).decode("utf-8")
+        if isinstance(content_data, dict):
+            decoded = decode_github_file(content_data)
+            if decoded is not None:
+                contents.append(decoded)
 
-    raise RuntimeError(f"Could not fetch main.lua at {ref}")
+    if not contents:
+        raise RuntimeError(f"Could not fetch *.lua at {ref}")
+
+    return contents
 
 
-def check_version_compatibility(plugin_content: str, plugin_name: str, yazi_version: str) -> str:
+def required_version_from_lua(plugin_content: str) -> str | None:
+    """Read a Yazi @since requirement from the first line of a Lua file."""
+    first_line = plugin_content.split("\n", 1)[0]
+    required_version_match = re.search(r"since ([0-9.]+)", first_line)
+    return required_version_match.group(1) if required_version_match else None
+
+
+def check_version_compatibility(plugin_contents: list[str], plugin_name: str, yazi_version: str) -> str:
     """Check if the plugin is compatible with the current Yazi version"""
-    required_version_match = re.search(r"since ([0-9.]+)", plugin_content.split("\n")[0])
-    required_version = required_version_match.group(1) if required_version_match else "0"
+    required_version = "0"
+    for plugin_content in plugin_contents:
+        file_required_version = required_version_from_lua(plugin_content)
+        if file_required_version is None:
+            continue
+        if required_version == "0" or version.parse(file_required_version) > version.parse(required_version):
+            required_version = file_required_version
 
     if required_version == "0":
         print(f"No version requirement found for {plugin_name}, assuming compatible with any Yazi version")
@@ -191,7 +253,7 @@ def get_commit_candidates(owner: str, repo: str, plugin_pname: str, headers: dic
             repo,
             "commits",
             headers,
-            {"path": f"{plugin_pname}/main.lua", "per_page": 100},
+            {"path": plugin_pname, "per_page": 100},
         )
         if not isinstance(commits_data, list) or not commits_data:
             raise RuntimeError(f"Could not get recent commits for {plugin_pname}")
@@ -310,8 +372,8 @@ def is_yazi_compatible(
 ) -> bool:
     """Check if a candidate supports nixpkgs' Yazi version."""
     try:
-        plugin_content = fetch_plugin_content(owner, repo, plugin_pname, candidate.rev, headers)
-        check_version_compatibility(plugin_content, plugin_name, yazi_version)
+        plugin_contents = fetch_plugin_lua_contents(owner, repo, plugin_pname, candidate.rev, headers)
+        check_version_compatibility(plugin_contents, plugin_name, yazi_version)
         return True
     except RuntimeError as e:
         print(f"Skipping {candidate.rev}: {e}")

--- a/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "vcs-files.yazi";
-  version = "0-unstable-2026-08-18";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "6af9bf23be808db4a86e89d2fc32d488dcafdd34";
-    hash = "sha256-LzIM/X2+/KLo/TO7XhFEBtgkzP7g5O98haOUb1wUCdU=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/zoom/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/zoom/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "zoom.yazi";
-  version = "0-unstable-2026-06-20";
+  version = "0-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "38efe09c270162f1b0dfb6020e021a5b64bdc735";
-    hash = "sha256-rgelX8Aj6iPYzk3NZN5NLMiJ/dQKJD2BKXsrK6xXdkc=";
+    rev = "4dc7f1b6458c2578f4494f10d468c68c1082214f";
+    hash = "sha256-BSAOkL4H4LVMbTRFv4kzGGRpLgtKkfNTEsDH2EQ219Q=";
   };
 
   meta = {


### PR DESCRIPTION
Since [Yazi v25.12.29](https://github.com/sxyazi/yazi/blob/main/CHANGELOG.md#v251229), the plugin system supports multiple entry points besides `main.lua` (https://github.com/sxyazi/yazi/pull/3154). Official plugins can now ship extra Lua files.

The updater still only watched `{plugin}/main.lua` and read `@since` from that file's first line. That missed `mime-ext.yazi` (https://github.com/yazi-rs/plugins/tree/main/mime-ext.yazi): after the multi-entry split, `main.lua` is just a deprecated wrapper, while the real changes and `@since` live in `local.lua` / `remote.lua`.

This changes official commit detection to the plugin directory, and takes the highest `@since` across top-level `*.lua` files.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
