### PR TITLE
go-c8y-cli: init at 2.55.0

### DIFF
--- a/pkgs/by-name/go/go-c8y-cli/package.nix
+++ b/pkgs/by-name/go/go-c8y-cli/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "go-c8y-cli";
+  version = "2.55.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "reubenmiller";
+    repo = "go-c8y-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-swD2mFVn/N38HhdU8SCbmqcefyzWl4k/ARHkktYo2mQ=";
+  };
+
+  vendorHash = "sha256-1h4kdtdYUPqyCIhEDFRP2guduc2aXvvbolDIIFqrES0=";
+
+  # subPackage cmd/gen-docs is only built here to generate man pages in
+  # postInstall and is removed again in postInstall.
+  subPackages = [
+    "cmd/c8y"
+  ]
+  # only build gen-docs if postInstall is going to be run.
+  ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "cmd/gen-docs"
+  ];
+
+  ldflags = [
+    "-s"
+    "-X=github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd.buildVersion=${finalAttrs.version}"
+    "-X=github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd.buildBranch=v2"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    # c8y reads config from $HOME and might look for user-installed extensions
+    writableTmpDirAsHomeHook
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    export C8Y_SETTINGS_CI=true
+    export C8Y_SETTINGS_EXTENSIONS_DATADIR=$HOME/extensions
+
+    $out/bin/gen-docs --man-page --doc-path ./man
+    installManPage ./man/c8y*.1
+    rm $out/bin/gen-docs
+
+    installShellCompletion --cmd c8y \
+      --bash <(SHELL=bash $out/bin/c8y completion bash) \
+      --zsh <(SHELL=zsh $out/bin/c8y completion zsh) \
+      --fish <(SHELL=fish $out/bin/c8y completion fish)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cumulocity IoT command line tool";
+    homepage = "https://goc8ycli.netlify.app/";
+    changelog = "https://github.com/reubenmiller/go-c8y-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ skowalak ];
+    mainProgram = "c8y";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
