### PR TITLE
openclaw: 2026.6.33 -> 2026.9.2

### DIFF
--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -1,20 +1,76 @@
 {
   lib,
   stdenvNoCC,
+  stdenv,
   buildPackages,
   fetchFromGitHub,
+  fetchurl,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_11,
-  nodejs-slim_22,
+  pnpm_12,
+  nodejs-slim_24,
   makeWrapper,
   versionCheckHook,
-  rolldown,
+  autoPatchelfHook,
   installShellFiles,
-  version ? "2026.6.33",
+  ncurses,
+  libx11,
+  libxi,
+  libxkbcommon,
+  gtk3,
+  webkitgtk_4_1,
+  libsoup_3,
+  cairo,
+  gdk-pixbuf,
+  glib,
+  wayland,
+  dbus,
+  xdotool,
+  version ? "2026.9.2",
 }:
 let
-  pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_22; };
+  pnpm = pnpm_12.override { nodejs-slim = nodejs-slim_24; };
+
+  # Downgrade xdotool locally to version 3: Copilot's bundled webview
+  # needs libxdo.so.3, while nixpkgs' xdotool 4 provides libxdo.so.4.
+  xdotoolCompat = xdotool.overrideAttrs {
+    version = "3.20211022.1";
+    src = fetchFromGitHub {
+      owner = "jordansissel";
+      repo = "xdotool";
+      tag = "v3.20211022.1";
+      hash = "sha256-XFiaiHHtUSNFw+xhUR29+2RUHOa+Eyj1HHfjCUjwd9k=";
+    };
+  };
+
+  matrixCryptoFilename =
+    {
+      "x86_64-linux" =
+        if stdenvNoCC.hostPlatform.isMusl then
+          "matrix-sdk-crypto.linux-x64-musl.node"
+        else
+          "matrix-sdk-crypto.linux-x64-gnu.node";
+      "aarch64-linux" =
+        assert
+          !stdenvNoCC.hostPlatform.isMusl || throw "openclaw: Matrix crypto does not support aarch64-musl";
+        "matrix-sdk-crypto.linux-arm64-gnu.node";
+      "x86_64-darwin" = "matrix-sdk-crypto.darwin-x64.node";
+      "aarch64-darwin" = "matrix-sdk-crypto.darwin-arm64.node";
+    }
+    .${stdenvNoCC.hostPlatform.system};
+
+  matrixCrypto = fetchurl {
+    url = "https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/releases/download/v0.6.6/${matrixCryptoFilename}";
+    hash =
+      {
+        "matrix-sdk-crypto.linux-x64-gnu.node" = "sha256-rrIQKaxrspzQZJP2exmlp1s9A3Ghq0Uv5Z94JJNQ8Pc=";
+        "matrix-sdk-crypto.linux-x64-musl.node" = "sha256-41fCtYgB5Il0zavQ+3bvLMeXLIRcQbtQGRoNbqA2O8o=";
+        "matrix-sdk-crypto.linux-arm64-gnu.node" = "sha256-xDw0fzl4buny0Rta4wiNGCwagWNvK2jcIpf+Zxa+KJE=";
+        "matrix-sdk-crypto.darwin-x64.node" = "sha256-SiKjUemIue0ekGILNHTldjJc5Sh/YjNRtrLpz68HjCw=";
+        "matrix-sdk-crypto.darwin-arm64.node" = "sha256-mdx9kKqDDZttlrzaI1ic4Pty0Q+E7ER8nSQZN/7obZ8=";
+      }
+      .${matrixCryptoFilename};
+  };
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "openclaw";
@@ -24,45 +80,84 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "openclaw";
     repo = "openclaw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OdH5olBLDGQYCtR2ElbzcQ2+Hgy3cZDixkIwmSPh9Xw=";
+    hash = "sha256-VRY5aJDmctoblL9hPb//Y3H1+1zWoKa0sbApdHu4saY=";
   };
 
