### PR TITLE
python3Packages.redisvl: 0.26.0 -> 0.27.1; python3Packages.redi-om: unbreak

### DIFF
--- a/pkgs/development/python-modules/redis-om/default.nix
+++ b/pkgs/development/python-modules/redis-om/default.nix
@@ -32,6 +32,11 @@ buildPythonPackage rec {
     hash = "sha256-qjGrhEINW9p2Rd3O5WI4QKYcj8tn/FI3pjnhI1k3mmc=";
   };
 
+  pythonRelaxDeps = [
+    "more-itertools"
+    "redis"
+  ];
+
   build-system = [
     hatchling
     unasync

--- a/pkgs/development/python-modules/redisvl/default.nix
+++ b/pkgs/development/python-modules/redisvl/default.nix
@@ -15,19 +15,17 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "redisvl";
-  version = "0.26.0";
+  version = "0.27.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "redis";
     repo = "redis-vl-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-za3ZFvB8/BiQrzjEC2iF33tpAI/l5ghZzoVpN5ISUco=";
+    hash = "sha256-0jrSr3fhYt/ofqNBzFl6DM6fY8BaN7fsrCwwVGmlO0A=";
   };
 
   build-system = [ hatchling ];
-
-  pythonRelaxDeps = [ "redis" ];
 
   dependencies = [
     numpy


### PR DESCRIPTION
Since the `redis-om` bump, both `redis` and `more-ittertools` have been bumped. This breaks the version constraint of `redis-om` and causes a [build failure](https://hydra.nixos.org/job/nixpkgs/unstable/python314Packages.redis-om.x86_64-linux). As [upstreams](https://github.com/redis/redis-om-python/pull/853/changes) [PRs](https://github.com/redis/redis-om-python/pull/854/changes) didn't change anything code-wise, it should be fine just relaxing the dependencies for the time being.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
