### PR TITLE
motrix-next: 3.9.7 -> 3.9.8

### DIFF
--- a/pkgs/by-name/mo/motrix-next/fix-copy-path.patch
+++ b/pkgs/by-name/mo/motrix-next/fix-copy-path.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/build-native-messaging-launcher.mjs b/scripts/build-native-messaging-launcher.mjs
+index e80f6137fd..1cecabafb6 100644
+--- a/scripts/build-native-messaging-launcher.mjs
++++ b/scripts/build-native-messaging-launcher.mjs
+@@ -26,7 +26,7 @@
+ 
+ execFileSync('cargo', cargoArgs, { cwd: tauriDir, stdio: 'inherit' })
+ 
+-const source = join(tauriDir, 'target', targetTriple, 'release', binaryName)
++const source = join(root, 'target', targetTriple, 'release', binaryName)
+ const destination = join(
+   tauriDir,
+   'generated-binaries',

--- a/pkgs/by-name/mo/motrix-next/package.nix
+++ b/pkgs/by-name/mo/motrix-next/package.nix
@@ -4,7 +4,7 @@
   rustPlatform,
   fetchFromGitHub,
   cargo-tauri,
-  pnpm_10,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -21,20 +21,20 @@
   nix-update-script,
 }:
 let
-  pnpm = pnpm_10;
+  pnpm = pnpm_11;
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "motrix-next";
-  version = "3.9.7";
+  version = "3.9.8";
 
   src = fetchFromGitHub {
     owner = "AnInsomniacy";
     repo = "motrix-next";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-REB89vOrNKyqH39OVd/jQonDvuIIYpm5rrBYg6w6Vq8=";
+    hash = "sha256-Xg8atHZfz0qiVMyxJGzUhxkfJxxC6bkEMxXM/KOE1Tg=";
   };
 
-  cargoHash = "sha256-mffAas2SsiEL/IXYIsToe/hnMywsaRadEUEwIHOKZBo=";
+  cargoHash = "sha256-ebwJq2r7Akz8f01dtMglMPpaDs7KRqS74/TU2ypU1hw=";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs)
@@ -43,8 +43,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       src
       ;
     inherit pnpm;
-    hash = "sha256-hdoXnfM+dn+I5T7EMklUB1L1FvywaI6hGpRGSQYkQvY=";
-    fetcherVersion = 3;
+    hash = "sha256-niT70XdE31nZhPU+053Er5mO1XpoVI51B2jrMR2SqJ4=";
+    fetcherVersion = 4;
   };
 
   nativeBuildInputs = [
@@ -59,6 +59,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     moreutils
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  patches = [ ./fix-copy-path.patch ];
 
   # we don't want to wrap aria2c
   dontWrapGApps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/AnInsomniacy/motrix-next/releases/tag/v3.9.8
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
