### PR TITLE
glib: watch XDG state profiles for application changes

### DIFF
--- a/pkgs/by-name/gl/glib/glib-appinfo-watch.patch
+++ b/pkgs/by-name/gl/glib/glib-appinfo-watch.patch
@@ -47,15 +47,15 @@ index 87db7a97a..2e1689ed7 100644
      {
        gchar *alternative_dir;
  
-@@ -1650,6 +1660,40 @@ desktop_file_dirs_lock (void)
+@@ -1650,6 +1660,47 @@ desktop_file_dirs_lock (void)
        for (i = 0; dirs[i]; i++)
          g_ptr_array_add (desktop_file_dirs, desktop_file_dir_new (dirs[i]));
  
 +      {
-+        /* Monitor the system and user profile under /nix/var/nix/profiles and
-+         * treat modifications to them as if they were modifications to their
-+         * /share sub-directory.  */
++        /* Monitor the system and user profiles and treat modifications to them
++         * as if they were modifications to their /share sub-directory.  */
 +        const gchar *user;
++        gchar *profile_dir, *user_data_dir;
 +        DesktopFileDir *system_profile_dir, *user_profile_dir, *user_env_dir;
 +
 +        system_profile_dir =
@@ -63,10 +63,17 @@ index 87db7a97a..2e1689ed7 100644
 +        system_profile_dir->nix_profile_watch_dir = g_strdup ("/nix/var/nix/profiles");
 +        g_ptr_array_add (desktop_file_dirs, desktop_file_dir_ref (system_profile_dir));
 +
++        profile_dir = g_build_filename (g_get_user_state_dir (), "nix", "profiles", NULL);
++        user_data_dir = g_build_filename (profile_dir, "profile", "share", NULL);
++        user_profile_dir = desktop_file_dir_new (user_data_dir);
++        user_profile_dir->nix_profile_watch_dir = profile_dir;
++        g_ptr_array_add (desktop_file_dirs, user_profile_dir);
++        g_free (user_data_dir);
++
 +        user = g_get_user_name ();
 +        if (user != NULL)
 +          {
-+            gchar *profile_dir, *user_data_dir, *env_dir, *env_data_dir;
++            gchar *env_dir, *env_data_dir;
 +
 +            profile_dir = g_build_filename ("/nix/var/nix/profiles/per-user", user, NULL);
 +            user_data_dir = g_build_filename (profile_dir, "profile", "share", NULL);


### PR DESCRIPTION
Current patch watches `/nix/var/nix/profiles` and `/nix/var/nix/profiles/system/sw/share`, but misses `$XDG_STATE_HOME/nix/profiles`. This means glib will not detect changes after `nix profile install` or `home-manager switch` if they target `~/.local/state/nix/profiles`.

Related to https://github.com/NixOS/nixpkgs/pull/561029. With both, newly installed programs will correctly show up in the menu with their icons.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Check user state dir nix profile changes in addition to hardcoded system paths.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
