### PR TITLE
python3Packages.gftools: 0.9991 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/gftools/default.nix
+++ b/pkgs/development/python-modules/gftools/default.nix
@@ -50,6 +50,7 @@
   vharfbuzz,
   vttlib,
   python,
+  gitUpdater,
 }:
 
 let
@@ -192,6 +193,12 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "gftools" ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+    # Miss Released version
+    ignoredVersions = "0.9991";
+  };
 
   meta = {
     description = "Misc tools for working with the Google Fonts library";

--- a/pkgs/development/python-modules/gftools/default.nix
+++ b/pkgs/development/python-modules/gftools/default.nix
@@ -14,7 +14,6 @@
   coreutils,
   diffenator2,
   ffmpeg-python,
-  fontbakery,
   fontfeatures,
   fontmake,
   fonttools,
@@ -49,6 +48,8 @@
   unidecode,
   vharfbuzz,
   vttlib,
+  gitpython,
+  freetype-py,
   python,
   gitUpdater,
 }:
@@ -59,14 +60,14 @@ let
 in
 buildPythonPackage rec {
   pname = "gftools";
-  version = "0.9991";
+  version = "0.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = "gftools";
     tag = "v${version}";
-    hash = "sha256-660/sU9aSt1y3iljss82SJT8QTMnVMjjJECIgHA9xso=";
+    hash = "sha256-EpEMvHoSuuptVu/GVk+RFmxa0jE3acg9KUYtUrodHOs=";
   };
 
   postPatch = ''
@@ -160,6 +161,7 @@ buildPythonPackage rec {
     unidecode
     vharfbuzz
     vttlib
+    gitpython
   ]
   ++ fonttools.optional-dependencies.ufo
   ++ fontmake.optional-dependencies.json;
@@ -167,8 +169,8 @@ buildPythonPackage rec {
   optional-dependencies = {
     qa = [
       diffenator2
-      fontbakery
       pycairo
+      freetype-py
     ];
     test = [
       black


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
