### PR TITLE
yeswiki: 4.4.2 -> 4.6.7

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -29,6 +29,10 @@
 
 - `moon` has been updated to `2.x` and needs manual migration. See the [migration guide](https://moonrepo.dev/docs/migrate/2.0) for instructions.
 
+- `yeswiki` has been updated from 4.4.2 to 4.6.7 and now requires PHP 8.3 or newer.
+  The release also removes legacy JSONP endpoints and changes several security-sensitive operations from GET to POST with CSRF tokens.
+  Review the upstream [4.6.7 release notes](https://github.com/YesWiki/yeswiki/releases/tag/v4.6.7) before upgrading custom themes or integrations.
+
 - `perlPackages.NetOAuth` has been updated from 0.28 to 0.33.
   Callers that verify messages must now set `allowed_signature_methods` per message or configure `@Net::OAuth::ALLOWED_SIGNATURE_METHODS`; `verify` otherwise throws an exception.
   See the [upstream changelog](https://metacpan.org/dist/Net-OAuth/changes) for details.

--- a/pkgs/by-name/ye/yeswiki/package.nix
+++ b/pkgs/by-name/ye/yeswiki/package.nix
@@ -4,15 +4,16 @@
   unzip,
 }:
 let
-  version = "4.4.2";
+  version = "4.6.7";
 in
 stdenv.mkDerivation {
   pname = "yeswiki";
   inherit version;
 
+  # The release archive contains the bundled PHP and JavaScript dependencies.
   src = fetchurl {
-    url = "https://repository.yeswiki.net/doryphore/yeswiki-doryphore-${version}.zip";
-    hash = "sha256-TNiVBragEnLkMTu/Op6sCFsk9wWXUQ2GUPqmWgPV/vk=";
+    url = "https://github.com/YesWiki/yeswiki/releases/download/v${version}/yeswiki-v${version}.zip";
+    hash = "sha256-QgF08amdCh4q3E3/wat4e/KhIWMtBTkFJzT3p5m61FU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates YesWiki to 4.6.7, the current stable release.

Upstream release notes: https://github.com/YesWiki/yeswiki/releases/tag/v4.6.7

Addresses #529816, #552190 and #560162.

This change will need to be backported manually to `release-26.05` after the PR is merged.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test