### PR TITLE
python3Packages.django-pglocks: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/django-pglocks/default.nix
+++ b/pkgs/development/python-modules/django-pglocks/default.nix
@@ -7,10 +7,12 @@
   six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "django-pglocks";
   version = "1.0.4";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   meta = {
     description = "PostgreSQL locking context managers and functions for Django";
@@ -19,8 +21,8 @@ buildPythonPackage rec {
   };
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "3c47c66fbfbd268ef46269673a0516a039539b0972b8ed2ec9cfee44c4b65523";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-PEfGb7+9Jo70YmlnOgUWoDlTmwlyuO0uyc/uRMS2VSM=";
   };
 
   build-system = [ setuptools ];
@@ -33,4 +35,6 @@ buildPythonPackage rec {
 
   # tests need a postgres database
   doCheck = false;
-}
+
+  pythonImportsCheck = [ "django_pglocks" ];
+})

--- a/pkgs/development/python-modules/django-pglocks/default.nix
+++ b/pkgs/development/python-modules/django-pglocks/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   django,
   six,
 }:
@@ -9,7 +10,7 @@
 buildPythonPackage rec {
   pname = "django-pglocks";
   version = "1.0.4";
-  format = "setuptools";
+  pyproject = true;
 
   meta = {
     description = "PostgreSQL locking context managers and functions for Django";
@@ -22,8 +23,10 @@ buildPythonPackage rec {
     sha256 = "3c47c66fbfbd268ef46269673a0516a039539b0972b8ed2ec9cfee44c4b65523";
   };
 
+  build-system = [ setuptools ];
+
   buildInputs = [ django ];
-  propagatedBuildInputs = [
+  dependencies = [
     django
     six
   ];

--- a/pkgs/development/python-modules/django-pglocks/default.nix
+++ b/pkgs/development/python-modules/django-pglocks/default.nix
@@ -14,12 +14,6 @@ buildPythonPackage (finalAttrs: {
 
   __structuredAttrs = true;
 
-  meta = {
-    description = "PostgreSQL locking context managers and functions for Django";
-    homepage = "https://github.com/Xof/django-pglocks";
-    license = lib.licenses.mit;
-  };
-
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     hash = "sha256-PEfGb7+9Jo70YmlnOgUWoDlTmwlyuO0uyc/uRMS2VSM=";
@@ -28,6 +22,7 @@ buildPythonPackage (finalAttrs: {
   build-system = [ setuptools ];
 
   buildInputs = [ django ];
+
   dependencies = [
     django
     six
@@ -37,4 +32,10 @@ buildPythonPackage (finalAttrs: {
   doCheck = false;
 
   pythonImportsCheck = [ "django_pglocks" ];
+
+  meta = {
+    description = "PostgreSQL locking context managers and functions for Django";
+    homepage = "https://github.com/Xof/django-pglocks";
+    license = lib.licenses.mit;
+  };
 })


### PR DESCRIPTION
As part of #515974

Also reordered attrs, because what in the world is this??? eww.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
