### PR TITLE
tokui: init at 0.12.0

### DIFF
--- a/pkgs/by-name/to/tokui/package.nix
+++ b/pkgs/by-name/to/tokui/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  buildPackages,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  gitMinimal,
+  tokei,
+  installShellFiles,
+  makeBinaryWrapper,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "tokui";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "zdyxry";
+    repo = "tokui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-v87AVzzNXTll0X+KEeU8/4z/kDm9r0ETvTUaumB8Pc0=";
+  };
+
+  vendorHash = "sha256-Om+htWFDfimXmIufFgqdF4olX1mXGGsrAUi97VTkSzg=";
+
+  __structuredAttrs = true;
+
+  ldflags = [
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ];
+
+  nativeCheckInputs = [
+    gitMinimal
+    tokei
+  ];
+
+  postInstall =
+    let
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}"
+        else
+          lib.getExe buildPackages.tokui;
+    in
+    ''
+      installShellCompletion --cmd ${finalAttrs.meta.mainProgram} \
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    ''
+    + ''
+      wrapProgram $out/bin/${finalAttrs.meta.mainProgram} \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            gitMinimal
+            tokei
+          ]
+        }
+    '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Interactive TUI for visualizing code statistics from tokei";
+    mainProgram = "tokui";
+    homepage = "https://github.com/zdyxry/tokui";
+    changelog = "https://github.com/zdyxry/tokui/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20 # bundled copy of tokei uses this, pkg itself is mit
+    ];
+    maintainers = with lib.maintainers; [
+      kangazero
+    ];
+  };
+})


### PR DESCRIPTION
`tokui` init at 0.12.0

An interactive TUI for visualizing code statistics from tokei.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
