### PR TITLE
nixos-rebuild-ng: replace get_generations with a shell-based approach

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/get_generations.sh
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/get_generations.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# Return generations from target Nix profile in a JSON-lines(ish) format.
+# Example:
+# $ ./get_generations.sh /nix/var/nix/profiles/system
+# {"id":642,"timestamp":"2026-09-06 11:57:05","current":false}
+# {"id":643,"timestamp":"2026-09-06 13:01:11","current":false}
+# {"id":644,"timestamp":"2026-09-06 18:59:37","current":false}
+# {"id":645,"timestamp":"2026-09-07 18:17:07","current":true}
+
+profile="$1"
+
+if [ ! -L "$profile" ]; then
+  printf "no profile '%s' found" "$profile" >&2
+  exit 1
+fi
+
+dir="${profile%/*}"
+name="${profile##*/}"
+
+current="$(readlink "$profile")"
+current="${current##*/}"
+
+for path in "$dir"/"$name"-*-link; do
+  [ -L "$path" ] || continue
+
+  basename="${path##*/}"
+  id="${basename#"$name"-}"
+  id="${id%-link}"
+
+  # Use birth time if available, otherwise fallback to
+  # creation time
+  # https://github.com/NixOS/nixpkgs/issues/435555
+  # shellcheck disable=SC2046
+  set -- $(stat -L -c '%W %Z' "$path")
+  btime="$1"
+  ctime="$2"
+
+  if [ "$btime" -ne 0 ]; then
+    creation_time="$btime"
+  else
+    creation_time="$ctime"
+  fi
+
+  timestamp="$(date -d "@$creation_time" '+%Y-%m-%d %H:%M:%S')"
+
+  if [ "$basename" = "$current" ]; then
+    is_current=true
+  else
+    is_current=false
+  fi
+
+  printf '{"id":%d,"timestamp":"%s","current":%s}\n' \
+    "$id" \
+    "$timestamp" \
+    "$is_current"
+done

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -10,7 +10,6 @@ from importlib.resources import files
 from pathlib import Path
 from string import Template
 from subprocess import PIPE, CalledProcessError
-from textwrap import dedent
 from typing import Final, Literal
 
 from . import tmpdir
@@ -31,7 +30,11 @@ from .process import run_wrapper, ssh_default_opts
 from .utils import Args, dict_to_flags
 
 local_tz: Final = datetime.now().astimezone().tzinfo
+logger: Final = logging.getLogger(__name__)
 
