### PR TITLE
libpaper: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/by-name/li/libpaper/package.nix
+++ b/pkgs/by-name/li/libpaper/package.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ autoreconfHook ];
 
+  strictDeps = true;
+
   # The configure script of libpaper is buggy: it uses AC_SUBST on a headerfile
   # to compile sysconfdir into the library. Autoconf however defines sysconfdir
   # as "${prefix}/etc", which is not expanded by AC_SUBST so libpaper will look

--- a/pkgs/by-name/li/libpaper/package.nix
+++ b/pkgs/by-name/li/libpaper/package.nix
@@ -23,11 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
   # as "${prefix}/etc", which is not expanded by AC_SUBST so libpaper will look
   # for config files in (literally, without expansion) '${prefix}/etc'. Manually
   # setting sysconfdir fixes this issue.
-  preConfigure = ''
-    configureFlagsArray+=(
-      "--sysconfdir=$out/etc"
-    )
-  '';
+  configureFlags = [
+    "--sysconfdir=${placeholder "out"}/etc"
+  ];
 
   # Set the default paper to letter (this is what libpaper uses as default as well,
   # if you call getdefaultpapername()).
@@ -36,6 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/etc
     echo letter > $out/etc/papersize
   '';
+
+  __structuredAttrs = true;
 
   meta = {
     changelog = "https://github.com/rrthomas/libpaper/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
