### PR TITLE
civicrm: split core from standalone

### DIFF
--- a/pkgs/by-name/ci/civicrm-core/package.nix
+++ b/pkgs/by-name/ci/civicrm-core/package.nix
@@ -30,7 +30,7 @@ php.buildComposerProject2 (finalAttrs: {
   meta = {
     homepage = "https://civicrm.org/";
     changelog = "https://download.civicrm.org/release/${finalAttrs.version}";
-    description = "Standalone version of CiviCRM, a CRM software for non-profit organizations";
+    description = "Core version of CiviCRM, a CRM software for non-profit organizations";
     license = lib.licenses.agpl3Plus;
     maintainers = [ lib.maintainers.sorooris ];
     mainProgram = "civicrm";

--- a/pkgs/by-name/ci/civicrm-standalone/package.nix
+++ b/pkgs/by-name/ci/civicrm-standalone/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  php,
+  fetchFromGitHub,
+  civicrm-core,
+}:
+php.buildComposerProject2 (finalAttrs: {
+  pname = "civicrm-standalone";
+  version = "1.0.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+  dontUnpack = false;
+
+  src = fetchFromGitHub {
+    owner = "civicrm";
+    repo = "civicrm-standalone";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-P49JDw6MGwhyIsgz8EmgKFuarPS3P4VRV5JnUudiYIg=";
+  };
+
+  vendorHash = "sha256-ninW1PL4d/S6m/04cB68Taj7sru73D8X02KISHZvScw=";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/core $out/private $out/public
+    cp -R $src/. $out/
+    cp -R ${civicrm-core}/. $out/core/
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://civicrm.org/";
+    changelog = "https://download.civicrm.org/release/${finalAttrs.version}";
+    description = "Standalone version of CiviCRM, a CRM software for non-profit organizations";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.sorooris ];
+    mainProgram = "civicrm-standalone";
+  };
+})


### PR DESCRIPTION
Standalone CiviCRM apparently requires Core according to documentation https://docs.civicrm.org/installation/en/latest/standalone/#installer
so as to build properly the package is now being split into separate ones with Standalone depending on Core.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
