### PR TITLE
qui: drop unused typescript_7 from qui-web nativeBuildInputs

### DIFF
--- a/pkgs/by-name/qu/qui/package.nix
+++ b/pkgs/by-name/qu/qui/package.nix
@@ -9,7 +9,6 @@
   pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
-  typescript_7,
   versionCheckHook,
 }:
 buildGo126Module (finalAttrs: {
@@ -30,7 +29,6 @@ buildGo126Module (finalAttrs: {
       nodejs
       pnpmConfigHook
       pnpm_11
-      typescript_7
     ];
 
     sourceRoot = "${finalAttrs.src.name}/web";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The `tsc` command runs through pnpm:
https://github.com/autobrr/qui/blob/v1.26.0/web/package.json#L12

After this change

```console
> nix run .#qui -- serve
{"level":"info","version":"1.26.0","time":"2026-09-08T12:13:31+09:00","message":"Starting qui"}
{"level":"warn","time":"2026-09-08T12:13:31+09:00","message":"No Polar organization ID configured - premium themes will be disabled"}
{"level":"info","environment":"","base_url":"https://live.dodopayments.com","time":"2026-09-08T12:13:31+09:00","message":"Initialized Dodo Payments client"}
{"level":"info","time":"2026-09-08T12:13:31+09:00","message":"Initializing database at: /home/kachick/.config/qui/qui.db"}
{"level":"debug","time":"2026-09-08T12:13:31+09:00","message":"Database directory ensured: /home/kachick/.config/qui"}
{"level":"debug","time":"2026-09-08T12:13:31+09:00","message":"Writer connection opened with single connection"}
{"level":"debug","time":"2026-09-08T12:13:31+09:00","message":"Reader pool opened in read-only mode"}
{"level":"debug","time":"2026-09-08T12:13:31+09:00","message":"No pending migrations"}
{"level":"info","time":"2026-09-08T12:13:31+09:00","message":"Database initialized successfully at: /home/kachick/.config/qui/qui.db"}
{"level":"debug","count":0,"time":"2026-09-08T12:13:31+09:00","message":"Refreshing licenses"}
{"level":"info","time":"2026-09-08T12:13:31+09:00","message":"Torznab/Jackett service initialized"}
{"level":"info","time":"2026-09-08T12:13:31+09:00","message":"ARR service initialized"}
{"level":"info","time":"2026-09-08T12:13:31+09:00","message":"metadata: TVDB not configured, using TVMaze only"}
{"level":"info","time":"2026-09-08T12:13:31+09:00","message":"dirscan: scheduler started"}
{"level":"info","module":"api","protocol":"tcp","addr":"127.0.0.1:7476","base_url":"/","time":"2026-09-08T12:13:31+09:00","message":"Starting API server - Open: http://127.0.0.1:7476/"}
{"level":"debug","time":"2026-09-08T12:13:31+09:00","message":"Starting cross-seed automation loop"}
{"level":"info","component":"update","tag":"v1.28.0","time":"2026-09-08T12:13:34+09:00","message":"new qui release detected"}
```

<img width="1606" height="1506" alt="image" src="https://github.com/user-attachments/assets/7e529f32-3372-4f11-be53-accfbe03c663" />


cc: @pta2002 @hesiod @wegank

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
