### PR TITLE
common-updater-scripts: add latest-github-release

### DIFF
--- a/pkgs/common-updater/scripts.nix
+++ b/pkgs/common-updater/scripts.nix
@@ -90,8 +90,7 @@ stdenvNoCC.mkDerivation {
       runHook postInstall
     '';
 
-  # TODO: fix ShellCheck bugs and enable
-  doCheck = false;
+  doCheck = true;
   nativeCheckInputs = [ shellcheck ];
 
   checkPhase = ''

--- a/pkgs/common-updater/scripts.nix
+++ b/pkgs/common-updater/scripts.nix
@@ -1,7 +1,11 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
+  shellcheck,
+  installShellFiles,
   makeWrapper,
+  runtimeShellPackage,
+
   coreutils,
   diffutils,
   git,
@@ -9,15 +13,30 @@
   gnused,
   jq,
   nix,
+  curl,
+  python3,
   python3Packages,
 }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   name = "common-updater-scripts";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontUpdateAutotoolsGnuConfigScripts = true;
 
   nativeBuildInputs = [
     makeWrapper
     python3Packages.wrapPython
+    installShellFiles
+  ];
+
+  buildInputs = [
+    python3
+    runtimeShellPackage
   ];
 
   pythonPath = [
@@ -25,31 +44,64 @@ stdenv.mkDerivation {
     python3Packages.requests
   ];
 
-  dontUnpack = true;
+  pythonScripts = [
+    "list-directory-versions"
+  ];
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp ${./scripts}/* $out/bin
+  bashScripts = [
+    "list-archive-two-levels-versions"
+    "list-git-tags"
+    "mark-broken"
+    "update-source-version"
+  ];
 
-    # wrap non python scripts
-    for f in $out/bin/*; do
-      if ! (head -n1 "$f" | grep -q '#!.*/env.*\(python\|pypy\)'); then
-        wrapProgram $f --prefix PATH : ${
-          lib.makeBinPath [
-            coreutils
-            diffutils
-            git
-            gnugrep
-            gnused
-            jq
-            nix
-          ]
-        }
-      fi
+  src = ./scripts;
+
+  installPhase =
+    let
+      bashScriptInputs = [
+        coreutils
+        diffutils
+        git
+        gnugrep
+        gnused
+        jq
+        nix
+        curl
+      ];
+    in
+    ''
+      runHook preInstall
+
+      installBin "''${bashScripts[@]}" "''${pythonScripts[@]}"
+
+      # wrap non python scripts
+      for f in ''${bashScripts[@]}; do
+        wrapProgram $out/bin/$f --prefix PATH : "${lib.makeBinPath bashScriptInputs}"
+      done
+
+      # wrap python scripts
+      buildPythonPath "''${pythonPath[*]}"
+      for f in ''${pythonScripts[@]}; do
+        patchPythonScript $out/bin/$f
+        wrapProgram $out/bin/$f --prefix PATH : "${lib.makeBinPath [ nix ]}"
+      done
+
+      runHook postInstall
+    '';
+
+  # TODO: fix ShellCheck bugs and enable
+  doCheck = false;
+  nativeCheckInputs = [ shellcheck ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    for file in ''${bashScripts[@]}; do
+      printf "checking '%s' with shellcheck...\n" "$file"
+      shellcheck "$file"
     done
 
-    # wrap python scripts
-    makeWrapperArgs+=( --prefix PATH : "${lib.makeBinPath [ nix ]}" )
-    wrapPythonPrograms
+    runHook postCheck
   '';
 }

--- a/pkgs/common-updater/scripts.nix
+++ b/pkgs/common-updater/scripts.nix
@@ -16,6 +16,8 @@
   curl,
   python3,
   python3Packages,
+  getopt,
+  gh,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -49,6 +51,8 @@ stdenvNoCC.mkDerivation {
   ];
 
   bashScripts = [
+    "latest-github-release"
+
     "list-archive-two-levels-versions"
     "list-git-tags"
     "mark-broken"
@@ -68,6 +72,8 @@ stdenvNoCC.mkDerivation {
         jq
         nix
         curl
+        getopt
+        gh
       ];
     in
     ''

--- a/pkgs/common-updater/scripts/latest-github-release
+++ b/pkgs/common-updater/scripts/latest-github-release
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+
+# fetch latest GitHub release name for a repository
+
+set -euo pipefail
+
+declare -r scriptName="latest-github-release"
+trap 'printf "%s: failed at line %s" "$scriptName" "$LINENO" >&2' ERR
+
+nixpkgs_root="$(git rev-parse --show-toplevel || echo "./.")"
+readonly nixpkgs_root
+
+usage() {
+  echo "Usage:"
+  echo "  $scriptName [options...] {--attr | -A} ATTR_PATH"
+  echo "  $scriptName [options...] --owner OWNER --repo REPO"
+  echo
+  echo "  -A, --attr ATTR_PATH         look up repository owner and name based on src attribute of ATTR_PATH (defaults to \$UPDATE_NIX_ATTR_PATH)"
+  echo "  -o, --owner OWNER            GitHub repository owner"
+  echo "  -r, --repo OWNER             GitHub repository name"
+  echo
+  echo "Options:"
+  echo "  --system SYSTEM              use system for nixpkgs evaluation (default: builtins.currentSystem)"
+  echo "  --github-base GITHUB_BASE    use GITHUB_BASE instead of default hostname (github.com)"
+  echo "  --gh                         use gh api tool to make GitHub API request (default)"
+  echo "  --curl                       use curl to make GitHub API request"
+  echo "  --trim-prefix                trim 'v' prefix from tag name"
+  echo "  --jq JQ_FILTER               additionally pipe the tag name through JQ_FILTER"
+  echo "  --select-release RELEASE_JQ_FILTER"
+  echo "                               use jq filter to select a release tag name (example: startswith(\"vulkan-cts-\"))"
+  echo "  -v, --verbose                increase verbosity"
+  echo
+  echo "Note: Prereleases and draft releases are always filtered."
+
+  exit 1
+}
+
+declare have_gh
+if gh --version >/dev/null; then
+  have_gh=true
+else
+  have_gh=false
+fi
+readonly have_gh
+
+opts=$(getopt \
+  --shell bash \
+  --name "$scriptName" \
+  --options hA:o:r:v \
+  --longoptions help,system:,attr:,owner:,repo:,github-base:,jq:,curl,gh,trim-prefix,select-release:,verbose \
+  -- "$@") || usage
+
+eval set -- "$opts"
+
+declare verbose=false system attrpath githubBase="github.com" owner repo use_gh=$have_gh trim_prefix=false jq_extra_filter release_filter
+
+if [[ -v UPDATE_NIX_ATTR_PATH ]]; then
+  attrpath="$UPDATE_NIX_ATTR_PATH"
+fi
+
+while (($#))
+do
+  case $1 in
+    -h|--help)
+      usage;;
+    --system)
+      system=$2; shift;;
+    -A|--attr)
+      attrpath=$2; shift;;
+    -o|--owner)
+      owner=$2; shift;;
+    -r|--repo)
+      repo=$2; shift;;
+    --github-base)
+      githubBase=$2; shift;;
+    --jq)
+      jq_extra_filter=$2; shift;;
+    --trim-prefix)
+      trim_prefix=true;;
+    --gh)
+      use_gh=true;;
+    --curl)
+      use_gh=false;;
+    --select-release)
+      release_filter=$2; shift;;
+    -v|--verbose)
+      verbose=true;;
+    --)
+      shift; break;;
+    *)
+      false
+  esac
+  shift
+done
+readonly verbose system attrpath githubBase owner repo use_gh trim_prefix jq_extra_filter release_filter
+
+declare release_filter_mode=false
+if [[ -v release_filter ]]; then
+  release_filter_mode=true
+fi
+readonly release_filter_mode
+
+verbose_printf() {
+  if [ $verbose = true ]; then
+    # shellcheck disable=SC2059
+    printf 1>&2 "$@"
+  fi
+}
+
+if [ $release_filter_mode = true ] && [ $have_gh = false ]; then
+  printf "%s: request --select-filter, but gh tool is not available\n" "$scriptName" 1>&2
+  exit 1
+fi
+
+if [[ ! -v attrpath ]] && [[ ! -v owner ]] && [[ ! -v repo ]]; then
+  printf "%s: either attrpath (-A) or owner and repository (-o/-r) are required\n" "$scriptName" 1>&2
+  exit 1
+fi
+
+read -r -d '' get_github_api_url <<- 'EOF' || true
+{
+  system ? builtins.currentSystem,
+  tree ? ./.,
+  nixpkgs ? import tree { inherit system; },
+  attrpath ? null,
+  owner ? null,
+  repo ? null,
+}:
+
+assert attrpath != null || (owner != null && repo != null);
+
+let
+  path = nixpkgs.lib.splitString "." attrpath;
+  pkg = nixpkgs.lib.getAttrFromPath path nixpkgs;
+  src = pkg.src;
+in
+if owner != null && repo != null then
+  "${owner}/${repo}"
+else
+  "${src.owner}/${src.repo}"
+EOF
+declare -r get_github_api_url
+
+if [[ -v attrpath ]]; then
+  verbose_printf "%s: use attrpath='%s'\n" "$scriptName" "$attrpath"
+elif [[ -v owner ]] && [[ -v repo ]]; then
+  verbose_printf "%s: use owner='%s' repo='%s'\n" "$scriptName" "$owner" "$repo"
+fi
+
+owner_repo="$(nix-instantiate \
+  --eval \
+  --raw \
+  --arg tree "$nixpkgs_root" \
+  ${system:+--system "$system"} \
+  ${attrpath:+--argstr attrpath "$attrpath"} \
+  ${owner:+--argstr owner "$owner"} \
+  ${repo:+--argstr repo "$repo"} \
+  --expr "$get_github_api_url")"
+readonly owner_repo
+verbose_printf "%s: use owner/repo '%s'\n" "$scriptName" "$owner_repo"
+
+if [ $release_filter_mode = true ]; then
+  declare tag_name_jq_filter='.'
+  if [ $trim_prefix = true ]; then
+    tag_name_jq_filter='ltrimstr("v")'
+  fi
+  if [[ -v jq_extra_filter ]]; then
+    tag_name_jq_filter="$tag_name_jq_filter | $jq_extra_filter"
+  fi
+  readonly tag_name_jq_filter
+
+  verbose_printf "%s: final tag_name_jq_filter='%s'\n" "$scriptName" "$tag_name_jq_filter"
+
+  readonly release_jq_filter="map(.tagName | select(${release_filter:-.})) | first | $tag_name_jq_filter"
+  verbose_printf "%s: final release_jq_filter='%s'\n" "$scriptName" "$release_jq_filter"
+
+  tag_name=$(gh release list \
+    --json tagName \
+    --jq "$release_jq_filter" \
+    --repo "$githubBase/$owner_repo" \
+    --exclude-drafts \
+    --exclude-pre-releases)
+else
+  if [ $trim_prefix = true ]; then
+    tag_name_jq_filter='.tag_name | ltrimstr("v")'
+  else
+    tag_name_jq_filter='.tag_name'
+  fi
+  if [[ -v jq_extra_filter ]]; then
+    tag_name_jq_filter="$tag_name_jq_filter | $jq_extra_filter"
+  fi
+  readonly tag_name_jq_filter
+
+  verbose_printf "%s: final tag_name_jq_filter='%s'\n" "$scriptName" "$tag_name_jq_filter"
+
+  if [ $use_gh = true ]; then
+    readonly api_url="repos/$owner_repo/releases/latest"
+
+    tag_name=$(gh api \
+      ${githubBase:+--hostname "$githubBase"} \
+      --jq "$tag_name_jq_filter" \
+      "$api_url")
+  else
+    if [ $have_gh = true ] && [[ ! -v GITHUB_TOKEN ]]; then
+      GITHUB_TOKEN="$(gh auth token --hostname "$githubBase")" || true
+    fi
+
+    readonly url="https://api.$githubBase/$api_url"
+
+    tag_name=$(curl \
+      ${GITHUB_TOKEN:+--oauth2-bearer "$GITHUB_TOKEN"} \
+      --header "Accept: application/vnd.github+json" \
+      --header "X-GitHub-Api-Version: 2026-03-10" \
+      --location \
+      --proto =https \
+      --http2-prior-knowledge \
+      --tlsv1.3 \
+      --silent --show-error --fail \
+      "$url" \
+      | jq -r "$tag_name_jq_filter")
+  fi
+fi
+
+echo "$tag_name"
+

