### PR TITLE
python3Packages.opentelemetry-api: 1.43.0/0.64b0 -> 1.44.0/0.65b0

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -14,7 +14,7 @@
 let
   self = buildPythonPackage rec {
     pname = "opentelemetry-api";
-    version = "1.43.0";
+    version = "1.44.0";
     pyproject = true;
 
     # to avoid breakage, every package in opentelemetry-python must inherit this version, src, and meta
@@ -22,7 +22,7 @@ let
       owner = "open-telemetry";
       repo = "opentelemetry-python";
       tag = "v${version}";
-      hash = "sha256-NnRx0sMVlht2CVXeKjP7mZlzhyOqU/YyveDMWRbmAD8=";
+      hash = "sha256-e0JJL2fpDPDE/REyb0QptTYe4a6/smLrV88oKwOeG4M=";
     };
 
     sourceRoot = "${src.name}/opentelemetry-api";

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-structlog/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-structlog/default.nix
@@ -1,0 +1,39 @@
+{
+  buildPythonPackage,
+  structlog,
+  hatchling,
+  opentelemetry-api,
+  opentelemetry-instrumentation,
+  opentelemetry-semantic-conventions,
+  opentelemetry-test-utils,
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  inherit (opentelemetry-instrumentation) version src;
+  pname = "opentelemetry-instrumentation-structlog";
+  pyproject = true;
+
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-structlog";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    structlog
+    opentelemetry-instrumentation
+    opentelemetry-api
+    opentelemetry-semantic-conventions
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation.structlog" ];
+
+  meta = opentelemetry-instrumentation.meta // {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-structlog";
+    description = "structlog instrumentation for OpenTelemetry";
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "opentelemetry-instrumentation";
-  version = "0.64b0";
+  version = "0.65b0";
   pyproject = true;
 
   # To avoid breakage, every package in opentelemetry-python-contrib must inherit this version, src, and meta
@@ -20,7 +20,7 @@ buildPythonPackage (finalAttrs: {
     owner = "open-telemetry";
     repo = "opentelemetry-python-contrib";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dOcDzJD1xxCN7+Zrn+2mF/gbZjy/XC6uAKDhpfYLf98=";
+    hash = "sha256-hFoIO0NrjLG10zKOMTQ9nkxRBVpxCAoOsIKNze86x9Y=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/opentelemetry-instrumentation";

--- a/pkgs/development/python-modules/opentelemetry-propagator-b3/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-propagator-b3/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  hatchling,
+  typing-extensions,
+  opentelemetry-api,
+  opentelemetry-instrumentation,
+  opentelemetry-test-utils,
+  pytestCheckHook,
+  requests,
+  pytest-benchmark,
+}:
+
+buildPythonPackage {
+  inherit (opentelemetry-api) version src;
+  pname = "opentelemetry-propagator-b3";
+  pyproject = true;
+
+  sourceRoot = "${opentelemetry-api.src.name}/propagator/opentelemetry-propagator-b3";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    typing-extensions
+    opentelemetry-api
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+    pytest-benchmark
+    requests
+  ];
+
+  pytestFlags = [ "--benchmark-disable" ];
+
+  pythonImportsCheck = [ "opentelemetry.propagators.b3" ];
+
+  meta = opentelemetry-instrumentation.meta // {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python/blob/main/propagator/opentelemetry-propagator-b3";
+    description = "B3 Propagator for OpenTelemetry";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12734,6 +12734,10 @@ self: super: with self; {
     callPackage ../development/python-modules/opentelemetry-instrumentation-sqlite3
       { };
 
+  opentelemetry-instrumentation-structlog =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-structlog
+      { };
+
   opentelemetry-instrumentation-system-metrics =
     callPackage ../development/python-modules/opentelemetry-instrumentation-system-metrics
       { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12758,6 +12758,10 @@ self: super: with self; {
     callPackage ../development/python-modules/opentelemetry-propagator-aws-xray
       { };
 
+  opentelemetry-propagator-b3 =
+    callPackage ../development/python-modules/opentelemetry-propagator-b3
+      { };
+
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };
 
   opentelemetry-resourcedetector-gcp =


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.44.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
