### PR TITLE
python3Packages.xml2rfc: unmaintain

### DIFF
--- a/pkgs/development/python-modules/xml2rfc/default.nix
+++ b/pkgs/development/python-modules/xml2rfc/default.nix
@@ -88,7 +88,6 @@ buildPythonPackage (finalAttrs: {
     # http://metadata.ftp-master.debian.org/changelogs/non-free/x/xml2rfc/xml2rfc_2.9.6-1_copyright
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      vcunat
       yrashk
     ];
   };


### PR DESCRIPTION
- my usage of this package has been negligible
- it seems relatively unimportant
- I'm chronically overcommitted (even just around NixOS.org)