### PR TITLE
mediaharbor: set meta.platforms

### DIFF
--- a/pkgs/by-name/me/mediaharbor/package.nix
+++ b/pkgs/by-name/me/mediaharbor/package.nix
@@ -103,5 +103,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ idkdontaskm3 ];
     mainProgram = "mediaharbor";
+    platforms = [
+      "x86_64-linux"
+    ];
   };
 })


### PR DESCRIPTION
The installPhase uses `x86_64-unknown-linux-gnu`, so this package cannot build on other platforms.

```console
> hydra-check mediaharbor --arch aarch64-linux
Build Status for nixpkgs.mediaharbor.aarch64-linux on jobset nixos/unstable
https://hydra.nixos.org/job/nixos/unstable/nixpkgs.mediaharbor.aarch64-linux
✖ (Failed)  mediaharbor-2.1.0  2026-09-07  https://hydra.nixos.org/build/344947415
✖ (Failed)  mediaharbor-2.1.0  2026-08-31  https://hydra.nixos.org/build/344106269
```

https://github.com/NixOS/nixpkgs/blob/ab2c1b9ed105fea891a6b914c445071fd9df822d/pkgs/by-name/me/mediaharbor/package.nix#L94-L98

```
Running phase: installPhase
install: cannot stat 'target/x86_64-unknown-linux-gnu/release/mediaharbor': No such file or directory
```

The package description says this project is ideally cross-platform.
If so, using `meta.broken` might be better for this case.
@idkdontaskm3 What do you think about this?

I just want to reduce nixpkgs-review failures from `typescript` package rebuilds.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
