### PR TITLE
nixos/nspawn-container: move sandbox workarounds to testing module

### DIFF
--- a/nixos/lib/testing/nodes.nix
+++ b/nixos/lib/testing/nodes.nix
@@ -90,6 +90,19 @@ let
       {
         key = "base-nspawn";
 
+        # systemd-nspawn does some cleverness to mount a procfs and sysfs in an
+        # unprivileged container, see
+        # <https://github.com/systemd/systemd/blob/v258.2/src/nspawn/nspawn.c#L4341-L4349>.
+        # Unfortunately, this doesn't work in the Nix build sandbox as we do not
+        # have permission to mount filesystems of type `sysfs` nor `procfs`.
+        # Fortunately, the build sandbox does provide a `/proc` and `/sys` that
+        # we can just forward onto the container.
+        virtualisation.systemd-nspawn.options = [
+          "--private-users=no"
+          "--bind=/proc:/run/host/proc"
+          "--bind=/sys:/run/host/sys"
+        ];
+
         # PAM requires setuid and doesn't work in the build sandbox.
         # https://github.com/NixOS/nix/blob/959c244a1265f4048390f3ad21679219d7b27a99/src/libstore/unix/build/linux-derivation-builder.cc#L63
         services.openssh.settings.UsePAM = false;

--- a/nixos/modules/virtualisation/nspawn-container/default.nix
+++ b/nixos/modules/virtualisation/nspawn-container/default.nix
@@ -88,17 +88,6 @@ in
       "--machine=${config.system.name}"
       "--bind-ro=/nix/store:/nix/store"
 
-      # systemd-nspawn does some cleverness to mount a procfs and sysfs in an
-      # unprivileged container, see
-      # <https://github.com/systemd/systemd/blob/v258.2/src/nspawn/nspawn.c#L4341-L4349>.
-      # Unfortunately, this doesn't work in the Nix build sandbox as we do not
-      # have permission to mount filesystems of type `sysfs` nor `procfs`.
-      # Fortunately, the build sandbox does provide a `/proc` and `/sys` that
-      # we can just forward onto the container.
-      "--private-users=no"
-      "--bind=/proc:/run/host/proc"
-      "--bind=/sys:/run/host/sys"
-
       # From `man systemd-nspawn`:
       # > Use --keep-unit and --register=no in combination to disable any
       # > kind of unit allocation or registration with systemd-machined.

--- a/nixos/modules/virtualisation/nspawn-container/run-nspawn/src/run_nspawn/__init__.py
+++ b/nixos/modules/virtualisation/nspawn-container/run-nspawn/src/run_nspawn/__init__.py
@@ -229,14 +229,16 @@ def run(
             # "Linux file attributes". Please improve this if you run into this!
             #
             # [0]: https://github.com/NixOS/nixpkgs/blob/d1eff395720e1fe15838263642a2bc1dca1eea32/nixos/modules/system/activation/activation-script.nix#L281
-            subprocess.run(
-                [
-                    "@chattr@",
-                    "-i",
-                    root_dir / "var/empty",
-                ],
-                check=True,
-            )
+            empty_dir = root_dir / "var/empty"
+            if empty_dir.exists():
+                subprocess.run(
+                    [
+                        "@chattr@",
+                        "-i",
+                        empty_dir,
+                    ],
+                    check=True,
+                )
 
         sys.exit(exit_code)
 


### PR DESCRIPTION
Moves the sandbox specific workarounds to the testing module, so generic use of nspawn isn't limited by them.

Also contains a separate small fix for ephemeral container teardown as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Ran a few select nspawn NixOS tests locally (`blocky`, `dashy`, `kea`).

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
