### PR TITLE
 libirecovery: 1.3.1 -> 1.3.1-unstable-2026-08-23,  idevicerestore: 1.0.0-unstable-2026-07-26 -> 1.0.0-unstable-2026-09-07

### DIFF
--- a/pkgs/by-name/id/idevicerestore/package.nix
+++ b/pkgs/by-name/id/idevicerestore/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "idevicerestore";
-  version = "1.0.0-unstable-2026-07-26";
+  version = "1.0.0-unstable-2026-09-07";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = "idevicerestore";
-    rev = "45145e9fdc8458022c61a4b87bd029b866d5bcdc";
-    hash = "sha256-0W0DEnO8eZx2G3JKjp7SilLH8vmpfkiJxrwkudyf5rM=";
+    rev = "60192e97f87d1bbab5c493684e0a245b0966363f";
+    hash = "sha256-RLXyjEBO1RzDQGLI9c9wyD/MSIgMVfaPsfQ+NVaXzCI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libirecovery/package.nix
+++ b/pkgs/by-name/li/libirecovery/package.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libirecovery";
-  version = "1.3.1";
+  version = "1.3.1-unstable-2026-08-23";
 
   outputs = [
     "out"
@@ -21,8 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = "libirecovery";
-    rev = finalAttrs.version;
-    hash = "sha256-CSDG8mOLvKAIpxmZnNLMKY1HvQIqk66/rkjmzq7F8vY=";
+    rev = "95dec3aa25b1e30654ca107eb971971f6a216520";
+    hash = "sha256-k8aHdfqqMBDOnzyp+4SBTIbXiro2DhDywFAu4o6VhaY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
