### PR TITLE
mongoc: 1.30.3 -> 1.30.9

### DIFF
--- a/pkgs/by-name/mo/mongoc/package.nix
+++ b/pkgs/by-name/mo/mongoc/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mongoc";
-  version = "1.30.3";
+  version = "1.30.9";
 
   src = fetchFromGitHub {
     owner = "mongodb";
     repo = "mongo-c-driver";
     tag = finalAttrs.version;
-    hash = "sha256-3mzqsrbXfrtAAC5igIna5dAgU8FH23lkMS2IacVlCmI=";
+    hash = "sha256-5msXPEt4a/Q/LDSowf2Eu2HD7ktrTrB9Adi/PtPIs5o=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/mongodb/mongo-c-driver/releases/tag/1.30.4
https://github.com/mongodb/mongo-c-driver/releases/tag/1.30.5
https://github.com/mongodb/mongo-c-driver/releases/tag/1.30.6
https://github.com/mongodb/mongo-c-driver/releases/tag/1.30.7
https://github.com/mongodb/mongo-c-driver/releases/tag/1.30.8
https://github.com/mongodb/mongo-c-driver/releases/tag/1.30.9

this also automatically fixes the cmake error currently occuring with cmake 4.4.0+ on staging-next (#560469, https://hydra.nixos.org/build/344554671) as https://github.com/mongodb/mongo-c-driver/commit/3f9366cb27623f1a6f3b038146235059a378ad6d is included in this release.

Fixes: CVE-2026-84964, CVE-2026-84965, CVE-2026-84969, CVE-2026-84963

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
