### PR TITLE
python3Packages.ufo2ft: clean-up

### DIFF
--- a/pkgs/by-name/ca/cantarell-fonts/package.nix
+++ b/pkgs/by-name/ca/cantarell-fonts/package.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     python3.pkgs.afdko # for otfautohint
     python3.pkgs.cffsubr
     python3.pkgs.ufo2ft
+    python3.pkgs.ufolib2
     python3.pkgs.uharfbuzz
     gettext
   ];

--- a/pkgs/development/python-modules/fontmake/default.nix
+++ b/pkgs/development/python-modules/fontmake/default.nix
@@ -41,7 +41,8 @@ buildPythonPackage rec {
   ]
   ++ fonttools.optional-dependencies.ufo
   ++ fonttools.optional-dependencies.lxml
-  ++ fonttools.optional-dependencies.unicode;
+  ++ fonttools.optional-dependencies.unicode
+  ++ ufo2ft.optional-dependencies.compreffor;
 
   optional-dependencies = {
     pathops = [ skia-pathops ];

--- a/pkgs/development/python-modules/ufo2ft/default.nix
+++ b/pkgs/development/python-modules/ufo2ft/default.nix
@@ -53,18 +53,6 @@ buildPythonPackage (finalAttrs: {
   ++ finalAttrs.passthru.optional-dependencies.compreffor
   ++ finalAttrs.passthru.optional-dependencies.pathops;
 
-  disabledTests = [
-    # Do not depend on skia.
-    "test_removeOverlaps_CFF_pathops"
-    "test_removeOverlaps_pathops"
-    "test_custom_filters_as_argument"
-    "test_custom_filters_as_argument"
-    # Some integration tests fail
-    "test_compileVariableCFF2"
-    "test_compileVariableTTF"
-    "test_drop_glyph_names_variable"
-    "test_drop_glyph_names_variable"
-  ];
   optional-dependencies = {
     compreffor = [ compreffor ];
     cffsubr = [ ];

--- a/pkgs/development/python-modules/ufo2ft/default.nix
+++ b/pkgs/development/python-modules/ufo2ft/default.nix
@@ -4,16 +4,17 @@
   buildPythonPackage,
   cffsubr,
   compreffor,
-  cu2qu,
   defcon,
   fetchFromGitHub,
   fontmath,
   fonttools,
   pytestCheckHook,
+  setuptools,
   setuptools-scm,
   skia-pathops,
   syrupy,
   ufolib2,
+  uharfbuzz,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -29,19 +30,15 @@ buildPythonPackage (finalAttrs: {
   };
 
   build-system = [
+    setuptools
     setuptools-scm
   ];
 
   dependencies = [
-    cu2qu
     fontmath
     fonttools
-    defcon
-    compreffor
     booleanoperations
     cffsubr
-    ufolib2
-    skia-pathops
   ]
   ++ fonttools.optional-dependencies.lxml
   ++ fonttools.optional-dependencies.ufo;
@@ -49,7 +46,12 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     pytestCheckHook
     syrupy
-  ];
+    ufolib2
+    uharfbuzz
+    defcon
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.compreffor
+  ++ finalAttrs.passthru.optional-dependencies.pathops;
 
   disabledTests = [
     # Do not depend on skia.
@@ -63,6 +65,11 @@ buildPythonPackage (finalAttrs: {
     "test_drop_glyph_names_variable"
     "test_drop_glyph_names_variable"
   ];
+  optional-dependencies = {
+    compreffor = [ compreffor ];
+    cffsubr = [ ];
+    pathops = [ skia-pathops ];
+  };
 
   pythonImportsCheck = [ "ufo2ft" ];
 

--- a/pkgs/development/python-modules/ufo2ft/default.nix
+++ b/pkgs/development/python-modules/ufo2ft/default.nix
@@ -16,7 +16,7 @@
   ufolib2,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ufo2ft";
   version = "3.9.0";
   pyproject = true;
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = "ufo2ft";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-McMhpGIvQHpsOe3jza6E3b72cKiY8gr8W9OY2Mg9JvE=";
   };
 
@@ -69,8 +69,8 @@ buildPythonPackage rec {
   meta = {
     description = "Bridge from UFOs to FontTools objects";
     homepage = "https://github.com/googlefonts/ufo2ft";
-    changelog = "https://github.com/googlefonts/ufo2ft/releases/tag/${src.tag}";
+    changelog = "https://github.com/googlefonts/ufo2ft/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jopejoe1 ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
