### PR TITLE
python314Packages.transaction: 5.0 -> 5.1

### DIFF
--- a/pkgs/development/python-modules/doublemetaphone/default.nix
+++ b/pkgs/development/python-modules/doublemetaphone/default.nix
@@ -41,6 +41,9 @@ buildPythonPackage rec {
     "doublemetaphone"
   ];
 
+  # packaging.version.InvalidVersion: Invalid version: '1.2i'
+  dontCheckPythonMetadata = true;
+
   meta = {
     description = "Python wrapper for Double Metaphone phonetic encoding algorithm";
     homepage = "https://github.com/dedupeio/doublemetaphone";

--- a/pkgs/development/python-modules/transaction/default.nix
+++ b/pkgs/development/python-modules/transaction/default.nix
@@ -9,19 +9,19 @@
 
 buildPythonPackage rec {
   pname = "transaction";
-  version = "5.0";
+  version = "5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zopefoundation";
     repo = "transaction";
     tag = version;
-    hash = "sha256-8yvA2dvB69+EqsAa+hc93rgg6D64lcajl6JgFabhjwY=";
+    hash = "sha256-db6oEea+sIK9SN7fDP19qYgUgbeH9bv3vuQdssq78vo=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools<74" "setuptools"
+      --replace-fail "setuptools >= 78.1.1,< 81" "setuptools"
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/wsme/default.nix
+++ b/pkgs/development/python-modules/wsme/default.nix
@@ -3,56 +3,48 @@
   buildPythonPackage,
   fetchPypi,
   pbr,
-  setuptools,
-  importlib-metadata,
+  webob,
   simplegeneric,
   netaddr,
+  importlib-metadata,
   # Test inputs
-  flask,
-  flask-restful,
+  transaction,
   pecan,
   sphinx,
-  transaction,
+  flask,
+  flask-restful,
   webtest,
   pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "wsme";
-  version = "0.12.1";
+  version = "0.13.0";
   pyproject = true;
 
   src = fetchPypi {
-    pname = "WSME";
+    pname = "wsme";
     inherit (finalAttrs) version;
-    hash = "sha256-m36yJErzxwSskUte0iGVS7aK3QqLKy84okSwZ7M3mS0=";
+    hash = "sha256-W/MgEO2UPs+z8IeVpGAuJoPfXV6ozHHq8evj9EnzmDM=";
   };
 
-  build-system = [ setuptools ];
-
-  nativeBuildInputs = [ pbr ];
+  build-system = [ pbr ];
 
   dependencies = [
-    importlib-metadata
+    webob
     simplegeneric
     netaddr
+    importlib-metadata
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-    flask
-    flask-restful
+    transaction
     pecan
     sphinx
-    transaction
+    flask
+    flask-restful
     webtest
-  ];
-
-  enabledTestPaths = [
-    "wsme/tests"
-    "tests/pecantest"
-    "tests/test_sphinxext.py"
-    "tests/test_flask.py"
+    pytestCheckHook
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/zopefoundation/transaction/compare/5.0...5.1

Changelog: https://github.com/zopefoundation/transaction/blob/5.1/CHANGES.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
