### PR TITLE
inkscape-extensions.hexmap:  use tagged release, modernize

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions.nix
+++ b/pkgs/applications/graphics/inkscape/extensions.nix
@@ -11,14 +11,17 @@
 {
   applytransforms = callPackage ./extensions/applytransforms { };
 
-  hexmap = stdenv.mkDerivation {
+  hexmap = stdenv.mkDerivation (finalAttrs: {
     pname = "hexmap";
-    version = "unstable-2023-01-26";
+    version = "3.0pre2";
+
+    strictDeps = true;
+    __structuredAttrs = true;
 
     src = fetchFromGitHub {
       owner = "lifelike";
       repo = "hexmapextension";
-      rev = "241c9512d0113e8193b7cf06b69ef2c4730b0295";
+      tag = finalAttrs.version;
       hash = "sha256-pSPAupp3xLlbODE2BGu1Xiiiu1Y6D4gG4HhZwccAZ2E=";
     };
 
@@ -41,7 +44,7 @@
       maintainers = [ lib.maintainers.raboof ];
       platforms = lib.platforms.all;
     };
-  };
+  });
   inkcut = (
     runCommand "inkcut-inkscape-plugin" { } ''
       mkdir -p $out/share/inkscape/extensions


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The commit we were using is a tagged release ([source](https://github.com/lifelike/hexmapextension/releases/tag/3.0pre2)).  Part of #541820.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
