### PR TITLE
clickhouse-sqlalchemy: init at 0.3.2-unstable-2025-11-24

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -373,6 +373,7 @@ in
     inherit runTest;
     package = pkgs.clickhouse-lts;
   };
+  clickhouse-sqlalchemy = runTest ./clickhouse-sqlalchemy.nix;
   cloud-init = runTest ./cloud-init.nix;
   cloud-init-hostname = runTest ./cloud-init-hostname.nix;
   cloudcompare = import ./cloudcompare.nix { inherit pkgs runTest; };

--- a/nixos/tests/clickhouse-sqlalchemy.nix
+++ b/nixos/tests/clickhouse-sqlalchemy.nix
@@ -1,0 +1,46 @@
+{ lib, pkgs, ... }:
+let
+  pythonEnv = pkgs.python3.withPackages (p: [
+    p.clickhouse-sqlalchemy
+    p.pytest
+    p.pytest-asyncio
+    p.sqlalchemy
+    p.greenlet
+    p.alembic
+    p.requests
+    p.responses
+    p.parameterized
+  ]);
+  testsSrc = pkgs.applyPatches {
+    src = pkgs.python3Packages.clickhouse-sqlalchemy.src;
+    patches = pkgs.python3Packages.clickhouse-sqlalchemy.patches or [ ];
+  };
+in
+{
+  name = "clickhouse-sqlalchemy";
+  meta.maintainers = [ lib.maintainers.joaosreis ];
+
+  nodes.machine =
+    { ... }:
+    {
+      environment.systemPackages = [ pythonEnv ];
+
+      services.clickhouse.enable = true;
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("mkdir -p /build/source")
+
+    machine.succeed("cp ${testsSrc}/setup.cfg /build/source/")
+
+    machine.succeed("cp -r ${testsSrc}/tests /build/source/tests")
+
+    machine.wait_for_unit("clickhouse.service")
+
+    machine.succeed("cd /build/source && systemd-cat -t clickhouse-sqlalchemy-test ${pythonEnv.interpreter} -m pytest");
+  '';
+}

--- a/pkgs/development/python-modules/clickhouse-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/clickhouse-sqlalchemy/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  setuptools,
+  sqlalchemy,
+  requests,
+  asynch,
+  clickhouse-driver,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "clickhouse-sqlalchemy";
+  version = "0.3.2-unstable-2025-11-24";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "xzkostyan";
+    repo = "clickhouse-sqlalchemy";
+    rev = "25721c3cd6e094ae1853327ab1de3a5d7144acbd";
+    hash = "sha256-QCwxPZa3DUFCpZeyrynhd+xuXCyAmtNPRQtJqBbisqg=";
+  };
+
+  patches = [
+    # Support asynch 0.2.x and 0.3.1+
+    (fetchpatch {
+      url = "https://github.com/xzkostyan/clickhouse-sqlalchemy/commit/bd62d6a7ec91b72b78bc1ba8315157d7b989f310.patch";
+      sha256 = "sha256-HsSDM4eRb1/4m6iGslUUjcgAlhBBq6wn652oMFSuIDI=";
+    })
+    # Support alembic 1.18
+    (fetchpatch {
+      url = "https://github.com/xzkostyan/clickhouse-sqlalchemy/commit/1a420b8ded794a81595cf18cb03240b69ef9602d.patch";
+      sha256 = "sha256-UOUcm4Jo0NNrzyKzaIEgsxBZCEbKugW1RKgLuIA46xM=";
+    })
+    # Skip JSON test when driver reports Unknown type JSON
+    (fetchpatch {
+      url = "https://github.com/xzkostyan/clickhouse-sqlalchemy/commit/b3312f29e5dbb6f04600d682bd668bba36a90177.patch";
+      sha256 = "sha256-jpIhdmh67iE5hVuDxg/+9qoGsN8vx24J/hYv41x7zsI=";
+    })
+  ];
+
+  # The asynch driver rewrites `%(name)s` binds into `{name}` only for the
+  # broken brace-style parameter substitution that asynch shipped in exactly
+  # 0.3.1 (asynch#141). asynch#147 restored this change, which
+  # is what 0.4.x uses, so applying the rewrite to >= 0.4.0 is broken.
+  # Restrict the rewrite to 0.3.1.
+  postPatch = ''
+    substituteInPlace clickhouse_sqlalchemy/drivers/asynch/base.py \
+      --replace-fail ") >= (0, 3, 1)" ") == (0, 3, 1)"
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    sqlalchemy
+    requests
+    clickhouse-driver
+    asynch
+  ];
+
+  pythonImportsCheck = [
+    "clickhouse_sqlalchemy"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "ClickHouse dialect for SQLAlchemy";
+    homepage = "https://github.com/xzkostyan/clickhouse-sqlalchemy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      jlesquembre
+      joaosreis
+    ];
+  };
+})

--- a/pkgs/development/python-modules/clickhouse-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/clickhouse-sqlalchemy/default.nix
@@ -9,6 +9,7 @@
   asynch,
   clickhouse-driver,
   nix-update-script,
+  nixosTests,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -67,7 +68,12 @@ buildPythonPackage (finalAttrs: {
     "clickhouse_sqlalchemy"
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = {
+      inherit (nixosTests) clickhouse-sqlalchemy;
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "ClickHouse dialect for SQLAlchemy";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2957,6 +2957,8 @@ self: super: with self; {
 
   clickhouse-driver = callPackage ../development/python-modules/clickhouse-driver { };
 
+  clickhouse-sqlalchemy = callPackage ../development/python-modules/clickhouse-sqlalchemy { };
+
   cliff = callPackage ../development/python-modules/cliff { };
 
   clifford = callPackage ../development/python-modules/clifford { };


### PR DESCRIPTION
Supersedes #542999.
Depends on #558749.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