-  pnpmDepsHash = "sha256-eVyR8SVp0SyjflFomvgn9dgAqvXIUgjCYc5NICxxIg8=";
+  pnpmDepsHash = "sha256-SshG3GKE5tvvcZzxxXdZSqArfEmKMjJb3HMoQ9PEhyA=";
 
   pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) pname version src;
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
     inherit pnpm;
+    prePnpmInstall = ''
+      pnpm config set fetch-retries 5
+      pnpm config set fetch-timeout 1200000
+      pnpm config set network-concurrency 8
+    '';
     fetcherVersion = 4;
     hash = finalAttrs.pnpmDepsHash;
   };
 
-  buildInputs = [ rolldown ];
+  pnpmInstallFlags = lib.optionals stdenv.hostPlatform.isLinux [
+    "--libc=${if stdenvNoCC.hostPlatform.isMusl then "musl" else "glibc"}"
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+    ncurses
+    libx11
+    libxi
+    libxkbcommon
+    gtk3
+    webkitgtk_4_1
+    libsoup_3
+    cairo
+    gdk-pixbuf
+    glib
+    wayland
+    dbus
+    xdotoolCompat
+  ];
 
   nativeBuildInputs = [
     pnpmConfigHook
     pnpm
-    nodejs-slim_22
+    nodejs-slim_24
     makeWrapper
     installShellFiles
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+
+  # Stripping the bundled Node SEA executable corrupts its embedded payload.
+  stripExclude = [
+    "lib/openclaw/node_modules/.pnpm/@github+copilot-*/node_modules/@github/copilot-*/copilot"
   ];
 
+  # Koffi ships both libc variants in one platform package. Keep only the
+  # host variant so autoPatchelf does not inspect an incompatible binary.
   buildPhase = ''
     runHook preBuild
 
-    pnpm install --frozen-lockfile
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      koffiCpu=${if stdenvNoCC.hostPlatform.isAarch64 then "arm64" else "x64"}
+      koffiLibcDir=${if stdenvNoCC.hostPlatform.isMusl then "linux" else "musl"}_$koffiCpu
+      rm -rf node_modules/.pnpm/@koromix+koffi-linux-*@*/node_modules/@koromix/koffi-linux-*/$koffiLibcDir
+    ''}
 
-    # Replace pnpm-installed rolldown with the Nix-built version
-    rm -rf node_modules/rolldown node_modules/@rolldown/pluginutils
-    mkdir -p node_modules/@rolldown node_modules/.pnpm/node_modules/@rolldown
-    cp -r ${rolldown}/lib/node_modules/rolldown node_modules/rolldown
-    cp -r ${rolldown}/lib/node_modules/@rolldown/pluginutils node_modules/@rolldown/pluginutils
-    cp -r ${rolldown}/lib/node_modules/rolldown node_modules/.pnpm/node_modules/rolldown
-    cp -r ${rolldown}/lib/node_modules/@rolldown/pluginutils node_modules/.pnpm/node_modules/@rolldown/pluginutils
-    chmod -R u+w node_modules/rolldown node_modules/@rolldown/pluginutils \
-      node_modules/.pnpm/node_modules/rolldown node_modules/.pnpm/node_modules/@rolldown/pluginutils
+    for matrixCryptoDir in node_modules/.pnpm/@matrix-org+matrix-sdk-crypto-nodejs@0.6.6*/node_modules/@matrix-org/matrix-sdk-crypto-nodejs; do
+      install -m644 ${matrixCrypto} "$matrixCryptoDir/${matrixCryptoFilename}"
+      printf 0.6.6 > "$matrixCryptoDir/${matrixCryptoFilename}.version"
+    done
 
-    pnpm build
-    pnpm ui:build
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      autoPatchelf node_modules
+    ''}
+
+    pnpm install --offline --frozen-lockfile ${lib.escapeShellArgs finalAttrs.pnpmInstallFlags}
+    OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB=8192 pnpm build
 
     runHook postBuild
   '';
