### PR TITLE
sdcc: 4.5.0 -> 4.6.0

### DIFF
--- a/pkgs/by-name/gl/glasgow/package.nix
+++ b/pkgs/by-name/gl/glasgow/package.nix
@@ -4,10 +4,14 @@
   fetchFromGitHub,
   icestorm,
   nextpnr,
-  sdcc,
+  sdcc_4_5,
   yosys,
 }:
 
+let
+  # The firmware must match glasgow's checked-in blob byte for byte, so libfx2 needs the same sdcc.
+  fx2 = python3Packages.fx2.override { sdcc = sdcc_4_5; };
+in
 python3Packages.buildPythonApplication rec {
   pname = "glasgow";
   version = "0-unstable-2025-07-25";
@@ -32,19 +36,21 @@ python3Packages.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [
-    sdcc
+    sdcc_4_5
   ];
 
   build-system = [
     python3Packages.pdm-backend
   ];
 
-  dependencies = with python3Packages; [
+  dependencies = [
+    fx2
+  ]
+  ++ (with python3Packages; [
     aiohttp
     amaranth
     cobs
     enum-tools
-    fx2
     importlib-resources
     libusb1
     packaging
@@ -52,7 +58,7 @@ python3Packages.buildPythonApplication rec {
     pyvcd
     typing-extensions
     tqdm
-  ];
+  ]);
 
   nativeCheckInputs = [
     # pytestCheckHook discovers way less tests
@@ -69,10 +75,10 @@ python3Packages.buildPythonApplication rec {
   __darwinAllowLocalNetworking = true;
 
   preBuild = ''
-    make -C firmware/fx2 GIT_TREE_DIRTY=0 GIT_REV_SHORT=${firmwareGitRev} LIBFX2=${python3Packages.fx2}/share/libfx2
+    make -C firmware/fx2 GIT_TREE_DIRTY=0 GIT_REV_SHORT=${firmwareGitRev} LIBFX2=${fx2}/share/libfx2
 
     # Normalize the .ihex file, see ./software/deploy-firmware.sh.
-    ${python3Packages.python.withPackages (p: [ p.fx2 ])}/bin/python firmware/fx2/normalize.py \
+    ${python3Packages.python.withPackages (_: [ fx2 ])}/bin/python firmware/fx2/normalize.py \
       firmware/fx2/build/firmware.ihex firmware/fx2/glasgow.ihex
 
     # Ensure the compiled firmware is exactly the same as the one shipped in the repo.

--- a/pkgs/by-name/sd/sdcc/package.nix
+++ b/pkgs/by-name/sd/sdcc/package.nix
@@ -2,13 +2,10 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
-  autoconf,
   bison,
   boost,
   flex,
   gputils,
-  texinfo,
   zlib,
   withGputils ? false,
   excludePorts ? [ ],
@@ -18,85 +15,67 @@ assert
   lib.subtractLists [
     "ds390"
     "ds400"
-    "gbz80"
+    "ez80"
+    "f8"
+    "f8l"
     "hc08"
     "mcs51"
+    "mos6502"
+    "mos65c02"
+    "pdk13"
+    "pdk14"
+    "pdk15"
     "pic14"
     "pic16"
     "r2k"
+    "r2ka"
     "r3ka"
+    "r4k"
+    "r5k"
+    "r6k"
+    "r800"
     "s08"
+    "sm83"
     "stm8"
     "tlcs90"
-    "z80"
     "z180"
+    "z80"
+    "z80n"
   ] excludePorts == [ ];
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdcc";
-  version = "4.5.0";
+  version = "4.6.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/sdcc/sdcc-src-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-1QMEN/tDa7HZOo29v7RrqqYGEzGPT7P1hx1ygV0e7YA=";
+    hash = "sha256-X9apPlmXzgF1aGj+NeRBCVz7Y3iUqAwmJRSmNAlJc7Y=";
   };
 
-  # TODO: sdcc version 4.5.0 does not currently produce a man output.
-  # Until the fix to sdcc's makefiles is released, this workaround
-  # conditionally withholds the man output on darwin.
-  #
-  # sdcc's tracking issue:
-  # <https://sourceforge.net/p/sdcc/bugs/3848/>
   outputs = [
     "out"
     "doc"
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     "man"
   ];
 
+  strictDeps = true;
   enableParallelBuilding = true;
 
+  # support/cpp is a gcc snapshot, which does not build with format hardening.
+  hardeningDisable = [ "format" ];
+
   nativeBuildInputs = [
-    autoconf
     bison
     flex
+  ]
+  ++ lib.optionals withGputils [
+    # gpasm, gplink and gplib assemble and link the pic14/pic16 device libraries
+    gputils
   ];
 
   buildInputs = [
     boost
-    texinfo
     zlib
-  ]
-  ++ lib.optionals withGputils [
-    gputils
   ];
-
-  patches = [
-    # Fix build with gcc15
-    # https://sourceforge.net/p/sdcc/bugs/3846/
-    (fetchpatch {
-      name = "sdcc-fix-aslink-elf-signature.patch";
-      url = "https://src.fedoraproject.org/rpms/sdcc/raw/4a7c2a7e32369461eb451fc6f4d678a010135afc/f/sdcc-4.4.0-aslink.patch";
-      hash = "sha256-xGilNetecPBj2VV3ebmln5BKqs3OoWFf6y2S3TBTHMQ=";
-    })
-  ];
-
-  # sdcc 4.5.0 massively rewrote sim/ucsim/Makefile.in, and lost the `.PHONY`
-  # rule in the process. As a result, on macOS (which uses a case-insensitive
-  # filesystem), the INSTALL file keeps the `install` target in the ucsim
-  # directory from running. Nothing else creates the `man` output, causing the
-  # entire build to fail.
-  #
-  # TODO: remove this when updating to the next release - it's been fixed in
-  # upstream sdcc r15384 <https://sourceforge.net/p/sdcc/code/15384/>.
-
-  postPatch = ''
-    if grep -q '\.PHONY:.*install' sim/ucsim/Makefile.in; then
-      echo 'Upstream has added `.PHONY: install` rule; must remove `postPatch` from the Nix file.' >&2
-      exit 1
-    fi
-    echo '.PHONY: install' >> sim/ucsim/Makefile.in
-  '';
 
   configureFlags =
     let
@@ -119,12 +98,15 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sdcc.sourceforge.net/";
     description = "Small Device C Compiler";
     longDescription = ''
-      SDCC is a retargettable, optimizing ANSI - C compiler suite that targets
-      the Intel MCS51 based microprocessors (8031, 8032, 8051, 8052, etc.),
-      Maxim (formerly Dallas) DS80C390 variants, Freescale (formerly Motorola)
-      HC08 based (hc08, s08) and Zilog Z80 based MCUs (z80, z180, gbz80, Rabbit
-      2000/3000, Rabbit 3000A). Work is in progress on supporting the Microchip
-      PIC16 and PIC18 targets. It can be retargeted for other microprocessors.
+      SDCC is a free open source, retargettable, optimizing ISO C compiler suite
+      that targets a growing list of processors including the Intel MCS-51 based
+      microprocessors (8031, 8032, 8051, 8052, etc.), Maxim (formerly Dallas)
+      DS80C390 variants, Freescale (formerly Motorola) HC08 based (hc08, s08),
+      Zilog Z80 based MCUs (Z80, Z80N, Z180, SM83 (e.g. Game Boy), Rabbit 2000,
+      Rabbit 2000A/3000, Rabbit 3000A, TLCS-90, R800), STMicroelectronics STM8,
+      Padauk PDK14 and PDK15 and MOS 6502. Work is in progress on supporting the
+      Padauk PDK13 target. There are unmaintained Microchip PIC16 and PIC18
+      targets. It can be retargeted for other microprocessors.
     '';
     license = if withGputils then lib.licenses.unfreeRedistributable else lib.licenses.gpl2Plus;
     mainProgram = "sdcc";

--- a/pkgs/by-name/sd/sdcc_4_5/package.nix
+++ b/pkgs/by-name/sd/sdcc_4_5/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  sdcc,
+  fetchurl,
+  fetchpatch,
+  autoconf,
+  texinfo,
+}:
+
+sdcc.overrideAttrs (
+  finalAttrs: prevAttrs: {
+    __structuredAttrs = true;
+
+    version = "4.5.0";
+
+    src = fetchurl {
+      url = "mirror://sourceforge/sdcc/sdcc-src-${finalAttrs.version}.tar.bz2";
+      hash = "sha256-1QMEN/tDa7HZOo29v7RrqqYGEzGPT7P1hx1ygV0e7YA=";
+    };
+
+    outputs = [
+      "out"
+      "doc"
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      "man"
+    ];
+
+    nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [
+      autoconf
+      texinfo
+    ];
+
+    patches = [
+      # Fix build with gcc15
+      # https://sourceforge.net/p/sdcc/bugs/3846/
+      (fetchpatch {
+        name = "sdcc-fix-aslink-elf-signature.patch";
+        url = "https://src.fedoraproject.org/rpms/sdcc/raw/4a7c2a7e32369461eb451fc6f4d678a010135afc/f/sdcc-4.4.0-aslink.patch";
+        hash = "sha256-xGilNetecPBj2VV3ebmln5BKqs3OoWFf6y2S3TBTHMQ=";
+      })
+    ];
+
+    postPatch = ''
+      echo '.PHONY: install' >> sim/ucsim/Makefile.in
+    '';
+  }
+)


### PR DESCRIPTION
Release announcement: https://sdcc.sourceforge.net/index.php#News

We still need to keep 4.5.0 for fx2 and (downstream) glasgow, until it's updated upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
