### PR TITLE
home-assistant-custom-components.openai-tts: init at 3.9.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/openai-tts/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/openai-tts/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  pytestCheckHook,
+  sentence-stream,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  owner = "sfortis";
+  domain = "openai_tts";
+  version = "3.9.1";
+
+  src = fetchFromGitHub {
+    inherit (finalAttrs) owner;
+    repo = "openai_tts";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hpGKSUMJuW2XSAGuqmCIXTtN4Qh2nwOFJWAg5X9JljA=";
+  };
+
+  dependencies = [ sentence-stream ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Custom TTS component for Home Assistant. Utilizes the OpenAI speech engine or any compatible endpoint to deliver high-quality speech";
+    longDescription = ''
+      OpenAI TTS for Home Assistant depends on ffmpeg component, example how to setup in NixOS `configuration.nix`:
+
+      ```
+      { pkgs, ... }:
+      {
+        services.home-assistant = {
+          customComponents = [ pkgs.home-assistant-custom-components.openai-tts ];
+          extraComponents = [ "ffmpeg" ];
+        };
+      }
+      ```
+    '';
+    homepage = "https://github.com/sfortis/openai_tts";
+    changelog = "https://github.com/sfortis/openai_tts/releases/tag/${finalAttrs.src.tag}";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.gpl3Only;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
