### PR TITLE
chasquid: init at 1.18.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29025,6 +29025,11 @@
     github = "thiloho";
     githubId = 123883702;
   };
+  ThinkChaos = {
+    name = "ThinkChaos";
+    github = "ThinkChaos";
+    githubId = 4761135;
+  };
   thled = {
     name = "Thomas Le Duc";
     email = "dev@tleduc.de";

--- a/pkgs/by-name/ch/chasquid/detect-dovecot-sock.patch
+++ b/pkgs/by-name/ch/chasquid/detect-dovecot-sock.patch
@@ -1,0 +1,51 @@
+From 07defb13fef3690a5096dd838a3dde8c35f36eeb Mon Sep 17 00:00:00 2001
+From: ThinkChaos <ThinkChaos@users.noreply.github.com>
+Date: Tue, 12 Aug 2025 20:04:00 -0400
+Subject: [PATCH] dovecot: auto-detect sockets in `/run/dovecot2`
+
+NixOS uses this path, and it seems generic enough to be worth adding
+here.
+
+The `/var/run` paths should probably also be updated to `/run`, but I'm
+not going to risk breaking anything :)
+---
+ docs/dovecot.md             | 4 ++--
+ internal/dovecot/dovecot.go | 4 ++++
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/docs/dovecot.md b/docs/dovecot.md
+index 853e7cc7..660c9de6 100644
+--- a/docs/dovecot.md
++++ b/docs/dovecot.md
+@@ -45,8 +45,8 @@ dovecot_auth: true
+ ```
+ 
+ That should be it, because chasquid will "autodetect" the full path to the
+-dovecot sockets, by looking in the usual places (tested in Debian, Ubuntu, and
+-CentOS).
++dovecot sockets, by looking in the usual places (tested in Debian, Ubuntu,
++CentOS, and NixOS).
+ 
+ If chasquid can't find them, the paths can be set with the
+ `dovecot_userdb_path` and `dovecot_client_path` options.
+diff --git a/internal/dovecot/dovecot.go b/internal/dovecot/dovecot.go
+index 711cd233..e230680e 100644
+--- a/internal/dovecot/dovecot.go
++++ b/internal/dovecot/dovecot.go
+@@ -34,11 +34,15 @@ var (
+ )
+ 
+ var defaultUserdbPaths = []string{
++	"/run/dovecot2/auth-chasquid-userdb",
++	"/run/dovecot2/auth-userdb",
+ 	"/var/run/dovecot/auth-chasquid-userdb",
+ 	"/var/run/dovecot/auth-userdb",
+ }
+ 
+ var defaultClientPaths = []string{
++	"/run/dovecot2/auth-chasquid-client",
++	"/run/dovecot2/auth-client",
+ 	"/var/run/dovecot/auth-chasquid-client",
+ 	"/var/run/dovecot/auth-client",
+ }
+

--- a/pkgs/by-name/ch/chasquid/detect-lego-cert.patch
+++ b/pkgs/by-name/ch/chasquid/detect-lego-cert.patch
@@ -1,0 +1,63 @@
+From 89dc2a001f5b6eaddb80c3be43061588d2ec687f Mon Sep 17 00:00:00 2001
+From: ThinkChaos <ThinkChaos@users.noreply.github.com>
+Date: Wed, 13 Aug 2025 22:12:04 -0400
+Subject: [PATCH] chasquid: support `key.pem` private filename
+
+Lego, the ACME client used by the NixOS ACME module, names the private
+keys `key.pem`.
+Auto-detect that filename so Chasquid just works with Lego & NixOS ACME.
+
+https://go-acme.github.io/lego/
+https://wiki.nixos.org/wiki/ACME
+---
+ chasquid.go | 27 ++++++++++++++++++++++++---
+ 1 file changed, 24 insertions(+), 3 deletions(-)
+
+diff --git a/chasquid.go b/chasquid.go
+index 18040e2..7261d1b 100644
+--- a/chasquid.go
++++ b/chasquid.go
+@@ -269,18 +269,39 @@ func loadCert(name, dir string, s *smtpsrv.Server) {
+ 		log.Infof("    skipping: %v", err)
+ 		return
+ 	}
+-	keyPath := filepath.Join(dir, "privkey.pem")
+-	if _, err := os.Stat(keyPath); err != nil {
++
++	keyPath, err := findCertKey(dir)
++	if err != nil {
+ 		log.Infof("    skipping: %v", err)
+ 		return
+ 	}
+ 
+-	err := s.AddCerts(certPath, keyPath)
++	err = s.AddCerts(certPath, keyPath)
+ 	if err != nil {
+ 		log.Fatalf("    %v", err)
+ 	}
+ }
+ 
++func findCertKey(dir string) (string, error) {
++	keyFiles := []string{
++		"key.pem",
++		"privkey.pem",
++	}
++
++	var err error
++
++	for _, name := range keyFiles {
++		keyPath := filepath.Join(dir, name)
++
++		_, err = os.Stat(keyPath)
++		if err == nil {
++			return keyPath, nil
++		}
++	}
++
++	return "", err
++}
++
+ // Helper to load a single domain configuration into the server.
+ func loadDomain(name, dir string, s *smtpsrv.Server) {
+ 	s.AddDomain(name)
+

--- a/pkgs/by-name/ch/chasquid/package.nix
+++ b/pkgs/by-name/ch/chasquid/package.nix
@@ -1,0 +1,43 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "chasquid";
+  version = "1.18.0";
+
+  src = fetchFromGitHub {
+    owner = "albertito";
+    repo = "chasquid";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FNr1DjH5AaLZdPsLy/jowpXkX3YhLkH2ygUANMD9ON0=";
+  };
+
+  vendorHash = "sha256-zRd4CCLv9gVLykLazGH2P+XPKO8xh5QKshFrVP4YIZY=";
+
+  ldflags = [ "-X main.version=v${finalAttrs.version}" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  # https://github.com/albertito/chasquid/pull/84
+  patches = [
+    ./detect-dovecot-sock.patch
+    ./detect-lego-cert.patch
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "SMTP (email) server with a focus on simplicity, security, and ease of operation";
+    homepage = "https://blitiri.com.ar/p/chasquid/";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    mainProgram = "chasquid";
+    maintainers = with lib.maintainers; [
+      ThinkChaos
+    ];
+  };
+})


### PR DESCRIPTION
Chasquid is an SMTP (email) server with a focus on simplicity, security, and ease of operation.  
https://blitiri.com.ar/p/chasquid/

The patches help with NixOS integration: they make interop with NixOS dovecot & ACME modules straightforward.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
