### PR TITLE
tests.fetchRepoProject: init

### DIFF
--- a/pkgs/build-support/fetchrepoproject/tests.nix
+++ b/pkgs/build-support/fetchrepoproject/tests.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  testers,
+  fetchRepoProject,
+  ...
+}:
+
+{
+  # fetch repo by git rev
+  manifest-demo-by-rev = testers.invalidateFetcherByDrvHash fetchRepoProject {
+    name = "manifest-demo-git-repo-by-rev";
+    manifest = "https://github.com/iayanpahwa/manifest-demo.git";
+    rev = "6f731a3dd689d58333e53e259cd3b7d2242a4dc8";
+    hash = "sha256-cMEvM9lqi8Zl/cFLnTHYv/VVxTzBTHkvhs+jp5U7M/g=";
+  };
+
+  # fetch repo by tag
+  sel4test-by-tag = testers.invalidateFetcherByDrvHash fetchRepoProject {
+    name = "sel4test-by-tag";
+    manifest = "https://github.com/seL4/sel4test-manifest.git";
+    rev = "refs/tags/16.0.0";
+    hash = "sha256-W2vOPWpbcgYPdo+Ife2ddFi3Xpe5Q9jjYqUJd31NQBA=";
+  };
+
+  # use different manifest in repo
+  sel4test-manifestName = testers.invalidateFetcherByDrvHash fetchRepoProject {
+    name = "sel4test-manifestName";
+    manifest = "https://github.com/seL4/sel4test-manifest.git";
+    manifestName = "master.xml";
+    rev = "refs/tags/16.0.0";
+    hash = "sha256-H8hxCCa4etdh8+4dSA91mr7BnqvaJsK3Bdik9dx3vSI=";
+  };
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -148,6 +148,7 @@ in
   fetchDebianPatch = recurseIntoAttrs (callPackages ../build-support/fetchdebianpatch/tests.nix { });
   fetchzip = recurseIntoAttrs (callPackages ../build-support/fetchzip/tests.nix { });
   fetchgit = recurseIntoAttrs (callPackages ../build-support/fetchgit/tests.nix { });
+  fetchRepoProject = recurseIntoAttrs (callPackages ../build-support/fetchrepoproject/tests.nix { });
   fetchNextcloudApp = recurseIntoAttrs (
     callPackages ../build-support/fetchnextcloudapp/tests.nix { }
   );


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
