### PR TITLE
nixos/tests/logkeys: fix failure

### DIFF
--- a/nixos/tests/logkeys.nix
+++ b/nixos/tests/logkeys.nix
@@ -3,25 +3,23 @@
   name = "logkeys";
   meta.maintainers = with lib.maintainers; [ h7x4 ];
 
-  nodes.machine =
-    { pkgs, ... }:
-    {
-      imports = [ ./common/user-account.nix ];
+  nodes.machine = {
+    imports = [ ./common/user-account.nix ];
 
-      services.getty.autologinUser = "alice";
+    services.getty.autologinUser = "alice";
 
-      services.logkeys = {
-        enable = true;
-        device = "virtio-kbd";
-      };
-
-      # logkeys doesn't support specifying a device in `by-path`.
-      # In order not to make the test dependend on the ordering of the input event devices,
-      # we'll create a custom symlink before starting the service.
-      systemd.services.logkeys.serviceConfig.ExecStartPre = [
-        "+${lib.getExe' pkgs.coreutils "ln"} -s /dev/input/by-path/pci-0000:00:0a.0-event-kbd /dev/input/virtio-kbd"
-      ];
+    services.logkeys = {
+      enable = true;
+      device = "virtio-kbd";
     };
+
+    # logkeys doesn't support specifying a device in `by-path`.
+    # In order not to make the test dependend on the ordering of the input event devices,
+    # we'll create a custom symlink before starting the service.
+    systemd.services.logkeys.preStart = ''
+      ln -sf /dev/input/by-path/pci-*-event-kbd /dev/input/virtio-kbd
+    '';
+  };
 
   testScript = ''
     machine.wait_for_unit("getty@tty1.service")


### PR DESCRIPTION
The PCI slot was hardcoded and did no longer match the correct address. This fix makes the test more robust against future changes to the address by globbing the device instead of hardcoding it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
