### PR TITLE
partclone: 0.3.38 -> 0.3.48

### DIFF
--- a/pkgs/by-name/pa/partclone/package.nix
+++ b/pkgs/by-name/pa/partclone/package.nix
@@ -3,36 +3,62 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  docbook_xml_dtd_45,
+  docbook_xsl,
+  libtool,
+  libxslt,
   pkg-config,
+  liburcu,
   libuuid,
   e2fsprogs,
   nilfs-utils,
   ntfs3g,
   openssl,
+  xxhash,
+  zlib,
+  zstd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "partclone";
-  version = "0.3.38";
+  version = "0.3.48";
 
   src = fetchFromGitHub {
     owner = "Thomas-Tsai";
     repo = "partclone";
     rev = finalAttrs.version;
-    sha256 = "sha256-lWnGi8giz7vzdBnuth55h0VMuNyCQaCclRqPJdm0I14=";
+    hash = "sha256-mN4hIIFBHCawpHq6qGcSmBTsuQk2/gngSgnXMka1HTA=";
   };
 
   nativeBuildInputs = [
     autoreconfHook
+    docbook_xml_dtd_45
+    docbook_xsl
+    libtool
+    libxslt
     pkg-config
   ];
+
+  postPatch = ''
+    substituteInPlace docs/Makefile.am \
+      --replace-fail 'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl' \
+                     '${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl'
+    substituteInPlace docs/*.xml \
+      --replace-fail 'http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd' \
+                     '${docbook_xml_dtd_45}/xml/dtd/docbook/docbookx.dtd'
+  '';
+
   buildInputs = [
     e2fsprogs
+    liburcu
     libuuid
     stdenv.cc.libc
     nilfs-utils
     ntfs3g
     openssl
+    xxhash
+    zlib
+    zstd
     (lib.getOutput "static" stdenv.cc.libc)
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