--- a/pkgs/common-updater/scripts/list-archive-two-levels-versions
+++ b/pkgs/common-updater/scripts/list-archive-two-levels-versions
@@ -40,14 +40,12 @@ fi
 
 # by default set url to the base dir of the first url in src.urls
 if [[ -z "$url" ]]; then
-    url="$(nix-instantiate $systemArg --eval -E \
-               "with import ./. {}; dirOf (dirOf (lib.head $attr_path.src.urls))" \
-            | tr -d '"')"
+    url="$(nix-instantiate --eval --raw -E "with import ./. {}; dirOf (dirOf (lib.head $attr_path.src.urls))")"
 fi
 
 # print a debugging message
 if [[ -n "$file" ]]; then
-    echo "# Listing versions for '$pname' at $url" >> $file
+    echo "# Listing versions for '$pname' at $url" >> "$file"
 fi
 
 # list all major-minor versions from url

--- a/pkgs/common-updater/scripts/list-git-tags
+++ b/pkgs/common-updater/scripts/list-git-tags
@@ -40,14 +40,12 @@ fi
 
 # By default we set url to src.url or src.meta.homepage
 if [[ -z "$url" ]]; then
-    url="$(nix-instantiate $systemArg --eval -E \
-               "with import ./. {}; $attr_path.src.meta.homepage or $attr_path.src.url" \
-        | tr -d '"')"
+    url="$(nix-instantiate --raw --eval -E "with import ./. {}; $attr_path.src.meta.homepage or $attr_path.src.url or \"null\"")"
 fi
 
 # print a debugging message
 if [[ -n "$file" ]]; then
