### PR TITLE
broot: 1.59.0 -> 1.60.0, remove stale RUSTONIG_SYSTEM_LIBONIG

### DIFF
--- a/pkgs/by-name/br/broot/package.nix
+++ b/pkgs/by-name/br/broot/package.nix
@@ -31,8 +31,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildFeatures = lib.optionals withClipboard [ "clipboard" ];
 
-  env.RUSTONIG_SYSTEM_LIBONIG = true;
-
   postPatch = ''
     # Fill the version stub in the man page. We can't fill the date
     # stub reproducibly.

--- a/pkgs/by-name/br/broot/package.nix
+++ b/pkgs/by-name/br/broot/package.nix
@@ -5,9 +5,6 @@
   fetchFromGitHub,
   installShellFiles,
   makeBinaryWrapper,
-  pkg-config,
-  libgit2,
-  zlib,
   buildPackages,
   versionCheckHook,
   nix-update-script,
@@ -16,24 +13,21 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "broot";
-  version = "1.59.0";
+  version = "1.60.0";
 
   src = fetchFromGitHub {
     owner = "Canop";
     repo = "broot";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-z0n0+dM2lpnM/1Nw28kLnO3UQq1zrhzD2QBPV+zcDfQ=";
+    hash = "sha256-VTVnE96hddGgJ7jXW4eWZ/rJhvgUS+FVR4Ck2Vip4uo=";
   };
 
-  cargoHash = "sha256-MhUjKIW2Nb2Ou0sW7iA4S3ecu3UGIRtFCW+KhbwIjtI=";
+  cargoHash = "sha256-uYbdkaSHkFCzWoUte4/WNdBuz4oOt+AgkQnrswoboMA=";
 
   nativeBuildInputs = [
     installShellFiles
     makeBinaryWrapper
-    pkg-config
   ];
-
-  buildInputs = [ libgit2 ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ zlib ];
 
   buildFeatures = lib.optionals withClipboard [ "clipboard" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
