### PR TITLE
python313Packages.ufomerge: 1.9.7 -> 1.9.8

### DIFF
--- a/pkgs/development/python-modules/ufomerge/default.nix
+++ b/pkgs/development/python-modules/ufomerge/default.nix
@@ -10,7 +10,7 @@
   ufolib2,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ufomerge";
   version = "1.9.8";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = "ufomerge";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-rIIT4FHdKVob+7AWONWcMCrwVZc4bkzni2csJ9L41fE=";
   };
 
@@ -42,8 +42,8 @@ buildPythonPackage rec {
   meta = {
     description = "Command line utility and Python library that merges two UFO source format fonts into a single file";
     homepage = "https://github.com/googlefonts/ufomerge";
-    changelog = "https://github.com/googlefonts/ufomerge/releases/tag/${src.tag}";
+    changelog = "https://github.com/googlefonts/ufomerge/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ jopejoe1 ];
   };
-}
+})

--- a/pkgs/development/python-modules/ufomerge/default.nix
+++ b/pkgs/development/python-modules/ufomerge/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonRelaxDepsHook,
   pytestCheckHook,
   setuptools,
   setuptools-scm,
@@ -13,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "ufomerge";
-  version = "1.9.7";
+  version = "1.9.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = "ufomerge";
     tag = "v${version}";
-    hash = "sha256-bA0tXopktnkrLTaRmqppqqQgC0nx8MxncO5oTuZeMQc=";
+    hash = "sha256-rIIT4FHdKVob+7AWONWcMCrwVZc4bkzni2csJ9L41fE=";
   };
 
   build-system = [
@@ -36,11 +35,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     fontfeatures
-  ];
-
-  disabledTests = [
-    # Fails with `KeyError: 'B'`
-    "test_28"
   ];
 
   pythonImportsCheck = [ "ufomerge" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
