### PR TITLE
dvgrab: 2016-05-16 -> 3.5.2, adopt

### DIFF
--- a/pkgs/by-name/dv/dvgrab/package.nix
+++ b/pkgs/by-name/dv/dvgrab/package.nix
@@ -12,16 +12,16 @@
   autoreconfHook,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dvgrab";
-  version = "2016-05-16";
+  version = "3.5.2";
 
   src = fetchFromGitHub {
     # mirror of original project with some build fixes
     owner = "ddennedy";
     repo = "dvgrab";
-    rev = "e46042e0c7b3523b6854ee547b0534e8310b7460";
-    sha256 = "17qy76fjpzrbxm4pj0ljx5lbimxryv24fvr13jwkh24j85dxailn";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SAxI0jYSmNCwhz921nIhMcYVrpwsoX5YTO4qFrkcmeA=";
   };
 
   buildInputs = [
@@ -54,5 +54,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.gnu ++ lib.platforms.linux;
     mainProgram = "dvgrab";
+    maintainers = [ lib.maintainers.ryand56 ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/ddennedy/dvgrab/releases/tag/v3.5.2
Diff: https://github.com/ddennedy/dvgrab/compare/e46042e0c7b3523b6854ee547b0534e8310b7460...v3.5.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
