### PR TITLE
python314Packages.testresources: 2.0.2 -> 2.1.2

### DIFF
--- a/pkgs/development/python-modules/testresources/default.nix
+++ b/pkgs/development/python-modules/testresources/default.nix
@@ -2,8 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
-  pbr,
+  hatchling,
+  hatch-vcs,
   fixtures,
   testtools,
   pytestCheckHook,
@@ -11,23 +11,19 @@
 
 buildPythonPackage rec {
   pname = "testresources";
-  version = "2.0.2";
+  version = "2.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "testing-cabal";
     repo = "testresources";
     tag = version;
-    hash = "sha256-cdZObOgBOUxYg4IGUUMb6arlpb6NTU7w+EW700LKH4Y=";
+    hash = "sha256-CLo0b0V1fXQQFHDn/rYAmZy4ifzMEnFv26opmvn6TdQ=";
   };
 
   build-system = [
-    setuptools
-    pbr
-  ];
-
-  dependencies = [
-    pbr
+    hatchling
+    hatch-vcs
   ];
 
   nativeCheckInputs = [
@@ -35,14 +31,6 @@ buildPythonPackage rec {
     testtools
     pytestCheckHook
   ];
-
-  disabledTestPaths = [
-    # imports fixtures.test.helpers, but fixtures does not install tests anymore
-    # https://github.com/testing-cabal/fixtures/commit/349afbb1ec7dde2e472b4563025660a35e595153
-    "testresources/tests/test_test_resource.py"
-  ];
-
-  env.PBR_VERSION = version;
 
   meta = {
     description = "Pyunit extension for managing expensive test resources";


### PR DESCRIPTION
Diff: https://github.com/testing-cabal/testresources/compare/2.0.2...2.1.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