@@ -73,13 +168,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     libdir=$out/lib/openclaw
     mkdir -p $libdir $out/bin
 
-
-    cp --reflink=auto -r package.json dist node_modules $libdir/
+    cp --reflink=auto -r package.json dist node_modules packages $libdir/
     cp --reflink=auto -r docs skills patches extensions qa $libdir/
     mkdir -p $libdir/src
     cp --reflink=auto -r src/agents $libdir/src/
 
-    rm -f $libdir/node_modules/.pnpm/node_modules/clawdbot \
+    rm -f $libdir/node_modules/.pnpm/node_modules/@openclaw/example-ai-chat \
+      $libdir/node_modules/.pnpm/node_modules/clawdbot \
       $libdir/node_modules/.pnpm/node_modules/moltbot \
       $libdir/node_modules/.pnpm/node_modules/openclaw-control-ui
 
@@ -88,7 +183,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # Remove symlinks pointing back to the build sandbox
     find $libdir/dist/extensions -type l -lname "$NIX_BUILD_TOP/*" -delete
 
-    makeWrapper ${lib.getExe nodejs-slim_22} $out/bin/openclaw \
+    makeWrapper ${lib.getExe nodejs-slim_24} $out/bin/openclaw \
       --add-flags "$libdir/dist/index.js" \
       --set NODE_PATH "$libdir/node_modules"
     ln -s $out/bin/openclaw $out/bin/moltbot
@@ -129,14 +224,28 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
     homepage = "https://openclaw.ai";
     changelog = "https://github.com/openclaw/openclaw/releases/tag/${finalAttrs.src.tag}";
