### PR TITLE
dockerTools: use nix through nativeBuildInputs

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -71,9 +71,7 @@ let
       # A user is required by nix
       # https://github.com/NixOS/nix/blob/9348f9291e5d9e4ba3c4347ea1b235640f54fd79/src/libutil/util.cc#L478
       export USER=nobody
-      ${lib.getExe' buildPackages.nix "nix-store"} --load-db < ${
-        closureInfo { rootPaths = contentsList; }
-      }/registration
+      nix-store --load-db < ${closureInfo { rootPaths = contentsList; }}/registration
       # Reset registration times to make the image reproducible
       ${lib.getExe buildPackages.sqlite} nix/var/nix/db/db.sqlite "UPDATE ValidPaths SET registrationTime = ''${SOURCE_DATE_EPOCH}"
 
@@ -430,6 +428,7 @@ rec {
       keepContentsDirlinks ? false,
       # Additional commands to run on the layer before it is tar'd up.
       extraCommands ? "",
+      nativeBuildInputs ? [ ],
       uid ? 0,
       gid ? 0,
     }:
@@ -441,7 +440,8 @@ rec {
           jshon
           rsync
           tarsum
-        ];
+        ]
+        ++ nativeBuildInputs;
       }
       ''
         mkdir layer
@@ -705,6 +705,7 @@ rec {
               uid
               gid
               ;
+            nativeBuildInputs = optionals includeNixDB [ nix ];
             extraCommands = extraCommandsWithDB;
             copyToRoot = rootContents;
           }
@@ -1082,6 +1083,9 @@ rec {
         ]
         ++ optionals enableFakechroot [
           proot
+        ]
+        ++ optionals includeNixDB [
+          nix
         ];
         postBuild = ''
           mv $out old_out


### PR DESCRIPTION
It works much the same, but allows nix as a whole to be overridden. The only build time difference is that it now uses PATH, and that's ok.

Tested with the following, but to make it work (fail) I needed to hack around how `examples` was wired up.
```nix
(dockerTools.override { nix = abort "nix!"; }).examples.nix-layered
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
    - [x] dockerTools
    - [x] dockerTools-cross
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
