### PR TITLE
brave{,-origin}: switch to dmg; don't strip on darwin

### DIFF
--- a/pkgs/applications/networking/browsers/brave/make-brave.nix
+++ b/pkgs/applications/networking/browsers/brave/make-brave.nix
@@ -71,7 +71,7 @@
   libxcb,
   zlib,
   # Darwin dependencies
-  unzip,
+  undmg,
   makeWrapper,
   # command line arguments which are always set e.g "--disable-gpu"
   commandLineArgs ? "",
@@ -194,6 +194,7 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
   dontPatchELF = true;
+  dontStrip = stdenv.hostPlatform.isDarwin;
   doInstallCheck = stdenv.hostPlatform.isLinux;
 
   nativeBuildInputs =
@@ -204,7 +205,7 @@ stdenv.mkDerivation {
       (buildPackages.wrapGAppsHook3.override { makeWrapper = buildPackages.makeShellWrapper; })
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      unzip
+      undmg
       makeWrapper
     ];
 

--- a/pkgs/applications/networking/browsers/brave/packages/brave-origin.nix
+++ b/pkgs/applications/networking/browsers/brave/packages/brave-origin.nix
@@ -14,8 +14,8 @@ rec {
       sha256 = "0f76ec5f00413954355c19b0d6633b618ac4418afed333e14ece980c6b6b1495";
     };
     aarch64-darwin = {
-      url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-origin-v${version}-darwin-arm64.zip";
-      sha256 = "223a57405f4beffa62191ec8c3da4dc57f22fe97bd40cb5a7e436f8090e410a4";
+      url = "https://github.com/brave/brave-browser/releases/download/v${version}/Brave-Origin-arm64.dmg";
+      sha256 = "471eb0ec7e7ee7cd28a23c2c0ee5eebee4b621854f8966b2b45cc28e88332ecb";
     };
   };
 }

--- a/pkgs/applications/networking/browsers/brave/packages/brave.nix
+++ b/pkgs/applications/networking/browsers/brave/packages/brave.nix
@@ -13,8 +13,8 @@ rec {
       sha256 = "21d7ac36b64a408dc598bb6ec3db84b07b2cbca854d26b28055a2fb5b94a2e77";
     };
     aarch64-darwin = {
-      url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-v${version}-darwin-arm64.zip";
-      sha256 = "a92bb8dafc02bd386654e0149e386c816474b7e40bdf52b1d4d9723911df08df";
+      url = "https://github.com/brave/brave-browser/releases/download/v${version}/Brave-Browser-arm64.dmg";
+      sha256 = "fdb8af6099d91ec3813c93d9cc1bcb6e59ee1b9fde97e0a94283e4ed6c5db3b5";
     };
   };
 }

--- a/pkgs/applications/networking/browsers/brave/update.py
+++ b/pkgs/applications/networking/browsers/brave/update.py
@@ -8,12 +8,12 @@ download_urls = {
     "brave": {
         "aarch64-linux": "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_arm64.deb",
         "x86_64-linux": "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb",
-        "aarch64-darwin": "https://github.com/brave/brave-browser/releases/download/v${version}/brave-v${version}-darwin-arm64.zip",
+        "aarch64-darwin": "https://github.com/brave/brave-browser/releases/download/v${version}/Brave-Browser-arm64.dmg",
     },
     "brave-origin": {
         "aarch64-linux": "https://github.com/brave/brave-browser/releases/download/v${version}/brave-origin_${version}_arm64.deb",
         "x86_64-linux": "https://github.com/brave/brave-browser/releases/download/v${version}/brave-origin_${version}_amd64.deb",
-        "aarch64-darwin": "https://github.com/brave/brave-browser/releases/download/v${version}/brave-origin-v${version}-darwin-arm64.zip",
+        "aarch64-darwin": "https://github.com/brave/brave-browser/releases/download/v${version}/Brave-Origin-arm64.dmg",
     },
 }
 


### PR DESCRIPTION
On MacOS 27, only Brave apps with original Team ID signatures will be
allowed to access their default datadir.

ZIP archives don't have proper signatures, so we switch to dmg here.
Plus disable stripping - it was actually nearly useless anyway, saving
~0.5MB in package size (~0.12%).

Fixes #541861


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
