### PR TITLE
nixos/tests/nix-remote-build: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1227,6 +1227,7 @@ in
   nix-ld = runTest ./nix-ld.nix;
   nix-local-store = runTest ./nix-local-store.nix;
   nix-misc = handleTest ./nix/misc.nix { };
+  nix-remote-build = runTest ./nix/remote-build.nix;
   nix-required-mounts = runTest ./nix-required-mounts;
   nix-serve = runTest ./nix-serve.nix;
   nix-serve-ssh = runTest ./nix-serve-ssh.nix;

--- a/nixos/tests/nix/remote-build.nix
+++ b/nixos/tests/nix/remote-build.nix
@@ -1,0 +1,74 @@
+{ pkgs, lib, ... }:
+let
+  inherit (import ../ssh-keys.nix pkgs) snakeOilEd25519PrivateKey snakeOilEd25519PublicKey;
+in
+{
+  name = "nix-remote-build";
+
+  meta.maintainers = with lib.maintainers; [ h7x4 ];
+
+  nodes = {
+    builder = {
+      networking.hostName = "myBuildMachine";
+      services.openssh.enable = true;
+      users.users.root.openssh.authorizedKeys.keys = [ snakeOilEd25519PublicKey ];
+    };
+
+    client = {
+      nix.settings.max-jobs = 0;
+      nix.settings.substituters = lib.mkForce [ ];
+      nix.distributedBuilds = true;
+      nix.buildMachines = [
+        {
+          hostName = "myBuildMachine";
+          system = pkgs.stdenv.hostPlatform.system;
+          sshUser = "root";
+          sshKey = "/root/.ssh/id_ed25519";
+        }
+      ];
+
+      programs.ssh.extraConfig = ''
+        Host myBuildMachine
+          StrictHostKeyChecking no
+          UserKnownHostsFile /dev/null
+      '';
+    };
+  };
+
+  testScript =
+    let
+      remoteBuildExpr = pkgs.writeText "remote-build-test.nix" ''
+        derivation {
+          name = "remote-build-test";
+          system = builtins.currentSystem;
+          builder = "/bin/sh";
+          args = [ "-c" "echo -n hello > $out" ];
+        }
+      '';
+    in
+    ''
+      start_all()
+
+      builder.wait_for_unit("sshd.service")
+      client.wait_for_unit("multi-user.target")
+
+      client.succeed(
+          "install -Dm600 ${snakeOilEd25519PrivateKey} /root/.ssh/id_ed25519"
+      )
+
+      with subtest("Client can reach the remote builder over ssh"):
+          client.succeed("ssh -o BatchMode=yes myBuildMachine true")
+
+      with subtest("Builds are delegated to the remote builder"):
+          out = client.succeed(
+              "nix-build -o /root/result ${remoteBuildExpr} 2>&1"
+          )
+          assert "on 'ssh://root@myBuildMachine'" in out, (
+              f"expected nix-build to report delegating the build to 'builder', got:\n{out}"
+          )
+
+          nix_store_path = client.succeed("readlink -f /root/result").strip()
+          assert builder.succeed(f"cat {nix_store_path}").strip() == "hello"
+          assert client.succeed(f"cat {nix_store_path}").strip() == "hello"
+    '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This test makes it easier to verify changes to `nixos/modules/config/nix-remote-build.nix`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
