### PR TITLE
iconic: 2025.9.1 -> 2026.8.1

### DIFF
--- a/pkgs/by-name/ic/iconic/package.nix
+++ b/pkgs/by-name/ic/iconic/package.nix
@@ -19,27 +19,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "iconic";
-  version = "2025.9.1";
+  version = "2026.8.1";
 
   src = fetchFromGitHub {
     owner = "youpie";
     repo = "Iconic";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vjtPVE+n1p5DB+KewhylA9w1kVkpKyDz0WF5Mrd+BBM=";
+    hash = "sha256-Q6AB3SNqodjRiv9EqjfNHE9MTP+LpnuxG7oyjF4Uzd8=";
   };
 
   postPatch = ''
     substituteInPlace src/windows/file_handling.rs \
-      --replace-fail "/app" "$out"
-    substituteInPlace src/windows/regeneration.rs \
-      --replace-fail "/app" "$out"
-    substituteInPlace src/window.rs \
-      --replace-fail "create_dir" "create_dir_all"
+      --replace-fail '"/app/share/Iconic/folders/"' '"$out/share/Iconic/folders/"'
   '';
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-Ma+ryvDaFfP3BYrtuPPKMVjF2l83xP+T7GlIiOenRAo=";
+    hash = "sha256-l5UpqzgRcM5q7l14b5NAyLuY5QloAA20/0sYrEQA6QE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/youpie/Iconic/releases/tag/v2026.8.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
