### PR TITLE
changedetection-io: qualify Playwright container image

### DIFF
--- a/nixos/modules/services/web-apps/changedetection-io.nix
+++ b/nixos/modules/services/web-apps/changedetection-io.nix
@@ -202,7 +202,7 @@ in
 
         (mkIf cfg.playwrightSupport {
           changedetection-io-playwright = {
-            image = "browserless/chrome";
+            image = "docker.io/browserless/chrome";
             environment = {
               SCREEN_WIDTH = "1920";
               SCREEN_HEIGHT = "1024";


### PR DESCRIPTION
The `services.changedetection-io.playwrightSupport` option creates a Podman container with the unqualified image name `browserless/chrome`. On systems without `unqualified-search-registries` in `registries.conf`, Podman cannot determine which registry to use and the generated service fails before creating the container:

```text
podman-changedetection-io-playwright-start: Error: short-name "browserless/chrome" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
podman-changedetection-io-playwright.service: Main process exited, code=exited, status=125/n/a
podman-changedetection-io-playwright.service: Failed with result 'exit-code'.
```

Qualify the image as `docker.io/browserless/chrome`. This preserves the intended Docker Hub image while allowing Podman to resolve it without relying on host-wide short-name registry configuration.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Additional validation:

- `nix-instantiate --parse nixos/modules/services/web-apps/changedetection-io.nix`
- `nixfmt --check nixos/modules/services/web-apps/changedetection-io.nix`
- Evaluated the generated `changedetection-io-playwright` container image and confirmed it is `docker.io/browserless/chrome`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