-    echo "# Listing tags for '$pname' at $url" >> $file
+    echo "# Listing tags for '$pname' at $url" >> "$file"
 fi
 
 # list all tags from the remote repository

--- a/pkgs/common-updater/scripts/mark-broken
+++ b/pkgs/common-updater/scripts/mark-broken
@@ -24,8 +24,8 @@ failMark() {
         local attr=$1
         shift 1
 
-        echo "$attr: $@" >&2
-        echo $attr >> failed-marks.txt
+        printf "%s: %s" "$attr" "$@" >&2
+        echo "$attr" >> failed-marks.txt
 }
 
 usage() {
@@ -56,23 +56,23 @@ function attemptToMarkBroken() {
         local attr=$1
 
         # skip likely to be noisy attrs
-        for badAttr in ${denyAttrList[@]};do
+        for badAttr in "${denyAttrList[@]}"; do
                 if [[ $attr =~ $badAttr ]]; then
-                        failMark $attr "attr contained $badAttr, skipped."
+                        failMark "$attr" "attr contained $badAttr, skipped."
                         return
                 fi
         done
 
-        nixFile=$(nix-instantiate --eval --json -E "with import ./. {}; (builtins.unsafeGetAttrPos \"description\" $attr.meta).file" 2>/dev/null | jq -r .)
+        nixFile=$(nix-instantiate --eval --raw --json -E "with import ./. {}; (builtins.unsafeGetAttrPos \"description\" $attr.meta).file" 2>/dev/null)
         if [[ ! -f "$nixFile" ]]; then
-            failMark $attr "Couldn't locate correct file"
+            failMark "$attr" "Couldn't locate correct file"
             return
         fi
 
         # skip files which are auto-generated
-        for filename in ${denyFileList[@]};do
-                if [[ "$filename" == $(basename $nixFile) ]]; then
-                        failMark $attr "filename matched $filename, skipped."
+        for filename in "${denyFileList[@]}"; do
+                if [[ "$filename" == $(basename "$nixFile") ]]; then
+                        failMark "$attr" "filename matched $filename, skipped."
                         return
                 fi
         done
@@ -84,7 +84,7 @@ function attemptToMarkBroken() {
 
         if cmp -s "$nixFile" "$nixFile.bak"; then
             mv "$nixFile.bak" "$nixFile"
-            failMark $attr "Does it have a meta attribute?"
+            failMark "$attr" "Does it have a meta attribute?"
             return
         fi
 
@@ -92,13 +92,13 @@ function attemptToMarkBroken() {
         markedSuccessfully=$(nix-instantiate --eval -E "with import ./. {}; $attr.meta.broken")
         if [[ "$markedSuccessfully" != "true" ]]; then
             mv "$nixFile.bak" "$nixFile"
-            failMark $attr "$attr.meta.broken doesn't evaluate to true."
+            failMark "$attr" "$attr.meta.broken doesn't evaluate to true."
             return
         fi
 
         rm -f "$nixFile.bak"
 }
 
-for attr in $@; do
-        attemptToMarkBroken $attr
+for attr in "$@"; do
+        attemptToMarkBroken "$attr"
 done

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -24,7 +24,6 @@ for arg in "$@"; do
     case $arg in
         --system=*)
             system="${arg#*=}"
-            systemArg="--system ${arg#*=}"
         ;;
         --version-key=*)
             versionKey="${arg#*=}"
@@ -79,7 +78,7 @@ else
     requiredArgs=1
 fi
 
-if (( "${#args[*]}" < $requiredArgs )); then
+if (( "${#args[*]}" < requiredArgs )); then
     echo "$scriptName: Too few arguments"
     usage
     exit 1
@@ -99,18 +98,22 @@ if [[ -z "$sourceKey" ]]; then
     sourceKey=src
 fi
 
+do_eval() {
+    nix-instantiate ${system:+--system "$system"} --eval "$@"
+}
+
 # Allow finding packages among flake outputs in repos using flake-compat.
-pname=$(nix-instantiate $systemArg --eval --strict -A "$attr.name" || echo)
+pname=$(do_eval --strict -A "$attr.name" || echo)
 if [[ -z "$pname" ]]; then
     if [[ -z "$system" ]]; then
         system=$(nix-instantiate --eval -E 'builtins.currentSystem' | tr -d '"')
     fi
 
-    pname=$(nix-instantiate $systemArg --eval --strict -A "packages.$system.$attr.name" || echo)
+    pname=$(do_eval --strict -A "packages.$system.$attr.name" || echo)
     if [[ -n "$pname" ]]; then
         attr="packages.$system.$attr"
     else
-        pname=$(nix-instantiate $systemArg --eval --strict -A "legacyPackages.$system.$attr.name" || echo)
+        pname=$(do_eval --strict -A "legacyPackages.$system.$attr.name" || echo)
         if [[ -n "$pname" ]]; then
             attr="legacyPackages.$system.$attr"
         else
@@ -120,22 +123,25 @@ if [[ -z "$pname" ]]; then
 fi
 
 if [[ -z "$nixFile" ]]; then
-    nixFile=$(nix-instantiate $systemArg --eval --strict -A "$attr.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')
+    nixFile=$(do_eval --strict -A "$attr.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')
     if [[ ! -f "$nixFile" ]]; then
         die "Couldn't evaluate '$attr.meta.position' to locate the .nix file!"
     fi
 
     # flake-compat will return paths in the Nix store, we need to correct for that.
-    possiblyOutPath=$(nix-instantiate $systemArg --eval -E "with $importTree; outPath" 2>/dev/null | tr -d '"')
+    possiblyOutPath=$(do_eval -E "with $importTree; outPath" 2>/dev/null | tr -d '"')
     if [[ -n "$possiblyOutPath" ]]; then
+        # shellcheck disable=SC2001
         outPathEscaped=$(echo "$possiblyOutPath" | sed 's#[$^*\\.[|]#\\&#g')
+        # shellcheck disable=SC2001
         pwdEscaped=$(echo "$PWD" | sed 's#[$^*\\.[|]#\\&#g')
+        # shellcheck disable=SC2001
         nixFile=$(echo "$nixFile" | sed "s|^$outPathEscaped|$pwdEscaped|")
     fi
 fi
 
-oldHashAlgo=$(nix-instantiate $systemArg --eval --strict -E "let pkgs = $importTree; in pkgs.$attr.$sourceKey.drvAttrs.outputHashAlgo or pkgs.$attr.$sourceKey.drvAttrs.outputHash" | tr -d '"' | sed "s/-.*//")
-oldHash=$(nix-instantiate $systemArg --eval --strict -A "$attr.$sourceKey.drvAttrs.outputHash" | tr -d '"')
+oldHashAlgo=$(do_eval --strict -E "let pkgs = $importTree; in pkgs.$attr.$sourceKey.drvAttrs.outputHashAlgo or pkgs.$attr.$sourceKey.drvAttrs.outputHash" | tr -d '"' | sed "s/-.*//")
+oldHash=$(do_eval --strict -A "$attr.$sourceKey.drvAttrs.outputHash" | tr -d '"')
 
 if [[ -z "$oldHashAlgo" || -z "$oldHash" ]]; then
     die "Couldn't evaluate old source hash from '$attr.$sourceKey'!"
@@ -145,7 +151,7 @@ if [[ $(grep --count "$oldHash" "$nixFile") != 1 ]]; then
     die "Couldn't locate old source hash '$oldHash' (or it appeared more than once) in '$nixFile'!"
 fi
 
-oldVersion=$(nix-instantiate $systemArg --eval -E "with $importTree; $attr.${versionKey} or (builtins.parseDrvName $attr.name).version" | tr -d '"')
+oldVersion=$(do_eval -E "with $importTree; $attr.${versionKey} or (builtins.parseDrvName $attr.name).version" | tr -d '"')
 
 if [[ -z "$oldVersion" ]]; then
     die "Couldn't find out the old version of '$attr'!"
@@ -164,7 +170,7 @@ if [[ -z "$ignoreSameVersion" && "$oldVersion" = "$newVersion" ]]; then
 fi
 
 if [[ -n "$newRevision" ]]; then
-    oldRevision=$(nix-instantiate $systemArg --eval -E "with $importTree; $attr.$sourceKey.rev" | tr -d '"')
+    oldRevision=$(do_eval -E "with $importTree; $attr.$sourceKey.rev" | tr -d '"')
     if [[ -z "$oldRevision" ]]; then
         die "Couldn't evaluate source revision from '$attr.$sourceKey'!"
     fi
@@ -224,7 +230,7 @@ fi
 
 # Replace new URL
 if [[ -n "$newUrl" ]]; then
-    oldUrl=$(nix-instantiate $systemArg --eval -E "with $importTree; builtins.elemAt ($attr.$sourceKey.drvAttrs.urls or [ $attr.$sourceKey.url ]) 0" | tr -d '"')
+    oldUrl=$(do_eval -E "with $importTree; builtins.elemAt ($attr.$sourceKey.drvAttrs.urls or [ $attr.$sourceKey.url ]) 0" | tr -d '"')
     if [[ -z "$oldUrl" ]]; then
         die "Couldn't evaluate source url from '$attr.$sourceKey'!"
     fi
@@ -254,7 +260,7 @@ fi
 
 # If new hash not given on the command line, recalculate it ourselves.
 if [[ -z "$newHash" ]]; then
-    nix-build $systemArg --no-out-link -A "$attr.$sourceKey" 2>"$attr.fetchlog" >/dev/null || true
+    nix-build ${system:+--system "$system"} --no-out-link -A "$attr.$sourceKey" 2>"$attr.fetchlog" >/dev/null || true
     # FIXME: use nix-build --hash here once https://github.com/NixOS/nix/issues/1172 is fixed
     newHash=$(
         sed '1,/hash mismatch in fixed-output derivation/d' "$attr.fetchlog" \


### PR DESCRIPTION
Builds on top of #560016.
Still a draft while I'm bikeshedding some implementation details, but please feel free to offer any thoughts and comments already.
I'll add another PR shortly that showcases some cases where latest-github-release can replace a zoo of random curl calls in the wild.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
