### PR TITLE
ceres-solver: cleanup, fix cuda build

### DIFF
--- a/pkgs/by-name/ce/ceres-solver/package.nix
+++ b/pkgs/by-name/ce/ceres-solver/package.nix
@@ -1,26 +1,45 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  blas,
+  config,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
   cmake,
-  eigen,
+  cudaPackages,
+
+  # buildInputs
   gflags,
+
+  # propagatedBuildInputs
+  eigen,
   glog,
-  suitesparse,
+  blas,
   metis,
-  runTests ? false,
+  suitesparse,
+
+  # passthru
+  nix-update-script,
+
   enableStatic ? stdenv.hostPlatform.isStatic,
   withBlas ? true,
+  cudaSupport ? config.cudaSupport,
 }:
-
-stdenv.mkDerivation (finalAttrs: {
+let
+  effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
+in
+effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "ceres-solver";
   version = "2.2.0";
 
-  src = fetchurl {
-    url = "http://ceres-solver.org/ceres-solver-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-SLIwKnmG7OFyiYR3w7zW3rj7XPGbMye8SZaarUzt6C0=";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "ceres-solver";
+    repo = "ceres-solver";
+    tag = finalAttrs.version;
+    hash = "sha256-5SdHXcgwTlkDIUuyOQgD8JlAElk7aEWcFo/nyeOgN/k=";
   };
 
   outputs = [
@@ -28,20 +47,49 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = lib.optional runTests gflags;
+  # https://github.com/ceres-solver/ceres-solver/blob/85331393dc0dff09f6fb9903ab0c4bfa3e134b01/CMakeLists.txt#L251-L252
+  postPatch = lib.optionalString cudaSupport ''
+    nixLog "patching $PWD/CMakeLists.txt to remove hardcoded CUDA architectures"
+    substituteInPlace "$PWD/CMakeLists.txt" \
+      --replace-fail \
+        'set(CMAKE_CUDA_ARCHITECTURES' \
+        '# set(CMAKE_CUDA_ARCHITECTURES'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs =
+    lib.optionals finalAttrs.doCheck [
+      gflags
+    ]
+    ++ lib.optionals cudaSupport [
+      cudaPackages.cuda_cudart
+      cudaPackages.libcublas
+      cudaPackages.libcusolver
+      cudaPackages.libcusparse
+    ];
+
   propagatedBuildInputs = [
     eigen
     glog
   ]
   ++ lib.optionals withBlas [
     blas
-    suitesparse
     metis
+    suitesparse
   ];
 
   cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=${if enableStatic then "OFF" else "ON"}"
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!enableStatic))
+    (lib.cmakeBool "USE_CUDA" cudaSupport)
+  ]
+  ++ lib.optionals cudaSupport [
+    (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
   ];
 
   # The Basel BUILD file conflicts with the cmake build directory on
@@ -50,14 +98,39 @@ stdenv.mkDerivation (finalAttrs: {
     rm BUILD
   '';
 
-  doCheck = runTests;
-
+  doCheck = false;
   checkTarget = "test";
+
+  preCheck =
+    let
+      skippedTests = lib.concatStringsSep ":" [
+        # Failing (with more or less consistency) due to floating-point tolerance issues.
+        # Upstream issue: https://github.com/ceres-solver/ceres-solver/issues/1062
+        "Polynomial.NullPointerAsImaginaryPartWorks"
+        "Polynomial.PolynomialNullPointerAsImaginaryPartWorks"
+        "Polynomial.QuarticPolynomialWithTwoClustersOfCloseRootsWorks"
+        "Polynomial.QuarticPolynomialWithTwoZeroRootsWorks"
+        "Polynomial.QuarticPolynomialWorks"
+      ];
+    in
+    ''
+      export GTEST_FILTER="-${skippedTests}"
+    '';
+
+  passthru = {
+    tests.withTests = finalAttrs.finalPackage.overrideAttrs {
+      doCheck = true;
+    };
+
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "C++ library for modeling and solving large, complicated optimization problems";
     license = lib.licenses.bsd3;
     homepage = "http://ceres-solver.org";
+    downloadPage = "https://github.com/ceres-solver/ceres-solver";
+    teams = [ lib.teams.cuda ];
     maintainers = with lib.maintainers; [ giogadi ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
## Things done

Adapted from https://github.com/ConnorBaker/nixpkgs/commit/31a5f15104bd51babc9a41fbe313a163dcf9b495

Fixes #560909

Reported here: https://github.com/NixOS/nixpkgs/pull/503891#issuecomment-5574514869

cc @nixos/cuda-maintainers

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
