### PR TITLE
discord: update various

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,78 +1,78 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-xL+ntb88+J1cTuxjsnTaWT8CFrDWYr0pSMc64YIGuZE=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/full.distro"
+      "hash": "sha256-uQxJyinR8mB56H3KGSwWaXpZyIoxFgzohUh9K9IZwY8=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-0Aymzs0pcCNbJXkkuyo5xSkQrhbOhx5JOzG6tHcE5nY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_cloudsync/1/full.distro",
+        "hash": "sha256-ykYw8jQfU1BJXsKbrprCQt5g6cNT0RXcUyVNPmSNjpo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-gYEF/ZIpUmmHWfV/R/UI4ns6d92OEAmDnb+5qxZ0fvA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_desktop_core/1/full.distro",
+        "hash": "sha256-BtxzmKUVQBJto711gws1ARGN821TFRWaC1np+fh3/FU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-Z6vYHG2Dmmo5GX1xmgUG8hWvNgGD5BZGDOgRYy9ndnI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_dispatch/1/full.distro",
+        "hash": "sha256-B98prLZThAcAgKUOJnua/iItc0i4DhoBH2/+jzojj6g=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-9tnEm3suVSpo7fAmKs/U1GIMDYSmru8iIu9gC+VYwfc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_erlpack/1/full.distro",
+        "hash": "sha256-+BZSW5BTiBDTVhxe6/f9cLkNlp+lCtooNvhAfdhNzxU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-vAyeZHHAJehnu+AZgOjF9YAP10B2ae4K3lRhw4Wt4rw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_game_utils/1/full.distro",
+        "hash": "sha256-S4P4KzT83TWK/jhH35AcG+zGthrV4Mlf0cfeIgfcJgY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-6tsDKeI91t8blQ3L2KcDsJgZVpTcmZo8SjncWJZ6tEo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_krisp/1/full.distro",
+        "hash": "sha256-g79im20tF1XQniy8aOhnqL6EWLNpSoUKc+6z2bDOpG8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-9jKMVVZ5/Vpl73l5211gz3B51+v//oivW8j5JcykOjk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_modules/1/full.distro",
+        "hash": "sha256-teJ5+Yg1pfF8gtAOBcIRVY45Cl3U+jMF7/PrfBm6OzY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-bAmp7Db9RCsJLw4Ck9WXOTakid48xyKqiJvU8Q+E0/k=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_rpc/1/full.distro",
+        "hash": "sha256-BiUEtZYaKUYgtgDtxeezIz73o9iuRZHQzd9bJGNzAUw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-nGGBkx6H1hpF1ZJCj5wUu+FqbQDO/Ty9mWOuHQH/7Ds=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_spellcheck/1/full.distro",
+        "hash": "sha256-ZpaCPCHOVttMumVWON0HKVf+1TIK7UIyfmts1loBvEQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_sysimg": {
-        "hash": "sha256-EsflP0BDA/oUtQAoCd7d4TzVcXuCRYSIkRGYlwQujcw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_sysimg/1/full.distro",
+        "hash": "sha256-1g1nY1AnoHnxjbTdeGEa1kE7DciXXDn4qjSuPdj81UY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-egS7bHXtnR6dzrHGAhihFb1KSPb2ttt/ZDXODHkIKjw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_utils/1/full.distro",
+        "hash": "sha256-INtmrjzvkJ6UQM0FnOHZUc+ETABG7zRHzXvbJza06sE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-K5ZmvT6nUdtPifJU9W1Xp2JKBGk8KNjhaYb5n8IQ8XM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_voice/1/full.distro",
+        "hash": "sha256-7WwuJ2yEIVOtIsR5nlK8rElr2fOgY4Ixo+mzkGBbJps=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-tt5ite79S0aAJB7xlwNQp+w0pRD7K8nI1E86Z1XsVbo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_zstd/1/full.distro",
+        "hash": "sha256-YuoqodJ8vjlwyTzUptSlwdnfuL9biV+pCn4taWnSD+4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1836"
+    "version": "1.0.1837"
   },
   "linux-development": {
     "distro": {
@@ -377,9 +377,9 @@
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-3/6v6CNXFHfwGr63ytXz2P1qzWGPB9rm48JEz9tPiRc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_utils/6/full.distro",
-        "version": 6
+        "hash": "sha256-DGFzmkvpdEjRsKo2UNJvl1Tm8HP8j2ruGS4fYiWb8z4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_utils/7/full.distro",
+        "version": 7
       },
       "discord_voice": {
         "hash": "sha256-a27b533QSmdo7RiRes2gjSfcJRs/mDE/6TVC97nN/1s=",


### PR DESCRIPTION
discord-canary: 1.0.1836 -> 1.0.1837
discord-development: 1.0.1010 -> 1.0.1010
discord-ptb: 1.0.213 -> 1.0.213
discord: 1.0.156 -> 1.0.156
pkgsCross.aarch64-darwin.discord-canary: 0.0.1311 -> 0.0.1311
pkgsCross.aarch64-darwin.discord-development: 1.0.1021 -> 1.0.1021
pkgsCross.aarch64-darwin.discord-ptb: 0.0.259 -> 0.0.259
pkgsCross.aarch64-darwin.discord: 0.0.410 -> 0.0.410


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
