### PR TITLE
esptool: 5.3.1 -> 5.4.0

### DIFF
--- a/pkgs/by-name/es/esptool/package.nix
+++ b/pkgs/by-name/es/esptool/package.nix
@@ -9,14 +9,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "esptool";
-  version = "5.3.1";
+  version = "5.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oHQ6rkMnzvjtP/dg+tyc7Dw+D/WuWDqRwqePKBBnjCw=";
+    hash = "sha256-oQdRwPQvIqK9m5h1Tah+1ltSHD4KQ4xf1rTXDhxv2+o=";
   };
 
   postPatch = ''
@@ -30,16 +30,22 @@ python3Packages.buildPythonApplication (finalAttrs: {
     setuptools
   ];
 
-  dependencies = with python3Packages; [
-    bitstring
-    click
-    cryptography
-    intelhex
-    pyserial
-    pyyaml
-    reedsolo
-    rich-click
-  ];
+  dependencies =
+    with python3Packages;
+    [
+      bitstring
+      click
+      cryptography
+      esp-pylib
+      intelhex
+      pyserial
+      pyyaml
+      reedsolo
+      rich-click
+    ]
+    ++ esp-pylib.optional-dependencies.cli
+    ++ esp-pylib.optional-dependencies.ide
+    ++ esp-pylib.optional-dependencies.serial;
 
   optional-dependencies = with python3Packages; {
     hsm = [ python-pkcs11 ];

--- a/pkgs/development/python-modules/esp-pylib/default.nix
+++ b/pkgs/development/python-modules/esp-pylib/default.nix
@@ -1,0 +1,59 @@
+{
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  lib,
+  pyserial,
+  pytestCheckHook,
+  rich,
+  rich-click,
+  setuptools,
+  websockets,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "esp-pylib";
+  version = "1.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "esp-pylib";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-anos6sLybT6HQXslFpmRl6+0gF1OjrQqe3UAPbgcTYI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    rich
+  ];
+
+  optional-dependencies = {
+    cli = [
+      click
+      rich-click
+    ];
+    ide = [
+      websockets
+    ];
+    serial = [
+      pyserial
+    ];
+  };
+
+  pythonImportsCheck = [ "esp_pylib" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  meta = {
+    changelog = "https://github.com/espressif/esp-pylib/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Python library for logging, utils and constants for Espressif Systems' Python projects";
+    homepage = "https://github.com/espressif/esp-pylib";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5609,6 +5609,8 @@ self: super: with self; {
 
   esp-idf-size = callPackage ../development/python-modules/esp-idf-size { };
 
+  esp-pylib = callPackage ../development/python-modules/esp-pylib { };
+
   espeak-phonemizer = callPackage ../development/python-modules/espeak-phonemizer { };
 
   esper = callPackage ../development/python-modules/esper { };


### PR DESCRIPTION
Diff: https://github.com/espressif/esptool/compare/v5.3.1...v5.4.0

Changelog: https://github.com/espressif/esptool/blob/v5.4.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