+GET_GENERATIONS_SCRIPT: Final = (
+    files(__package__).joinpath("get_generations.sh").read_text()
+)
 FLAKE_FLAGS: Final = ["--extra-experimental-features", "nix-command flakes"]
 FLAKE_REPL_TEMPLATE: Final = "repl.nix.template"
 SWITCH_TO_CONFIGURATION_CMD_PREFIX: Final = [
@@ -51,7 +54,6 @@ SWITCH_TO_CONFIGURATION_CMD_PREFIX: Final = [
     "--service-type=exec",
     "--unit=nixos-rebuild-switch-to-configuration",
 ]
-logger: Final = logging.getLogger(__name__)
 
 
 def build(
@@ -423,75 +425,30 @@ def get_nixpkgs_rev(nixpkgs_path: Path | None) -> str | None:
         return None
 
 
-def get_generations(profile: Profile) -> list[Generation]:
+def get_generations(
+    profile: Profile,
+    target_host: Remote | None = None,
+) -> list[Generation]:
     """Get all NixOS generations from profile.
 
     Includes generation ID (e.g.: 1, 2), timestamp (e.g.: when it was created)
     and if this is the current active profile or not.
     """
-    if not profile.path.exists():
-        raise NixOSRebuildError(f"no profile '{profile.name}' found")
 
-    def parse_path(path: Path, profile: Profile) -> Generation:
-        entry_id = path.name.split("-")[1]
-        current = path.name == profile.path.readlink().name
-        timestamp = datetime.fromtimestamp(
-            timestamp=path.stat().st_ctime,
-            tz=local_tz,
-        ).strftime("%Y-%m-%d %H:%M:%S")
-
-        return Generation(
-            id=int(entry_id),
-            timestamp=timestamp,
-            current=current,
+    try:
+        r = run_wrapper(
+            ["sh", "-c", GET_GENERATIONS_SCRIPT, "get-generations", profile.path],
+            capture_output=True,
+            remote=target_host,
         )
+    except CalledProcessError as ex:
+        # Capture the CalledProcessError and re-raise here as NixOSRebuildError,
+        # otherwise the default error handling will make this error too verbose
+        raise NixOSRebuildError(ex.stderr) from ex
 
     return sorted(
-        [
-            parse_path(p, profile)
-            for p in profile.path.parent.glob(f"{profile.name}-*-link")
-        ],
-        key=lambda d: d.id,
-    )
-
-
-def get_generations_from_nix_env(
-    profile: Profile,
-    target_host: Remote | None = None,
-    elevate: Elevator = NO_ELEVATOR,
-) -> list[Generation]:
-    """Get all NixOS generations from profile with nix-env. Needs root.
-
-    Includes generation ID (e.g.: 1, 2), timestamp (e.g.: when it was created)
-    and if this is the current active profile or not.
-    """
-    if not profile.path.exists():
-        raise NixOSRebuildError(f"no profile '{profile.name}' found")
-
-    # Using `nix-env --list-generations` needs root to lock the profile
-    r = run_wrapper(
-        ["nix-env", "-p", profile.path, "--list-generations"],
-        stdout=PIPE,
-        remote=target_host,
-        elevate=elevate,
-    )
-
-    def parse_line(line: str) -> Generation:
-        parts = line.split()
-
-        entry_id = parts[0]
-        timestamp = f"{parts[1]} {parts[2]}"
-        current = "(current)" in parts
-
-        return Generation(
-            id=int(entry_id),
-            timestamp=timestamp,
-            current=current,
-        )
-
-    return sorted(
-        [parse_line(line) for line in r.stdout.splitlines()],
-        key=lambda d: d.id,
+        (Generation(**json.loads(line)) for line in r.stdout.splitlines()),
+        key=lambda generation: generation.id,
     )
 
 
@@ -639,12 +596,9 @@ def rollback(profile: Profile, target_host: Remote | None, elevate: Elevator) ->
 def rollback_temporary_profile(
     profile: Profile,
     target_host: Remote | None,
-    elevate: Elevator,
 ) -> Path | None:
     "Rollback a temporary Nix profile, like one created by `nixos-rebuild test`."
-    generations = get_generations_from_nix_env(
-        profile, target_host=target_host, elevate=elevate
-    )
+    generations = get_generations(profile, target_host=target_host)
     previous_gen_id = None
     for generation in generations:
         if not generation.current:
@@ -672,7 +626,7 @@ def set_profile(
             check=False,
         )
         if r.returncode:
-            msg = dedent(
+            msg = textwrap.dedent(
                 # the lowercase for the first letter below is proposital
                 f"""
                     your NixOS configuration path seems to be missing essential files.

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -135,7 +135,6 @@ def _rollback_system(
             maybe_path_to_config = nix.rollback_temporary_profile(
                 profile,
                 target_host,
-                elevate=args.elevator,
             )
             if maybe_path_to_config:
                 path_to_config = maybe_path_to_config

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/pyproject.toml
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/pyproject.toml
@@ -10,7 +10,7 @@ version = "0.0.0"
 nixos-rebuild = "nixos_rebuild:main"
 
 [tool.setuptools.package-data]
-nixos_rebuild = ["*.nix.template"]
+nixos_rebuild = ["get_generations.sh", "*.nix.template"]
 
 [tool.mypy]
 files = ["nixos_rebuild", "tests"]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -1447,14 +1447,14 @@ def test_execute_test_rollback(
     mock_run: Mock,
 ) -> None:
     def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
-        if args[0] == "nix-env":
+        if args[0] == "sh":
             return CompletedProcess(
                 [],
                 0,
                 stdout=textwrap.dedent("""\
-                2082   2024-11-07 22:58:56
-                2083   2024-11-07 22:59:41
-                2084   2024-11-07 23:54:17   (current)
+                {"id":642,"timestamp":"2026-09-06 11:57:05","current":false}
+                {"id":643,"timestamp":"2026-09-06 13:01:11","current":false}
+                {"id":644,"timestamp":"2026-09-06 18:59:37","current":true}
                 """),
             )
         elif (args[0] == "nix-instantiate" and "nixos-system" in args) or args[
@@ -1474,14 +1474,21 @@ def test_execute_test_rollback(
     mock_run.assert_has_calls(
         [
             call(
+                ["nix-instantiate", "--find-file", "nixos-system"],
+                check=False,
+                capture_output=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
                 [
-                    "nix-env",
-                    "-p",
+                    "sh",
+                    "-c",
+                    nr.nix.GET_GENERATIONS_SCRIPT,
+                    "get-generations",
                     Path("/nix/var/nix/profiles/system-profiles/foo"),
-                    "--list-generations",
                 ],
                 check=True,
-                stdout=PIPE,
+                capture_output=True,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(
@@ -1492,7 +1499,7 @@ def test_execute_test_rollback(
             call(
                 [
                     Path(
-                        "/nix/var/nix/profiles/system-profiles/foo-2083-link/bin/switch-to-configuration"
+                        "/nix/var/nix/profiles/system-profiles/foo-643-link/bin/switch-to-configuration"
                     ),
                     "test",
                 ],

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -521,53 +521,6 @@ def test_get_generations_with_profile(tmp_path: Path) -> None:
     ]
 
 
-def test_get_generations_from_nix_env(tmp_path: Path) -> None:
-    path = tmp_path / "test"
-    path.touch()
-    return_value = CompletedProcess(
-        [],
-        0,
-        stdout=textwrap.dedent("""\
-        2082   2024-11-07 22:58:56
-        2083   2024-11-07 22:59:41
-        2084   2024-11-07 23:54:17   (current)
-        """),
-    )
-
-    with patch(
-        get_qualified_name(n.run_wrapper, n), autospec=True, return_value=return_value
-    ) as mock_run:
-        assert n.get_generations_from_nix_env(m.Profile("system", path)) == [
-            m.Generation(id=2082, current=False, timestamp="2024-11-07 22:58:56"),
-            m.Generation(id=2083, current=False, timestamp="2024-11-07 22:59:41"),
-            m.Generation(id=2084, current=True, timestamp="2024-11-07 23:54:17"),
-        ]
-        mock_run.assert_called_with(
-            ["nix-env", "-p", path, "--list-generations"],
-            stdout=PIPE,
-            remote=None,
-            elevate=e.NO_ELEVATOR,
-        )
-
-    remote = m.Remote("user@host", [], "ssh")
-    with patch(
-        get_qualified_name(n.run_wrapper, n), autospec=True, return_value=return_value
-    ) as mock_run:
-        assert n.get_generations_from_nix_env(
-            m.Profile("system", path), remote, SUDO
-        ) == [
-            m.Generation(id=2082, current=False, timestamp="2024-11-07 22:58:56"),
-            m.Generation(id=2083, current=False, timestamp="2024-11-07 22:59:41"),
-            m.Generation(id=2084, current=True, timestamp="2024-11-07 23:54:17"),
-        ]
-        mock_run.assert_called_with(
-            ["nix-env", "-p", path, "--list-generations"],
-            stdout=PIPE,
-            remote=remote,
-            elevate=SUDO,
-        )
-
-
 @patch(
     get_qualified_name(n.get_generations),
     autospec=True,
@@ -687,47 +640,25 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
             [],
             0,
             stdout=textwrap.dedent("""\
-                2082   2024-11-07 22:58:56
-                2083   2024-11-07 22:59:41
-                2084   2024-11-07 23:54:17   (current)
+                {"id":642,"timestamp":"2026-09-06 11:57:05","current":false}
+                {"id":643,"timestamp":"2026-09-06 13:01:11","current":false}
+                {"id":644,"timestamp":"2026-09-06 18:59:37","current":true}
                 """),
         )
         assert (
-            n.rollback_temporary_profile(m.Profile("system", path), None, e.NO_ELEVATOR)
-            == path.parent / "system-2083-link"
-        )
-        mock_run.assert_called_with(
-            [
-                "nix-env",
-                "-p",
-                path,
-                "--list-generations",
-            ],
-            stdout=PIPE,
-            remote=None,
-            elevate=e.NO_ELEVATOR,
+            n.rollback_temporary_profile(m.Profile("system", path), None)
+            == path.parent / "system-643-link"
         )
 
         target_host = m.Remote("user@localhost", [], "ssh")
         assert (
-            n.rollback_temporary_profile(m.Profile("foo", path), target_host, SUDO)
-            == path.parent / "foo-2083-link"
-        )
-        mock_run.assert_called_with(
-            [
-                "nix-env",
-                "-p",
-                path,
-                "--list-generations",
-            ],
-            stdout=PIPE,
-            remote=target_host,
-            elevate=SUDO,
+            n.rollback_temporary_profile(m.Profile("foo", path), target_host)
+            == path.parent / "foo-643-link"
         )
 
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         mock_run.return_value = CompletedProcess([], 0, stdout="")
-        assert n.rollback_temporary_profile(profile, None, e.NO_ELEVATOR) is None
+        assert n.rollback_temporary_profile(profile, None) is None
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Port the old Python logic to POSIX's shell and remove the usage of `nix-env --list-generations`.

While the original objective of `nixos-rebuild-ng` was to avoid having logic written in shell scripting, the only way to unify the two separate approaches of get_generations was to write this in shell, because we also need to run this remotely, but sadly calling `nix-env --list-generations` needs root (NixOS/nix#5144).

This also fixes a long standing issue of `nix-collect-garbage` causing the `nixos-rebuild list-generations` to report the wrong build-date after a `nix-collect-garbage` or `nix store optimise`.

Fix #435555.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
