### PR TITLE
libipuz: 0.5.4 -> 0.5.5; crosswords: 0.3.17 -> 0.3.18.1 

### DIFF
--- a/pkgs/by-name/cr/crosswords/package.nix
+++ b/pkgs/by-name/cr/crosswords/package.nix
@@ -18,14 +18,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "crosswords";
-  version = "0.3.17";
+  version = "0.3.18.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "jrb";
     repo = "crosswords";
     rev = finalAttrs.version;
-    hash = "sha256-VeiVuMEfMCVjSk52BGtlypapeW6CBW1VQsrtDS8aCoY=";
+    hash = "sha256-d8KwZ06WubqIRq5aPm+W/MfLgNcLP+233gur5pLF/PY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cr/crosswords/package.nix
+++ b/pkgs/by-name/cr/crosswords/package.nix
@@ -45,6 +45,10 @@ stdenv.mkDerivation (finalAttrs: {
     libipuz
   ];
 
+  mesonFlags = [
+    (lib.mesonBool "development" false)
+  ];
+
   postInstall = ''
     substituteInPlace $out/share/thumbnailers/crosswords.thumbnailer \
       --replace-fail "TryExec=crosswords-thumbnailer" "TryExec=$out/bin/crosswords-thumbnailer" \

--- a/pkgs/by-name/li/libipuz/package.nix
+++ b/pkgs/by-name/li/libipuz/package.nix
@@ -14,14 +14,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libipuz";
-  version = "0.5.4";
+  version = "0.5.5";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "jrb";
     repo = "libipuz";
     rev = finalAttrs.version;
-    hash = "sha256-rUFYPtedcNqba2OLPo9nSjyGxuc3Q3RNoOmZx+RUOcU=";
+    hash = "sha256-si+cc129oXLzD1o1MFcaxieIw8vPzWP8dbAnd4inF0Y=";
   };
 
   cargoRoot = "libipuz/rust";


### PR DESCRIPTION
changelog: https://gitlab.gnome.org/jrb/crosswords/-/blob/0.3.18.1/NEWS.md
diff: https://gitlab.gnome.org/jrb/crosswords/-/compare/0.3.17...0.3.18.1

Supersedes #475822

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
