### PR TITLE
nwjs: 0.102.1 -> 0.115.0; remove ia32 & add arm64 target

### DIFF
--- a/pkgs/by-name/nw/nwjs/package.nix
+++ b/pkgs/by-name/nw/nwjs/package.nix
@@ -24,7 +24,6 @@
   libuuid,
   libxcb,
   libxkbcommon,
-  makeWrapper,
   libgbm,
   nspr,
   nss,
@@ -49,8 +48,6 @@
 }:
 
 let
-  bits = if stdenv.hostPlatform.is64bit then "x64" else "ia32";
-
   nwEnv = buildEnv {
     name = "nwjs-env";
     paths = [
@@ -102,7 +99,7 @@ let
     ];
   };
 
-  version = "0.102.1";
+  version = "0.115.0";
 in
 stdenv.mkDerivation {
   pname = "nwjs";
@@ -111,19 +108,27 @@ stdenv.mkDerivation {
   src =
     let
       flavor = if sdk then "sdk-" else "";
-    in
-    fetchurl {
-      url = "https://dl.nwjs.io/v${version}/nwjs-${flavor}v${version}-linux-${bits}.tar.gz";
+
+      arch =
+        if stdenv.hostPlatform.is64bit then
+          "x64"
+        else if stdenv.hostPlatform.isAarch64 then
+          "arm64"
+        else
+          throw "nwjs: unsupported architecture.";
+
       # TODO: Write an update script to update all 4 hashes.
       # nixpkgs-update: no auto update
-      hash =
-        {
-          "sdk-ia32" = "sha256-uzDbEq2vNC+fm95Co3lnQX7mrUXsIDWFoa0osWCn3EM=";
-          "sdk-x64" = "sha256-jWw5kXYGxu7oen8fK2Q58QPhiBRC6H2ibGXkeUFW2pI=";
-          "ia32" = "sha256-oODdSKNlOPSLD9vAqRwYcAgH6mumyOB5Fp6G9ifSgok=";
-          "x64" = "sha256-WhHV+xj2ngEz+i1ipBhwZD9b0EF/hdi8gMBZw5qYRGA=";
-        }
-        ."${flavor + bits}";
+      hashes = {
+        "sdk-arm64" = "sha256-yhAQNZ4eMAZIouD+twxfWPgL91b8pRR7YzVODwu0npg=";
+        "sdk-x64" = "sha256-H1yRI+xR/7+TDQ6xaswrvqhJcObO9ZVm6qXIDT5FTQc=";
+        "arm64" = "sha256-RF2QCVIRKd00heZKyzirCr7ePLjlGza19u8CN4fcxT0=";
+        "x64" = "sha256-XlGTxRWd7jwmCXrgSG8q/0tciW21p8f1wr8a4n8rmNk=";
+      };
+    in
+    fetchurl {
+      url = "https://dl.nwjs.io/v${version}/nwjs-${flavor}v${version}-linux-${arch}.tar.gz";
+      hash = hashes."${flavor + arch}";
     };
 
   nativeBuildInputs = [
@@ -168,15 +173,13 @@ stdenv.mkDerivation {
     description = "App runtime based on Chromium and node.js";
     homepage = "https://nwjs.io/";
     platforms = [
-      "i686-linux"
+      "aarch64-linux"
       "x86_64-linux"
     ];
+    changelog = "https://github.com/nwjs/nw.js/blob/nw-v${version}/CHANGELOG.md";
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     maintainers = [ lib.maintainers.mikaelfangel ];
     mainProgram = "nw";
     license = lib.licenses.mit;
-    knownVulnerabilities = [
-      "Uses Chrome 139.0.7258.128, known to have many vulnerabilities."
-    ];
   };
 }

--- a/pkgs/by-name/nw/nwjs/package.nix
+++ b/pkgs/by-name/nw/nwjs/package.nix
@@ -178,7 +178,10 @@ stdenv.mkDerivation {
     ];
     changelog = "https://github.com/nwjs/nw.js/blob/nw-v${version}/CHANGELOG.md";
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
-    maintainers = [ lib.maintainers.mikaelfangel ];
+    maintainers = with lib.maintainers; [
+      mikaelfangel
+      eljamm
+    ];
     mainProgram = "nw";
     license = lib.licenses.mit;
   };


### PR DESCRIPTION
There is a previous attempt to update `nwjs` in [this PR](https://github.com/NixOS/nixpkgs/pull/462257), but it's currently in draft since it has a conflict. As such, I thought I'd be best to do the update in this PR to unblock https://github.com/NixOS/nixpkgs/issues/559231, then the draft could rebase and add its improvements (update script, finalAttrs, ...) once the author is ready to work on it again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
