### PR TITLE
mediaharbor: drop unused typescript_7 from nativeBuildInputs

### DIFF
--- a/pkgs/by-name/me/mediaharbor/package.nix
+++ b/pkgs/by-name/me/mediaharbor/package.nix
@@ -20,7 +20,6 @@
   pango,
   pkg-config,
   rustPlatform,
-  typescript_7,
   webkitgtk_4_1,
   wrapGAppsHook4,
   zlib,
@@ -59,7 +58,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     nodejs
     npmHooks.npmConfigHook
     pkg-config
-    typescript_7
     wrapGAppsHook4
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The `tsc` command runs through `npm run build:react`:
https://github.com/MediaHarbor/mediaharbor/blob/v2.1.0/package.json#L7

https://github.com/NixOS/nixpkgs/blob/d89242dbcdb5f94ae2d1bfdb43bc0c198c99e771/pkgs/by-name/me/mediaharbor/package.nix#L88-L90

The dashboard opens even after this change.

```bash
> nix run .#mediaharbor
```

<img width="2532" height="1584" alt="image" src="https://github.com/user-attachments/assets/06836cc5-2345-4c88-b675-fdb0e05e3985" />

cc: @idkdontaskm3 @wegank

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux # See https://github.com/NixOS/nixpkgs/pull/560951
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
