### PR TITLE
openvpn3: use finalAttrs

### DIFF
--- a/pkgs/by-name/op/openvpn3/package.nix
+++ b/pkgs/by-name/op/openvpn3/package.nix
@@ -35,14 +35,14 @@ let
     hash = "sha256-ZFvxwzWiRgi0s08W7RC5I3u7ATFIhmj7hkVCAiOeCGw=";
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openvpn3";
   version = "27.1";
 
   src = fetchFromGitHub {
     owner = "OpenVPN";
     repo = "openvpn3-linux";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Egt6lVcvlmxnABw4v0cdROQzVdkA3DgOGGCSgl+QFdM=";
     # `openvpn3-core` is a submodule.
     # TODO: make it into a separate package
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     echo '#define OPENVPN_VERSION "3.git:unknown:unknown"
-    #define PACKAGE_GUIVERSION "v${builtins.replaceStrings [ "_" ] [ ":" ] version}"
+    #define PACKAGE_GUIVERSION "v${builtins.replaceStrings [ "_" ] [ ":" ] finalAttrs.version}"
     #define PACKAGE_NAME "openvpn3-linux"
     ' > ./src/build-version.h
 
@@ -134,7 +134,7 @@ stdenv.mkDerivation rec {
   '';
   postFixup = ''
     wrapPythonPrograms
-    wrapPythonProgramsIn "$out/libexec/openvpn3-linux" "$out ${pythonPath}"
+    wrapPythonProgramsIn "$out/libexec/openvpn3-linux" "$out ${finalAttrs.pythonPath}"
   '';
 
   env.NIX_LDFLAGS = "-lpthread";
@@ -145,10 +145,10 @@ stdenv.mkDerivation rec {
     description = "OpenVPN 3 Linux client";
     license = lib.licenses.agpl3Plus;
     homepage = "https://github.com/OpenVPN/openvpn3-linux/";
-    changelog = "https://github.com/OpenVPN/openvpn3-linux/releases/tag/v${version}";
+    changelog = "https://github.com/OpenVPN/openvpn3-linux/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [
       progrm_jarvis
     ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add finalAttrs to openvpn3, instead of using `rec`
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
