### PR TITLE
pioneers: 15.6 -> 15.7-unstable-2021-07-07, add darwin support

### DIFF
--- a/pkgs/by-name/pi/pioneers/package.nix
+++ b/pkgs/by-name/pi/pioneers/package.nix
@@ -1,39 +1,104 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  pkg-config,
+  fetchsvn,
+  autoreconfHook,
+  desktopToDarwinBundle,
+  gob2,
   intltool,
   itstool,
+  libcanberra,
+  avahi,
   gtk3,
+  libnotify,
+  librsvg,
   libxml2,
+  pkg-config,
+  gnome,
+  wrapGAppsHook3,
+  yelp-tools,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "pioneers";
-  version = "15.6";
+  # No releases since 2021-07-07; track trunk HEAD at r2340 (latest) – SVN has no tags.
+  version = "15.7-unstable-2021-07-07";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/pio/pioneers-${finalAttrs.version}.tar.gz";
-    sha256 = "07b3xdd81n8ybsb4fzc5lx0813y9crzp1hj69khncf4faj48sdcs";
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/pio/code/trunk/pioneers";
+    rev = "2340";
+    hash = "sha256-cggyPPza4QVbe9p68LdYHslTi3y9BMq6vDdsOW/u+X4=";
   };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  # Use merged gdk-pixbuf cache that includes librsvg's SVG loader (.dylib on darwin).
+  # findGdkPixbufLoaders would otherwise pick the longest existing cache (librsvg's
+  # alone or gdk-pixbuf's alone), missing the other set.
+  GDK_PIXBUF_MODULE_FILE = lib.optionalString stdenv.hostPlatform.isDarwin "${
+    gnome._gdkPixbufCacheBuilder_DO_NOT_USE
+    { extraLoaders = [ librsvg ]; }
+  }";
 
   nativeBuildInputs = [
-    pkg-config
+    autoreconfHook
+    gob2
     intltool
     itstool
-  ];
+    libxml2.bin
+    # configure probes rsvg-convert with AC_PATH_PROG;
+    librsvg
+    pkg-config
+    wrapGAppsHook3
+    yelp-tools
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;
 
   buildInputs = [
+    avahi
     gtk3
-    libxml2
+    libcanberra
+    libnotify
+    librsvg
   ];
 
+  configureFlags = [
+    "--enable-help"
+    "--with-avahi"
+    "--with-gtk"
+    "--with-notify"
+    "--with-sound"
+  ];
+
+  enableParallelBuilding = true;
+
+  # Upstream puts a GNU ld option in AM_CFLAGS. Nix already performs the
+  # equivalent dead-library elimination and Darwin's linker rejects it.
+  makeFlags = [ "GOB2=${lib.getExe gob2}" ] ++ lib.optional stdenv.hostPlatform.isDarwin "AM_CFLAGS=";
+
+  # librsvg's gdk-pixbuf loader is a .dylib with @rpath/librsvg-2.2.dylib; on darwin
+  # the loader's rpath is empty, so DYLD must be set for dlopen to find it.
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    for prog in $out/bin/*; do
+      wrapProgram "$prog" \
+        --prefix DYLD_LIBRARY_PATH : ${lib.getLib librsvg}/lib \
+        --prefix DYLD_FALLBACK_LIBRARY_PATH : ${lib.getLib librsvg}/lib
+    done
+  '';
+
   meta = {
-    description = "Addicting game based on The Settlers of Catan";
-    homepage = "https://pio.sourceforge.net/"; # https does not work
+    description = "Multiplayer strategy game inspired by The Settlers of Catan";
+    longDescription = ''
+      Pioneers is a faithful implementation of The Settlers of Catan board
+      game, supporting local and network multiplayer with GTK and Avahi
+      discovery.
+    '';
+    homepage = "https://pio.sourceforge.net/";
+    changelog = "https://sourceforge.net/p/pio/code/commit_browser";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
-    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    platforms = lib.platforms.unix;
+    mainProgram = "pioneers";
   };
-})
+}

--- a/pkgs/desktops/gnome/gdk-pixbuf-cache-builder.nix
+++ b/pkgs/desktops/gnome/gdk-pixbuf-cache-builder.nix
@@ -32,8 +32,20 @@ runCommand "gdk-pixbuf-loaders.cache"
           echo "Error: gdkPixbufCacheBuilder: Passed package “''${package}” does not contain GdkPixbuf loaders in “${gdk-pixbuf.moduleDir}”." 1>&2
           exit 1
         fi
-        GDK_PIXBUF_MODULEDIR="$module_dir" \
-          ${stdenv.hostPlatform.emulator buildPackages} ${gdk-pixbuf.dev}/bin/gdk-pixbuf-query-loaders
+        if [[ "${lib.boolToString stdenv.hostPlatform.isDarwin}" == true ]]; then
+          # gdk-pixbuf's Darwin scanner only considers .so modules, while
+          # some third-party loaders are shipped as .dylib. Query explicit
+          # module paths so both suffixes work.
+          loaders=()
+          for loader in "$module_dir"/loaders/*.so "$module_dir"/loaders/*.dylib "$module_dir"/*.so "$module_dir"/*.dylib; do
+            [[ -f "$loader" ]] && loaders+=("$loader")
+          done
+          DYLD_LIBRARY_PATH=${lib.makeLibraryPath loaderPackages} \
+            ${stdenv.hostPlatform.emulator buildPackages} ${gdk-pixbuf.dev}/bin/gdk-pixbuf-query-loaders "''${loaders[@]}"
+        else
+          GDK_PIXBUF_MODULEDIR="$module_dir" \
+            ${stdenv.hostPlatform.emulator buildPackages} ${gdk-pixbuf.dev}/bin/gdk-pixbuf-query-loaders
+        fi
       done
     ) > "$out"
   ''


### PR DESCRIPTION
Builds on #560433 with the Pioneers update and Darwin support.

- Updated Pioneers to use the upstream SVN revision, which is a LITTLE ahead of the old release tarball.
- Enabled all supported network/audio features.
- Made available on Darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test