### PR TITLE
gpu-screen-recorder{-gtk}: modernize

### DIFF
--- a/pkgs/by-name/gp/gpu-screen-recorder-gtk/package.nix
+++ b/pkgs/by-name/gp/gpu-screen-recorder-gtk/package.nix
@@ -51,6 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
   ];
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   preFixup =
     let
       gpu-screen-recorder-wrapped = gpu-screen-recorder.override {

--- a/pkgs/by-name/gp/gpu-screen-recorder/package.nix
+++ b/pkgs/by-name/gp/gpu-screen-recorder/package.nix
@@ -23,6 +23,7 @@
   libxrandr,
   libxfixes,
   libjpeg_turbo,
+  versionCheckHook,
   wrapperDir ? "/run/wrappers/bin",
   gitUpdater,
 }:
@@ -47,7 +48,10 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     meson
     ninja
+    wayland-scanner
   ];
+
+  depsBuildBuild = [ pkg-config ];
 
   buildInputs = [
     libxcomposite
@@ -56,7 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
     pipewire
     wayland
-    wayland-scanner
     vulkan-headers
     libdrm
     libva
@@ -65,6 +68,12 @@ stdenv.mkDerivation (finalAttrs: {
     libxrandr
     libxfixes
   ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   mesonFlags = [
     # Install the upstream systemd unit


### PR DESCRIPTION
- Add `strictDeps` & `__structuredAttrs`, adjust GSR package to accommodate 
- Add `versionCheckHook` to GSR

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
