### PR TITLE
gnome-shell: refresh icons after profile switches

### DIFF
--- a/pkgs/by-name/gn/gnome-shell/icon-theme-directory-identity.patch
+++ b/pkgs/by-name/gn/gnome-shell/icon-theme-directory-identity.patch
@@ -1,0 +1,44 @@
+diff --git a/src/st/st-icon-theme.c b/src/st/st-icon-theme.c
+--- a/src/st/st-icon-theme.c
++++ b/src/st/st-icon-theme.c
+@@ -220,6 +220,8 @@ typedef struct
+ {
+   char *dir;
+   time_t mtime;
++  dev_t device;
++  ino_t inode;
+   StIconCache *cache;
+   gboolean exists;
+ } IconThemeDirMtime;
+@@ -792,6 +794,8 @@ insert_theme (StIconTheme *icon_theme,
+       dir_mtime->dir = path;
+       if (g_stat (path, &stat_buf) == 0 && S_ISDIR (stat_buf.st_mode)) {
+         dir_mtime->mtime = stat_buf.st_mtime;
++        dir_mtime->device = stat_buf.st_dev;
++        dir_mtime->inode = stat_buf.st_ino;
+         dir_mtime->exists = TRUE;
+       } else {
+         dir_mtime->mtime = 0;
+@@ -1029,6 +1033,8 @@ load_themes (StIconTheme *icon_theme)
+       if (g_stat (dir, &stat_buf) != 0 || !S_ISDIR (stat_buf.st_mode))
+         continue;
+       dir_mtime->mtime = stat_buf.st_mtime;
++      dir_mtime->device = stat_buf.st_dev;
++      dir_mtime->inode = stat_buf.st_ino;
+       dir_mtime->exists = TRUE;
+ 
+       dir_mtime->cache = st_icon_cache_new_for_path (dir);
+@@ -2120,10 +2126,12 @@ rescan_themes (StIconTheme *icon_theme)
+-      /* dir mtime didn't change */
++      /* dir identity and mtime didn't change. */
+       if (stat_res == 0 && dir_mtime->exists &&
+           S_ISDIR (stat_buf.st_mode) &&
++          dir_mtime->device == stat_buf.st_dev &&
++          dir_mtime->inode == stat_buf.st_ino &&
+           dir_mtime->mtime == stat_buf.st_mtime)
+         continue;
+       /* didn't exist before, and still doesn't */
+       if (!dir_mtime->exists &&
+           (stat_res != 0 || !S_ISDIR (stat_buf.st_mode)))
+         continue;
+ 

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -100,6 +100,9 @@ stdenv.mkDerivation (finalAttrs: {
     # Make D-Bus services wrappable.
     ./wrap-services.patch
 
+    # Detect profile switches even when icon directory mtimes are unchanged.
+    ./icon-theme-directory-identity.patch
+
     # Fix greeter logo being too big.
     # https://gitlab.gnome.org/GNOME/gnome-shell/issues/2591
     # Reverts https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1101


### PR DESCRIPTION
GNOME checks for icon changes based on directory modification time. Since Nix hardcodes modification time to 1, GNOME never detects when icons are changed, leading to missing icons in the application menu on newly installed programs.

Related to https://github.com/NixOS/nixpkgs/pull/561023. With both, newly installed programs will correctly show up in the menu with their icons.

fixes https://github.com/NixOS/nixpkgs/issues/12757

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
In addition to directory modification time, invalidate icon cache on device and inode changes.
Pretty much just an implementation of what was suggested here https://github.com/NixOS/nixpkgs/issues/87668#issue-616668035

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
