### PR TITLE
audacity: add johnrichardrinehart as maintainer

### DIFF
--- a/pkgs/by-name/au/audacity/package.nix
+++ b/pkgs/by-name/au/audacity/package.nix
@@ -187,6 +187,7 @@ stdenv.mkDerivation (finalAttrs: {
       lib.licenses.cc-by-30
     ];
     maintainers = with lib.maintainers; [
+      johnrichardrinehart
       veprbl
       wegank
     ];


### PR DESCRIPTION
## Description of changes
Add myself (`johnrichardrinehart`) as a maintainer of `audacity`, alongside `veprbl` and `wegank`. My maintainer entry already exists.

This follows my work on the Audacity 4.0.0 update in #559623. This PR changes only `audacity.meta.maintainers`; it does not modify `audacity_3` or package build behavior.

## Verification
- Evaluated `audacity.meta.maintainers` and confirmed all three GitHub handles.
- `nixfmt --check` passed.

AI assistance was used to prepare and verify this metadata change.