-    license = lib.licenses.mit;
+    # This output bundles the separately licensed Claude SDK/runtime
+    # alongside OpenClaw's MIT-licensed code.
+    # It also bundles the separately licensed GitHub Copilot CLI/runtime.
+    license = with lib.licenses; [
+      mit
+      unfree
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
     mainProgram = "openclaw";
     maintainers = with lib.maintainers; [
       chrisportela
       mkg20001
       nikhilmaddirala
     ];
-    platforms = with lib.platforms; linux ++ darwin;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
     knownVulnerabilities = [
       "Project uses LLMs to parse untrusted content, making it vulnerable to prompt injection, while having full access to system by default."
     ];

--- a/pkgs/by-name/op/openclaw/update.sh
+++ b/pkgs/by-name/op/openclaw/update.sh
@@ -5,4 +5,5 @@
 set -euo pipefail
 
 export NIXPKGS_ALLOW_INSECURE=1 # package has knownVulnerabilities
+export NIXPKGS_ALLOW_UNFREE=1 # package includes unfree dependencies
 nix-update "$UPDATE_NIX_ATTR_PATH"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update OpenClaw from 2026.6.33 to [2026.9.2](https://github.com/openclaw/openclaw/releases/tag/v2026.9.2).

- Use source-built pnpm 12 and Node 24, satisfying both OpenClaw and Matrix crypto's engine requirements.
- Use lockfile-matched rolldown, upstream's integrated UI build, and the required runtime workspaces.
- Prefetch Matrix native artifacts for offline installation and supply platform-appropriate runtime libraries.
- Retain the locked GitHub Copilot CLI 1.0.80, SDK 1.0.11, and host platform payload; apply the Linux runtime fixups they require.
- Correct the inherited MIT-only metadata to mixed MIT/unfree with native-binary provenance, and allow the updater to evaluate that classification.
- Advertise `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`, rather than the previous overbroad platform list. The existing prompt-injection warning remains.

## Draft: prerequisite and unresolved runtime treatment

**Not ready to merge.** This package-local change depends on https://github.com/NixOS/nixpkgs/pull/547612, checked at https://github.com/NixOS/nixpkgs/commit/e97c70d3e2e777ddff111564204bdb9f1edfa827. It does not duplicate that PR's global pnpm changes. Bare master at the selected base lacks `pnpm_12`, so evaluation is expected to fail until the prerequisite is available.

Validation combined this OpenClaw diff with the prerequisite on https://github.com/NixOS/nixpkgs/commit/cc9f0b84452e7beaebc56b51d95af2879ea3c105. The prerequisite's pnpm definition hunk needed context adaptation to retain that base's newer pnpm 11.25.0 and vulnerability metadata; pnpm 12 and fetcher semantics were preserved. The Rust builder file matches the prerequisite head exactly.

## Copilot behavior

Source-built pnpm 12.3.4 installs the complete original lock graph, including the Copilot CLI 1.0.80, SDK 1.0.11, and host platform payload. On Linux, the package applies the required ELF fixups and adds the webview/runtime libraries. The bundled webview needs `libxdo.so.3`, so the package locally downgrades nixpkgs' xdotool 4 to xdotool 3 rather than using its incompatible `libxdo.so.4`. The strip exclusion is narrowly limited to the six locked Copilot Node SEA package paths—Linux glibc, Linux musl, and Darwin for x64 and arm64—while sibling and unrelated native controls remain selected for stripping.

On x86_64-linux/glibc, the installed native payload and launcher both pass `--version` and `--help`; the launcher-to-platform link, bundled plugin discovery, payload links, and runtime-library resolution also pass. A sandboxed, credential-free SDK `CopilotClient.start()` / `stop()` handshake succeeds in `mode: "empty"`. No authentication, model conversation, inference, or prompt submission was tested.

## Validation

Built the combined source on **x86_64-linux/glibc** with sandboxing enabled, pnpm 12.3.4 and Node 24.19.0. Separately, a full local NixOS system build passed using the immutable prerequisite https://github.com/NixOS/nixpkgs/commit/e97c70d3e2e777ddff111564204bdb9f1edfa827 plus the published OpenClaw patch https://github.com/samuela/nixpkgs/commit/7c6e462032fd06680de5c56e44694d8a53677e21. This is local composition validation, not upstream bare-master CI. Verified:

- CLI version/help, all three executable aliases, and bash/fish/zsh completions. The cited successful runtime checks were rerun with disposable config/state directories; one earlier completion invocation was not isolated and read the live config.
- Matrix native-module loading on Node 24.
- 1,218 UI asset hashes, HTML references, runtime workspace imports, and OpenAI/Codex plugin manifests.
- Copilot CLI 1.0.80, Linux x64 native payload, SDK 1.0.11 import, launcher/platform and payload links, native and launcher `--version`/`--help`, bundled plugin discovery, runtime-library resolution, and a sandboxed SDK start/stop handshake.
- Copilot ELF dependency resolution, including the webview addon's `libxdo.so.3` requirement and the compatibility library's matching SONAME.
- The actual stdenv strip-selection fixture across all six locked 1.0.80 platform paths (`linux-{x64,arm64}`, `linuxmusl-{x64,arm64}`, and `darwin-{x64,arm64}`), with sibling and unrelated native controls still selected for stripping.
- Normal symlink QA, formatting, and diff checks.
- Non-mutating updater evaluation with both unfree/insecure opt-ins.

`aarch64-linux/glibc`, `aarch64-darwin`, and `x86_64-linux/musl` were **evaluated only**, not built or runtime-tested. Only x86_64-linux/glibc was built and runtime-tested. The stdenv fixture exercises strip selection for all six real package paths; it does not exercise non-host payload runtime behavior. `aarch64-linux/musl` is explicitly rejected by the Matrix loader constraint.

`nixpkgs-review` has not passed: the pre-submission WIP attempt omitted untracked prerequisite/patch files and failed before package evaluation. Direct combined-source builds and the checks above passed. The final output closure is approximately 3.7 GiB.

## AI assistance

Prepared with Pi and GPT-5.6 Sol, including implementation, validation, review fixes, and this description. Earlier packaging/research used Pi with GPT-6 Astra and materially informed the change. The commit includes `Assisted-by:` trailers. Independent AI review does not replace the author's review required by the [nixpkgs automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
