### PR TITLE
mir: 2.28.0 -> 2.29.0

### DIFF
--- a/pkgs/by-name/mi/miracle-wm/package.nix
+++ b/pkgs/by-name/mi/miracle-wm/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   gitUpdater,
   nixosTests,
   boost,
@@ -45,7 +46,21 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-htFgvXYgxQXV2U3F+tXEoaTb0udc2H1aHsIg5E8nRL8=";
   };
 
+  patches = [
+    # Mir 2.29 compat, remove when version > 0.10.1
+    (fetchpatch {
+      name = "0001-miracle-wm-remove-legacy-mir-optional-usage.patch";
+      url = "https://github.com/miracle-wm-org/miracle-wm/commit/a4d7b21e0d25667cd270d7ff52f8dccc2a217796.patch";
+      hash = "sha256-XBbYSuXUOS9Gbs/LwxbbTAVsFuH8xLj8VhoCAjmCDfQ=";
+    })
+  ];
+
+  # Mir 2.29 compat, remove when version > 0.10.1 (97a40cd8879898062b2cf7b5d1f5252ffc3b8dce is more than just a compat change)
   postPatch = ''
+    substituteInPlace src/policy.{cpp,h} \
+      --replace-fail 'handle_raise_window' 'handle_activate_window'
+  ''
+  + ''
     substituteInPlace CMakeLists.txt \
       --replace-fail 'DESTINATION lib' 'DESTINATION ''${CMAKE_INSTALL_LIBDIR}' \
       --replace-fail '-march=native' '# -march=native'

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,9 +5,9 @@ let
 in
 {
   mir = common {
-    version = "2.28.0";
-    hash = "sha256-sSxV20loRXQfGWMI1zAzrAwww00bc/BQqJaFB8whH5E=";
-    cargoHash = "sha256-AHB4OYP2kU47EsutOxYa693pMLgyXuF1p+mLXg2cIGs=";
+    version = "2.29.0";
+    hash = "sha256-jh8Qgr/5Ht0eioLH9ES4M+jZr3RLKHg2YJXX5XzzwEA=";
+    cargoHash = "sha256-VQpLjoKlaoYaSfVVNjxDGJXSlIri4RwETaQJf8faqHQ=";
   };
 
   mir_2_15 = common {


### PR DESCRIPTION
https://github.com/canonical/mir/releases/tag/v2.29.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
