### PR TITLE
terminal-browser: init at 0.8.0

### DIFF
--- a/pkgs/by-name/te/terminal-browser/package.nix
+++ b/pkgs/by-name/te/terminal-browser/package.nix
@@ -1,0 +1,158 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libdrm,
+  libgbm,
+  libGL,
+  libpulseaudio,
+  libxkbcommon,
+  libxshmfence,
+  nspr,
+  nss,
+  pango,
+  systemd,
+  wayland,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxrandr,
+  libxrender,
+  libxscrnsaver,
+  libxtst,
+}:
+
+let
+  sources = {
+    x86_64-linux = {
+      platform = "linux-x64";
+      hash = "sha256-99VhKMCepIE/fNN0uyIAnwwLr2QWmhcLy3DapjY9MSQ=";
+    };
+
+    aarch64-linux = {
+      platform = "linux-arm64";
+      hash = "sha256-LESPm8BD0Hid76kwX1v4TFnyYm5DFY8iAMJHQSsxmN8=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "terminal-browser: unsupported system ${stdenv.hostPlatform.system}");
+
+  runtimeLibraries = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libdrm
+    libgbm
+    libGL
+    libpulseaudio
+    libxkbcommon
+    libxshmfence
+    nspr
+    nss
+    pango
+    systemd
+    wayland
+    libx11
+    libxcb
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxrandr
+    libxrender
+    libxscrnsaver
+    libxtst
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "terminal-browser";
+  version = "0.8.0";
+
+  src = fetchurl {
+    url = "https://github.com/zenbu-labs/terminal-browser/releases/download/v${finalAttrs.version}/terminal-browser-${source.platform}.tar.gz";
+    inherit (source) hash;
+  };
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = runtimeLibraries;
+
+  runtimeDependencies = runtimeLibraries;
+
+  sourceRoot = "terminal-browser";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib/terminal-browser" "$out/bin"
+
+    cp -R . "$out/lib/terminal-browser"
+
+    # The upstream Electron archive contains a setuid sandbox helper.
+    # Setuid permissions cannot be represented in the Nix store so Chromium
+    # can use the unprivileged user-namespace sandbox instead.
+    rm -f "$out/lib/terminal-browser/electron/chrome-sandbox"
+
+    runHook postInstall
+  '';
+
+  # Some Electron/Chromium libraries are loaded dynamically rather than
+  # appearing as DT_NEEDED entries.
+  postFixup = ''
+    makeWrapper "$out/lib/terminal-browser/bin/terminal-browser" "$out/bin/terminal-browser" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibraries}"
+  '';
+
+  meta = {
+    description = "Browser that runs directly inside your terminal";
+    homepage = "https://github.com/zenbu-labs/terminal-browser";
+    changelog = "https://github.com/zenbu-labs/terminal-browser/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "terminal-browser";
+    platforms = builtins.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ louis-thevenet ];
+  };
+})


### PR DESCRIPTION
A real browser that runs inside your terminal : https://github.com/zenbu-labs/terminal-browser

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
