### PR TITLE
finufft: init at 2.5.1

### DIFF
--- a/pkgs/by-name/fi/finufft/package.nix
+++ b/pkgs/by-name/fi/finufft/package.nix
@@ -1,0 +1,148 @@
+{
+  lib,
+  stdenv,
+  config,
+  fetchFromGitHub,
+  fetchurl,
+  applyPatches,
+
+  # nativeBuildInputs
+  cmake,
+  pkg-config,
+
+  # buildInputs
+  fftw,
+  fftwFloat,
+  llvmPackages,
+  cudaPackages,
+
+  # passthru
+  nix-update-script,
+
+  cudaSupport ? config.cudaSupport,
+}:
+
+let
+  cpmSourceCache = applyPatches (finalAttrs: {
+    name = "cpm-cmake";
+    # grep for CPM_DOWNLOAD_VERSION in CMakeLists.txt
+    version = "0.42.0";
+    src = fetchurl {
+      url = "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${finalAttrs.version}/CPM.cmake";
+      hash = "sha256-ICC0/ELbpEgXmD4GNC5oLs/D0vSEpYHxHMVzH75Nzoo=";
+    };
+    # CPM.cmake is a single file, not an archive, so unpackPhase just copies it.
+    unpackPhase = ''
+      cp $src CPM.cmake
+    '';
+    # Restructure into the layout CPM_SOURCE_CACHE expects:
+    #   <store-path>/cpm/CPM_<version>.cmake
+    postPatch = ''
+      mkdir -p cpm
+      mv CPM.cmake cpm/CPM_${finalAttrs.version}.cmake
+    '';
+  });
+
+  # CPM fetches a cmake find module for FFTW (provides FindFFTW.cmake).
+  # Pinned to the commit that upstream GIT_TAG "master" resolves to.
+  findfftwSrc = fetchFromGitHub {
+    owner = "egpbos";
+    repo = "findFFTW";
+    rev = "d449ea0bcbf94a4a1c3dbb2108aa57609a4967ff";
+    hash = "sha256-JM3DL43b3dlcazEW2bmJUH+XrIDbE54xwD5fRqnntUI=";
+  };
+
+  # grep for XSIMD_VERSION in CMakeLists.txt
+  xsimdSrc = fetchFromGitHub {
+    owner = "xtensor-stack";
+    repo = "xsimd";
+    rev = "6842624fc8adafd7168a999e7150b384411da448";
+    hash = "sha256-M6b2RDptZW5JwlVYNI4GEL6UI2Q+4sdhYBF/wP5wxeQ=";
+  };
+
+  # CCCL version pinned by finufft
+  ccclSrc = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "cccl";
+    tag = "v3.0.2";
+    hash = "sha256-sC9TpvhhFJRmZv25/l5L8jKq/wlAKLxf4C6O/a1xw/M=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "finufft";
+  version = "2.5.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "flatironinstitute";
+    repo = "finufft";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sOApnIqxgdbBqQ6SZQk8afTvgq3/XHG/EK5WHYkwd9U=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs = [
+    fftw
+    fftwFloat
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart # cuda_runtime.h, libcuda stub
+    cudaPackages.libcufft # cufft.h
+    cudaPackages.cccl # cufft.h
+  ];
+
+  env = lib.optionalAttrs cudaSupport {
+    NVCC_THREADS = 2;
+  };
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CPM_SOURCE_CACHE" cpmSourceCache.outPath)
+    (lib.cmakeFeature "CPM_findfftw_SOURCE" findfftwSrc.outPath)
+    (lib.cmakeFeature "CPM_xsimd_SOURCE" xsimdSrc.outPath)
+
+    # Build a shared library instead of the default static
+    (lib.cmakeBool "FINUFFT_STATIC_LINKING" false)
+
+    # Avoid -march=native for reproducibility
+    (lib.cmakeFeature "FINUFFT_ARCH_FLAGS" "")
+
+    (lib.cmakeBool "FINUFFT_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+  ]
+  ++ lib.optionals cudaSupport [
+    (lib.cmakeBool "FINUFFT_USE_CUDA" true)
+    (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
+    (lib.cmakeFeature "CPM_CCCL_SOURCE" ccclSrc.outPath)
+  ];
+
+  # GPU tests require a physical GPU, which is not available in the sandbox.
+  doCheck = !cudaSupport;
+
+  passthru = {
+    gpuCheck = finalAttrs.finalPackage.overrideAttrs {
+      requiredSystemFeatures = [ "cuda" ];
+      doCheck = true;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Non-uniform fast Fourier transform library of types 1, 2, 3 in dimensions 1, 2, 3 on the CPU or GPU";
+    homepage = "https://finufft.readthedocs.io/en/latest/index.html";
+    downloadPage = "https://github.com/flatironinstitute/finufft";
+    changelog = "https://github.com/flatironinstitute/finufft/blob/${finalAttrs.src.rev}/CHANGELOG";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/finufft/default.nix
+++ b/pkgs/development/python-modules/finufft/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  finufft,
+  python,
+
+  # dependencies
+  numpy,
+  packaging,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "finufft";
+  inherit (finufft) version src;
+  format = "other";
+  dontBuild = true;
+  __structuredAttrs = true;
+
+  dependencies = [
+    numpy
+    packaging
+  ];
+
+  # The Python bindings are pure Python + ctypes, no build system.
+  # Install the package files and symlink libfinufft into the package directory so
+  # np.ctypeslib.load_library finds it at runtime.
+  installPhase =
+    let
+      libFilename = "libfinufft${stdenv.hostPlatform.extensions.sharedLibrary}";
+    in
+    ''
+      runHook preInstall
+
+      libdir=$out/${python.sitePackages}/finufft
+      mkdir -p "$libdir"
+      cp python/finufft/finufft/*.py "$libdir"/
+      ln -s ${lib.getLib finufft}/lib/${libFilename} "$libdir"/${libFilename}
+
+      runHook postInstall
+    '';
+
+  pythonImportsCheck = [ "finufft" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    cd python/finufft/test
+  '';
+
+  meta = finufft.meta // {
+    description = "Python interface to FINUFFT";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6077,6 +6077,10 @@ self: super: with self; {
 
   fints = callPackage ../development/python-modules/fints { };
 
+  finufft = callPackage ../development/python-modules/finufft {
+    inherit (pkgs) finufft;
+  };
+
   finvizfinance = callPackage ../development/python-modules/finvizfinance { };
 
   fiona = callPackage ../development/python-modules/fiona { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [finufft](https://github.com/flatironinstitute/finufft), a library to compute efficiently the three most common types of nonuniform fast Fourier transform (NUFFT) to a specified precision, in one, two, or three dimensions, either on a multi-core shared-memory machine, or on a GPU.

cc @RaulPPelaez

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
