### PR TITLE
nixos/netfoil: fix systemd socket

### DIFF
--- a/nixos/modules/services/networking/netfoil.nix
+++ b/nixos/modules/services/networking/netfoil.nix
@@ -254,6 +254,7 @@ in
           wantedBy = [ "sockets.target" ];
           socketConfig = {
             ListenDatagram = "${cfg.listen.ipAddress}:${toString cfg.listen.port}";
+            ListenStream = "${cfg.listen.ipAddress}:${toString cfg.listen.port}";
             Service = "netfoil.service";
           };
         };

--- a/pkgs/by-name/ne/netfoil/package.nix
+++ b/pkgs/by-name/ne/netfoil/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  nixosTests,
 }:
 
 buildGoModule rec {
@@ -24,7 +25,10 @@ buildGoModule rec {
 
   vendorHash = "sha256-L+E6pLDi68TpXxzSwWlbwMLbnkJHvQY1kRwTtk6pWYM=";
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.nixos = nixosTests.netfoil;
+  };
 
   meta = with lib; {
     description = "Minimal, filtering, DNS proxy";


### PR DESCRIPTION
In the v0.6.0, [the software expected the systemd socket to pass both a tcp and a udp listener](https://github.com/tinfoil-factory/netfoil/blob/c214e2963ade0396574a80075744f29fd4c326ac/cmd/netfoil/main.go#L298-L315). [The package update](https://github.com/NixOS/nixpkgs/pull/536537) caused the module to silently break.

This PR adds a TCP listener on the same IP + port pair as the UDP listener was registered on up until now, matching the upstream suggested socket unit.

The NixOS test is now passing again.

Also registered the test in the package's passthru field, so it hopefully doesn't break as silently next time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
