### PR TITLE
tgrep: init at 1.0.4

### DIFF
--- a/pkgs/by-name/tg/tgrep/package.nix
+++ b/pkgs/by-name/tg/tgrep/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  git,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tgrep";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "tgrep";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-t+gtDMpoxuRN2K6xeztNcOJMuc4eGnF8H3sacN21UF4=";
+  };
+
+  cargoHash = "sha256-Vtqx76DHnsP6gexjTPj0hfCGHnS5yQ5xM+7RbgwrzAA=";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  cargoBuildFlags = [
+    "--package"
+    "tgrep-cli"
+  ];
+  cargoTestFlags = [
+    "--package"
+    "tgrep-cli"
+  ];
+  cargoInstallFlags = [
+    "--path"
+    "tgrep-cli"
+  ];
+
+  # Most integration tests spawn `tgrep serve` and talk to it over 127.0.0.1 TCP, and the watcher tests rely on FSEvents; neither is available in the darwin sandbox.
+  doCheck = !stdenv.hostPlatform.isDarwin;
+  nativeCheckInputs = [ git ];
+  # test expects stdout to not be a tty, but the nix sandbox attaches a pty
+  checkFlags = [
+    "--skip"
+    "search::tests::stats_requests_match_detail_so_spans_are_available_to_count"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    PATH="$out/bin:$PATH"
+    mkdir -p "$TMPDIR/tgrep-install-check"
+    pushd "$TMPDIR/tgrep-install-check"
+    echo "the quick brown fox jumps over the lazy dog" > ./file.txt
+    tgrep index .
+    tgrep --color never "brown f.x" . | grep "the quick brown fox jumps over the lazy dog"
+    popd
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Trigram-indexed grep with a client/server architecture for fast regex search in large codebases";
+    homepage = "https://github.com/microsoft/tgrep";
+    changelog = "https://github.com/microsoft/tgrep/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xiaoxiangmoe ];
+    mainProgram = "tgrep";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
