### PR TITLE
strongswan{NM,TNC,TPM}: disable auto-updates

### DIFF
--- a/pkgs/by-name/st/strongswanNM/package.nix
+++ b/pkgs/by-name/st/strongswanNM/package.nix
@@ -1,0 +1,11 @@
+{
+  strongswan,
+  ...
+}@args:
+# nixpkgs-update: no auto update
+strongswan.override (
+  {
+    enableNetworkManager = true;
+  }
+  // removeAttrs args [ "strongswan" ]
+)

--- a/pkgs/by-name/st/strongswanTNC/package.nix
+++ b/pkgs/by-name/st/strongswanTNC/package.nix
@@ -1,0 +1,11 @@
+{
+  strongswan,
+  ...
+}@args:
+# nixpkgs-update: no auto update
+strongswan.override (
+  {
+    enableTNC = true;
+  }
+  // removeAttrs args [ "strongswan" ]
+)

--- a/pkgs/by-name/st/strongswanTPM/package.nix
+++ b/pkgs/by-name/st/strongswanTPM/package.nix
@@ -1,0 +1,11 @@
+{
+  strongswan,
+  ...
+}@args:
+# nixpkgs-update: no auto update
+strongswan.override (
+  {
+    enableTPM2 = true;
+  }
+  // removeAttrs args [ "strongswan" ]
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2873,10 +2873,6 @@ with pkgs;
 
   stutter = haskell.lib.compose.justStaticExecutables haskellPackages.stutter;
 
-  strongswanTNC = strongswan.override { enableTNC = true; };
-  strongswanTPM = strongswan.override { enableTPM2 = true; };
-  strongswanNM = strongswan.override { enableNetworkManager = true; };
-
   stylish-haskell = haskell.lib.compose.justStaticExecutables haskellPackages.stylish-haskell;
 
   su = shadow.su;


### PR DESCRIPTION
Won't actually work until https://github.com/nix-community/nixpkgs-update/issues/558 is resolved, but useful for whenever that eventually happens.

Closes #560926.
Closes #560925.
Closes #560891.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
