### PR TITLE
nixos/tests/gocron: fix flakiness

### DIFF
--- a/nixos/tests/gocron.nix
+++ b/nixos/tests/gocron.nix
@@ -4,43 +4,53 @@
   name = "gocron";
   meta.maintainers = with pkgs.lib.maintainers; [ juliusfreudenberger ];
 
-  nodes.machine =
-    { pkgs, ... }:
-    {
-      environment.systemPackages = [ pkgs.jq ];
-      services.gocron = {
-        enable = true;
-        settings = {
-          jobs = [
-            {
-              name = "Test job";
-              disabled_cron = true;
-              commands = [
-                "echo 'Job runs successfully'"
-              ];
-            }
-          ];
-        };
+  nodes.machine = {
+    services.gocron = {
+      enable = true;
+      settings = {
+        jobs = [
+          {
+            name = "Test job";
+            disabled_cron = true;
+            commands = [
+              "echo 'Job runs successfully'"
+            ];
+          }
+        ];
       };
     };
+  };
 
   testScript = ''
+    import json
+
+    STATUS_RUNNING = 1
+    STATUS_SUCCESSFUL = 3
+
     def gocron_is_up(_) -> bool:
       status, _ = machine.execute("curl --fail http://localhost:8156")
       return status == 0
 
     def job_is_available() -> bool:
-      status, output = machine.execute("curl http://localhost:8156/api/jobs | jq '. | length'")
-      return status == 0 and int(output) == 1
+      output = machine.succeed("curl -s http://localhost:8156/api/jobs")
+      return len(json.loads(output)) == 1
 
     def start_job():
       machine.succeed("curl -X POST http://localhost:8156/api/jobs/test-job")
 
+    def get_last_run():
+      output = machine.succeed("curl -s http://localhost:8156/api/runs/test-job")
+      runs = json.loads(output)
+      return runs[0] if runs else None
+
+    def job_has_finished(_) -> bool:
+      run = get_last_run()
+      return run is not None and run["status_id"] != STATUS_RUNNING
+
     def job_ran_successfully() -> bool:
-      output = machine.succeed("curl http://localhost:8156/api/runs/test-job | jq '.[0].status_id, .[0].logs.[2].message'")
-      split_output = output.split('\n')
-      ran_successfully = int(split_output[0]) == 3
-      log_message_as_expected = "Job runs not successfully" in split_output[1]
+      run = get_last_run()
+      ran_successfully = run["status_id"] == STATUS_SUCCESSFUL
+      log_message_as_expected = "Job runs successfully" in run["logs"][2]["message"]
       return ran_successfully and log_message_as_expected
 
     machine.wait_for_unit("gocron.service")
@@ -50,9 +60,12 @@
 
     with machine.nested("Test job"):
       if not job_is_available():
+        print("Cron job is not available")
         exit(1)
       start_job()
+      retry(job_has_finished)
       if not job_ran_successfully():
+        print("Cron job did not run successfully")
         exit(1)
   '';
 }

--- a/nixos/tests/gocron.nix
+++ b/nixos/tests/gocron.nix
@@ -4,7 +4,7 @@
   name = "gocron";
   meta.maintainers = with pkgs.lib.maintainers; [ juliusfreudenberger ];
 
-  nodes.machine = {
+  containers.machine = {
     services.gocron = {
       enable = true;
       settings = {


### PR DESCRIPTION
The test would earlier be flaky because it expected the cronjob to have
finished inbetween the curl call that started it and the one inspecting
the response.

In addition, the code has been refactored to use the builtin python json
mechanism, which cleaned up a bit of the string juggling.

I also replaced the qemu vm with a more lightweight systemd container, the test does not need a full vm.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
