### PR TITLE
dhcpdump: 1.10 -> 2.00

### DIFF
--- a/pkgs/by-name/dh/dhcpdump/package.nix
+++ b/pkgs/by-name/dh/dhcpdump/package.nix
@@ -3,30 +3,34 @@
   stdenv,
   fetchFromGitHub,
   perl,
+  pkg-config,
   installShellFiles,
   libpcap,
+  yascreen,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dhcpdump";
-  version = "1.10";
+  version = "2.00";
 
   src = fetchFromGitHub {
     owner = "dhcpdump-org";
     repo = "dhcpdump";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EtCwtRvAvZdfW/6MjHEXJTHoD/OknJeZJ7q0qb+CzeE=";
+    hash = "sha256-yIrB8ALkaewRpZduKCnnrpnr+H7mHSv9wrFAQaeQ8HU=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
     perl # pod2man
+    pkg-config
     installShellFiles
   ];
 
   buildInputs = [
     libpcap
+    yascreen
   ];
 
   installPhase = ''


### PR DESCRIPTION
Diff: https://github.com/dhcpdump-org/dhcpdump/compare/v1.10...v2.00

Changelog: https://github.com/dhcpdump-org/dhcpdump/releases/tag/v2.00


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
