### PR TITLE
sculpin4: init at 4.0.0-alpha2

### DIFF
--- a/pkgs/by-name/sc/sculpin4/package.nix
+++ b/pkgs/by-name/sc/sculpin4/package.nix
@@ -1,0 +1,33 @@
+{
+  fetchFromGitHub,
+  lib,
+  php,
+  php85,
+}:
+
+php.buildComposerProject2 rec {
+  __structuredAttrs = true;
+
+  pname = "sculpin4";
+  version = "4.0.0-alpha2";
+
+  src = fetchFromGitHub {
+    owner = "sculpin";
+    repo = "sculpin";
+    tag = version;
+    hash = "sha256-2ZyV889Sk0xrBjjPUtVS06kDSN+AgLz+dqFDKk3hEH0=";
+  };
+
+  php = php85;
+
+  vendorHash = "sha256-WbvXS5ZJg9V0UGglkMiOS5pnztDE3gUxpkflMpSUbi4=";
+
+  meta = {
+    description = "PHP static site generator";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/sculpin/sculpin";
+    maintainers = with lib.maintainers; [ opdavies ];
+    inherit (php.meta) platforms;
+    mainProgram = "sculpin";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Now we have [Sculpin 3 in nixpkgs](https://github.com/NixOS/nixpkgs/pull/476433), I'd also like to add the current alpha version of Sculpin 4 (4.0.0-alpha2).

https://github.com/sculpin/sculpin/commits/4.0.0-alpha2

It's based on the Sculpin 3 package, but specifies PHP 8.5 must be used when building.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
