### PR TITLE
electron: allow use of suid sandbox 

### DIFF
--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -175,6 +175,10 @@ stdenv.mkDerivation (finalAttrs: {
     "Applications/Element.app/Contents/MacOS"
   ];
 
+  passthru = {
+    inherit (electron) sandboxExecutableName;
+  };
+
   meta = {
     description = "Matrix client for desktop";
     homepage = "https://element.io/";

--- a/pkgs/development/tools/electron/wrapper.nix
+++ b/pkgs/development/tools/electron/wrapper.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   electron-unwrapped,
   wrapGAppsHook3,
@@ -7,6 +8,8 @@
   glib,
   gtk3,
   gtk4,
+
+  sandboxExecutableName ? "__electron_${lib.versions.major electron-unwrapped.version}-suid-sandbox",
 }:
 
 stdenv.mkDerivation {
@@ -31,7 +34,10 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     makeWrapper "${electron-unwrapped}/libexec/electron/electron" "$out/bin/electron" \
       "''${gappsWrapperArgs[@]}" \
-      --set CHROME_DEVEL_SANDBOX $out/libexec/electron/chrome-sandbox
+      --run 'export CHROME_DEVEL_SANDBOX="$(
+              [ -x /run/wrappers/bin/${sandboxExecutableName} ] \
+              && echo /run/wrappers/bin/${sandboxExecutableName} \
+              || echo '$out'/libexec/electron/chrome-sandbox)"'
 
     ln -s ${electron-unwrapped}/libexec $out/libexec
   '';
@@ -39,6 +45,7 @@ stdenv.mkDerivation {
   passthru = {
     unwrapped = electron-unwrapped;
     inherit (electron-unwrapped) headers dist;
+    inherit sandboxExecutableName;
   };
 
   __structuredAttrs = true;


### PR DESCRIPTION
follows https://github.com/NixOS/nixpkgs/blob/ee9f3748e4a58da598d4cbdf599677bedeb83856/pkgs/applications/networking/browsers/chromium/default.nix#L147-L152

On non-NixOS linux:

```
bash-5.3$ nix build .#element-desktop
bash-5.3$ ./result/bin/element-desktop
[1018503:0907/183808.106421:FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /nix/store/ybjj4sa6isrx56mx0scjrghhb5n59v55-electron-42.9.3/libexec/electron/chrome-sandbox is owned by root and has mode 4755.
Trace/breakpoint trap      (core dumped) ./result/bin/element-desktop
bash-5.3$ nix eval .#element-desktop.sandboxExecutableName
"__electron_42-suid-sandbox"
bash-5.3$ sudo cp /nix/store/ybjj4sa6isrx56mx0scjrghhb5n59v55-electron-42.9.3/libexec/electron/chrome-sandbox /run/wrappers/bin/__electron_42-suid-sandbox
bash-5.3$ sudo chmod 0000 /run/wrappers/bin/__electron_42-suid-sandbox
bash-5.3$ sudo chmod u+s,g-s,u+rx,g+x,o+x /run/wrappers/bin/__electron_42-suid-sandbox
bash-5.3$ ./result/bin/element-desktop
```

And now it works, so I can add this as `security.wrappers.${element-desktop.sandboxExecutableName}` in system-manager.

ref. #89599
ref. #97682


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
