### PR TITLE
telegram-for-mac: init at 12.10.282985

### DIFF
--- a/pkgs/by-name/te/telegram-for-mac/package.nix
+++ b/pkgs/by-name/te/telegram-for-mac/package.nix
@@ -1,0 +1,99 @@
+# There are two official Telegram desktop apps:
+#
+# - Telegram Desktop ("tdesktop"): C++/Qt, GPL-3.0, targets Windows, Linux,
+#   and macOS. Website: desktop.telegram.org. GitHub:
+#   telegramdesktop/tdesktop. Packaged as `telegram-desktop`, built from
+#   source.
+# - Telegram for macOS ("TelegramSwift"): Swift, GPL-2.0, targets macOS
+#   only. Website: macos.telegram.org. GitHub: overtake/TelegramSwift.
+#   Packaged here as `telegram-for-mac`, as a prebuilt binary.
+#
+# This package is the latter. It repackages the official binary from
+# osx.telegram.org without any modification. Three constraints shape it:
+#
+# 1. Building from source is not possible in nixpkgs. It requires the full
+#    Xcode, which nixpkgs cannot ship. Upstream tags no releases and pushes
+#    the source with a delay of a year or more. Forks must also register
+#    their own Telegram API credentials.
+# 2. The Sparkle auto-updater cannot be disabled: patching Info.plist or
+#    re-signing breaks the signature and its entitlements. In-app updates
+#    therefore fail against the read-only store. We accept this, like other
+#    prebuilt app bundles (see daisydisk and monodraw).
+# 3. The license is unfree although the GitHub source is GPLv2: binaries
+#    ship ahead of the published source, so the source of a given binary is
+#    not actually available.
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  writeShellApplication,
+  cacert,
+  curl,
+  gawk,
+  xmlstarlet,
+  common-updater-scripts,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "telegram-for-mac";
+  version = "12.10.282985";
+
+  src = fetchzip {
+    url = "https://osx.telegram.org/updates/Telegram-${finalAttrs.version}.app.zip";
+    hash = "sha256-aknRqjc9JTN9E5dyhteWj5cT3NVwTdta+9+pGiHewKA=";
+    stripRoot = false;
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    mv Telegram.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "telegram-for-mac-update-script";
+    runtimeInputs = [
+      cacert
+      curl
+      gawk
+      xmlstarlet
+      common-updater-scripts
+    ];
+    text = ''
+      # The feed's pubDate values are malformed, so take the entry with the
+      # highest build number instead of the newest entry.
+      version=$(
+        curl -sf https://osx.telegram.org/updates/versions.xml \
+          | xmlstarlet sel -t -m '//item/enclosure' \
+              -v '@sparkle:version' -o ' ' -v '@sparkle:shortVersionString' -n \
+          | awk '$1 > build { build = $1; short = $2 } END { print short "." build }'
+      )
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  });
+
+  meta = {
+    description = "Telegram for macOS";
+    longDescription = ''
+      Official prebuilt binary of Telegram for macOS (TelegramSwift).
+    '';
+    homepage = "https://macos.telegram.org/";
+    # Although the GitHub repository is GPL-2.0, no new source code has been
+    # released since July 2025 (as of September 2026), so the software is
+    # effectively unfree.
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ larry0x ];
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Add `telegram-for-mac`: the native Swift Telegram client for macOS ("Telegram for macOS", <https://macos.telegram.org/>, source at <https://github.com/overtake/TelegramSwift>).

This is a different application from the existing [`telegram-desktop`](https://search.nixos.org/packages?channel=unstable&query=telegram-desktop#show=telegram-desktop) (tdesktop, C++/Qt, cross-platform).

Supersedes #403243. Related prior attempt: #326770.

### Notes

- Claude Code (claude-fable-5) assisted with this PR. I reviewed every change and every verification result.
- Building from source is not feasible for this package, due to:
  - It requires the full Xcode, which nixpkgs cannot provide.
  - Source code lags binary release for >1 year (master's last commit: 2025-07-29; current release: 12.10, 2026-08-24). For this reason, this package is tagged as `license = unfree`, even though the git repository is GPL-2.0.
  - Forks must register their own Telegram API credentials.

### Testing

- Built on aarch64-darwin (`sandbox = relaxed`). The bundle is universal (`lipo -archs`: `x86_64 arm64`), and `codesign --verify --deep --strict` passes on the installed app.
- `passthru.updateScript` tested end to end: pinned the package to 12.9.282555 and ran `maintainers/scripts/update.nix`, which bumped it back to 12.10.282985 with the correct hash.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
