### PR TITLE
nordvpn: 5.3.0 -> 5.4.0

### DIFF
--- a/pkgs/by-name/no/nordvpn/cli.nix
+++ b/pkgs/by-name/no/nordvpn/cli.nix
@@ -56,7 +56,7 @@ buildGoModule (finalAttrs: {
     makeWrapper
   ];
 
-  vendorHash = "sha256-yNeoj4W/eFoycY4AfajF8FkpkCCcj6kRbfOjZObp+VE=";
+  vendorHash = "sha256-vqNxPGcxGiEtBOGr+ZJHJNts/N4RMQzAL9DOjk13v/w=";
 
   preBuild = ''
     # redirect AppDataPathStatic (/usr/lib/nordvpn) to $out/bin so that

--- a/pkgs/by-name/no/nordvpn/package.nix
+++ b/pkgs/by-name/no/nordvpn/package.nix
@@ -6,7 +6,7 @@
   symlinkJoin,
 }:
 let
-  version = "5.3.0";
+  version = "5.4.0";
 
   common = {
     inherit version;
@@ -15,7 +15,7 @@ let
       owner = "NordSecurity";
       repo = "nordvpn-linux";
       tag = version;
-      hash = "sha256-5iWQE4fiXbDG/M072H1gigUO3YTjoRQVolXHjcxP1Mw=";
+      hash = "sha256-m3evkWYrXtgXJu7dt1mFKPVkcnrn5g3udZWafb4lFcM=";
     };
 
     # rec so that changelog can reference homepage

--- a/pkgs/by-name/no/nordvpn/pubspec.lock.json
+++ b/pkgs/by-name/no/nordvpn/pubspec.lock.json
@@ -4,31 +4,51 @@
       "dependency": "transitive",
       "description": {
         "name": "_fe_analyzer_shared",
-        "sha256": "da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f",
+        "sha256": "c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "85.0.0"
+      "version": "91.0.0"
+    },
+    "analysis_server_plugin": {
+      "dependency": "transitive",
+      "description": {
+        "name": "analysis_server_plugin",
+        "sha256": "26844e7f977087567135d62532b67d5639fe206c5194c3f410ba75e1a04a2747",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.3"
     },
     "analyzer": {
       "dependency": "transitive",
       "description": {
         "name": "analyzer",
-        "sha256": "f4ad0fea5f102201015c9aae9d93bc02f75dd9491529a8c21f88d17a8523d44c",
+        "sha256": "a40a0cee526a7e1f387c6847bd8a5ccbf510a75952ef8a28338e989558072cb0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.6.0"
+      "version": "8.4.0"
+    },
+    "analyzer_buffer": {
+      "dependency": "transitive",
+      "description": {
+        "name": "analyzer_buffer",
+        "sha256": "aba2f75e63b3135fd1efaa8b6abefe1aa6e41b6bd9806221620fa48f98156033",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.11"
     },
     "analyzer_plugin": {
       "dependency": "transitive",
       "description": {
         "name": "analyzer_plugin",
-        "sha256": "a5ab7590c27b779f3d4de67f31c4109dbe13dd7339f86461a6f2a8ab2594d8ce",
+        "sha256": "08cfefa90b4f4dd3b447bda831cecf644029f9f8e22820f6ee310213ebe2dd53",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.13.4"
+      "version": "0.13.10"
     },
     "args": {
       "dependency": "transitive",
@@ -44,11 +64,11 @@
       "dependency": "transitive",
       "description": {
         "name": "async",
-        "sha256": "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb",
+        "sha256": "e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.13.0"
+      "version": "2.13.1"
     },
     "boolean_selector": {
       "dependency": "transitive",
@@ -64,61 +84,41 @@
       "dependency": "transitive",
       "description": {
         "name": "build",
-        "sha256": "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7",
+        "sha256": "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.4"
+      "version": "4.0.7"
     },
     "build_config": {
       "dependency": "transitive",
       "description": {
         "name": "build_config",
-        "sha256": "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33",
+        "sha256": "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.2"
+      "version": "1.3.2"
     },
     "build_daemon": {
       "dependency": "transitive",
       "description": {
         "name": "build_daemon",
-        "sha256": "bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957",
+        "sha256": "79e05eaf15a48d7230b053a4363b8eaac0cc234bbd0134c3229455481f55cbc6",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.1.1"
-    },
-    "build_resolvers": {
-      "dependency": "transitive",
-      "description": {
-        "name": "build_resolvers",
-        "sha256": "ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.5.4"
+      "version": "4.1.5"
     },
     "build_runner": {
       "dependency": "direct dev",
       "description": {
         "name": "build_runner",
-        "sha256": "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53",
+        "sha256": "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.4"
-    },
-    "build_runner_core": {
-      "dependency": "transitive",
-      "description": {
-        "name": "build_runner_core",
-        "sha256": "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "9.1.2"
+      "version": "2.15.1"
     },
     "built_collection": {
       "dependency": "transitive",
@@ -134,21 +134,21 @@
       "dependency": "transitive",
       "description": {
         "name": "built_value",
-        "sha256": "6ae8a6435a8c6520c7077b107e77f1fb4ba7009633259a4d49a8afd8e7efc5e9",
+        "sha256": "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.12.4"
+      "version": "8.12.7"
     },
     "characters": {
       "dependency": "transitive",
       "description": {
         "name": "characters",
-        "sha256": "f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803",
+        "sha256": "faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.4.0"
+      "version": "1.4.1"
     },
     "checked_yaml": {
       "dependency": "transitive",
@@ -169,6 +169,16 @@
       },
       "source": "hosted",
       "version": "0.1.0"
+    },
+    "cli_config": {
+      "dependency": "transitive",
+      "description": {
+        "name": "cli_config",
+        "sha256": "ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
     },
     "cli_util": {
       "dependency": "transitive",
@@ -194,11 +204,11 @@
       "dependency": "transitive",
       "description": {
         "name": "code_builder",
-        "sha256": "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d",
+        "sha256": "aa5932e94c6c39c2f9ec4e5e06dfdd11a9430a61f6c41b6ba75b28ce0c481baf",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.11.1"
+      "version": "4.12.0"
     },
     "collection": {
       "dependency": "direct main",
@@ -220,6 +230,16 @@
       "source": "hosted",
       "version": "3.1.2"
     },
+    "coverage": {
+      "dependency": "transitive",
+      "description": {
+        "name": "coverage",
+        "sha256": "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.15.1"
+    },
     "crypto": {
       "dependency": "transitive",
       "description": {
@@ -230,75 +250,55 @@
       "source": "hosted",
       "version": "3.0.7"
     },
-    "csv": {
-      "dependency": "transitive",
-      "description": {
-        "name": "csv",
-        "sha256": "c6aa2679b2a18cb57652920f674488d89712efaf4d3fdf2e537215b35fc19d6c",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "6.0.0"
-    },
     "cupertino_icons": {
       "dependency": "direct main",
       "description": {
         "name": "cupertino_icons",
-        "sha256": "ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6",
+        "sha256": "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.8"
+      "version": "1.0.9"
     },
     "custom_lint": {
       "dependency": "direct dev",
       "description": {
         "name": "custom_lint",
-        "sha256": "9656925637516c5cf0f5da018b33df94025af2088fe09c8ae2ca54c53f2d9a84",
+        "sha256": "751ee9440920f808266c3ec2553420dea56d3c7837dd2d62af76b11be3fcece5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.6"
-    },
-    "custom_lint_builder": {
-      "dependency": "transitive",
-      "description": {
-        "name": "custom_lint_builder",
-        "sha256": "6cdc8e87e51baaaba9c43e283ed8d28e59a0c4732279df62f66f7b5984655414",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.7.6"
+      "version": "0.8.1"
     },
     "custom_lint_core": {
       "dependency": "transitive",
       "description": {
         "name": "custom_lint_core",
-        "sha256": "31110af3dde9d29fb10828ca33f1dce24d2798477b167675543ce3d208dee8be",
+        "sha256": "85b339346154d5646952d44d682965dfe9e12cae5febd706f0db3aa5010d6423",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.5"
+      "version": "0.8.1"
     },
     "custom_lint_visitor": {
       "dependency": "transitive",
       "description": {
         "name": "custom_lint_visitor",
-        "sha256": "4a86a0d8415a91fbb8298d6ef03e9034dc8e323a599ddc4120a0e36c433983a2",
+        "sha256": "91f2a81e9f0abb4b9f3bb529f78b6227ce6050300d1ae5b1e2c69c66c7a566d8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.0+7.7.0"
+      "version": "1.0.0+8.4.0"
     },
     "dart_style": {
       "dependency": "transitive",
       "description": {
         "name": "dart_style",
-        "sha256": "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb",
+        "sha256": "a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.1.1"
+      "version": "3.1.3"
     },
     "fake_async": {
       "dependency": "direct dev",
@@ -329,6 +329,16 @@
       },
       "source": "hosted",
       "version": "2.2.0"
+    },
+    "ffi_leak_tracker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "ffi_leak_tracker",
+        "sha256": "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.2"
     },
     "file": {
       "dependency": "transitive",
@@ -382,21 +392,21 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_riverpod",
-        "sha256": "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1",
+        "sha256": "a3cd0547353c1990bf5ad64f73143e5ce7a780409639559ad83a743ff3b945e4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.6.1"
+      "version": "3.2.0"
     },
     "flutter_svg": {
       "dependency": "direct main",
       "description": {
         "name": "flutter_svg",
-        "sha256": "87fbd7c534435b6c5d9d98b01e1fd527812b82e68ddd8bd35fc45ed0fa8f0a95",
+        "sha256": "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.3"
+      "version": "2.3.0"
     },
     "flutter_test": {
       "dependency": "direct dev",
@@ -414,11 +424,11 @@
       "dependency": "direct dev",
       "description": {
         "name": "freezed",
-        "sha256": "2d399f823b8849663744d2a9ddcce01c49268fb4170d0442a655bf6a2f47be22",
+        "sha256": "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.1.0"
+      "version": "3.2.3"
     },
     "freezed_annotation": {
       "dependency": "direct main",
@@ -460,21 +470,31 @@
       "dependency": "transitive",
       "description": {
         "name": "glob",
-        "sha256": "c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de",
+        "sha256": "218aeb56050c714f62a3182775320dfa04602b55074873e24e31bbd39bda96fb",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.3"
+      "version": "2.2.0"
     },
     "go_router": {
       "dependency": "direct main",
       "description": {
         "name": "go_router",
-        "sha256": "7974313e217a7771557add6ff2238acb63f635317c35fa590d348fb238f00896",
+        "sha256": "d7a3576cb312649eaa51f2356450aed686085fb58fcdebda5b359aa951eef7ea",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "17.1.0"
+      "version": "17.5.0"
+    },
+    "google_cloud": {
+      "dependency": "transitive",
+      "description": {
+        "name": "google_cloud",
+        "sha256": "b385e20726ef5315d302c5933bfb728103116c5be2d3d17094b01a82da538c1f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.5.0"
     },
     "google_identity_services_web": {
       "dependency": "transitive",
@@ -490,11 +510,11 @@
       "dependency": "transitive",
       "description": {
         "name": "googleapis_auth",
-        "sha256": "b81fe352cc4a330b3710d2b7ad258d9bcef6f909bb759b306bf42973a7d046db",
+        "sha256": "ea53b290aaf1fdff615c8d79091b02c9150ff81c48f7f3b7460598c444f3c50a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.0"
+      "version": "2.3.3"
     },
     "graphs": {
       "dependency": "transitive",
@@ -510,21 +530,11 @@
       "dependency": "direct main",
       "description": {
         "name": "grpc",
-        "sha256": "807a4da90fc1ba94dccc3a44653d3ff7bcf26818f030259d6a8f9fab405cb880",
+        "sha256": "86be3a7d39ad865b214a7370021ac80e68939238b507730de6d97fc662cb2723",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.3.1"
-    },
-    "hotreloader": {
-      "dependency": "transitive",
-      "description": {
-        "name": "hotreloader",
-        "sha256": "bc167a1163807b03bada490bfe2df25b0d744df359227880220a5cbd04e5734b",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "4.3.0"
+      "version": "5.1.0"
     },
     "http": {
       "dependency": "direct main",
@@ -586,31 +596,21 @@
       "dependency": "transitive",
       "description": {
         "name": "io",
-        "sha256": "dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b",
+        "sha256": "2635216ca6a737e60de577ffa1a48a0bec76ca8a62917cfc1bb88c14c570646f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.5"
-    },
-    "js": {
-      "dependency": "transitive",
-      "description": {
-        "name": "js",
-        "sha256": "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.7.2"
+      "version": "1.1.0"
     },
     "json_annotation": {
       "dependency": "transitive",
       "description": {
         "name": "json_annotation",
-        "sha256": "cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8",
+        "sha256": "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.11.0"
+      "version": "4.12.0"
     },
     "leak_tracker": {
       "dependency": "transitive",
@@ -656,11 +656,11 @@
       "dependency": "direct main",
       "description": {
         "name": "logger",
-        "sha256": "a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3",
+        "sha256": "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.6.2"
+      "version": "2.7.0"
     },
     "logging": {
       "dependency": "transitive",
@@ -676,41 +676,61 @@
       "dependency": "transitive",
       "description": {
         "name": "matcher",
-        "sha256": "dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2",
+        "sha256": "dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.12.17"
+      "version": "0.12.19"
     },
     "material_color_utilities": {
       "dependency": "transitive",
       "description": {
         "name": "material_color_utilities",
-        "sha256": "f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec",
+        "sha256": "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.11.1"
+      "version": "0.13.0"
     },
     "meta": {
       "dependency": "transitive",
       "description": {
         "name": "meta",
-        "sha256": "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394",
+        "sha256": "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.17.0"
+      "version": "1.18.0"
     },
     "mime": {
       "dependency": "transitive",
       "description": {
         "name": "mime",
-        "sha256": "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6",
+        "sha256": "bd47de35f07e27267e69c8c8b22edf9473bfee170a60d60fcc93730c5144b7f6",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.0"
+      "version": "2.1.0"
+    },
+    "mockito": {
+      "dependency": "transitive",
+      "description": {
+        "name": "mockito",
+        "sha256": "eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.6.4"
+    },
+    "node_preamble": {
+      "dependency": "transitive",
+      "description": {
+        "name": "node_preamble",
+        "sha256": "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.2"
     },
     "package_config": {
       "dependency": "transitive",
@@ -726,21 +746,21 @@
       "dependency": "direct main",
       "description": {
         "name": "package_info_plus",
-        "sha256": "f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d",
+        "sha256": "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.0.0"
+      "version": "10.2.1"
     },
     "package_info_plus_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "package_info_plus_platform_interface",
-        "sha256": "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086",
+        "sha256": "db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.2.1"
+      "version": "4.1.0"
     },
     "path": {
       "dependency": "direct main",
@@ -766,21 +786,21 @@
       "dependency": "transitive",
       "description": {
         "name": "path_provider_linux",
-        "sha256": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+        "sha256": "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.1"
+      "version": "2.2.2"
     },
     "path_provider_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "path_provider_platform_interface",
-        "sha256": "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334",
+        "sha256": "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.2"
+      "version": "2.1.3"
     },
     "path_provider_windows": {
       "dependency": "transitive",
@@ -826,111 +846,111 @@
       "dependency": "transitive",
       "description": {
         "name": "pool",
-        "sha256": "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d",
+        "sha256": "4177f68c237ea2128d1bee66ac17b2ce05ba3dbaafcbdd54c5d40a39d0b6b11c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.5.2"
+      "version": "1.5.3"
     },
     "posix": {
       "dependency": "direct main",
       "description": {
         "name": "posix",
-        "sha256": "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07",
+        "sha256": "bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.5.0"
+      "version": "6.5.2"
     },
     "process": {
       "dependency": "transitive",
       "description": {
         "name": "process",
-        "sha256": "c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744",
+        "sha256": "4242ba3508d37e01808bdf71ad1d5bb93a8d671bf2e7450e6b1b353fb0808891",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.0.5"
+      "version": "5.0.6"
     },
     "protobuf": {
       "dependency": "direct main",
       "description": {
         "name": "protobuf",
-        "sha256": "2fcc8a202ca7ec17dab7c97d6b6d91cf03aa07fe6f65f8afbb6dfa52cc5bd902",
+        "sha256": "75ec242d22e950bdcc79ee38dd520ce4ee0bc491d7fadc4ea47694604d22bf06",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.1.0"
+      "version": "6.0.0"
     },
     "pub_semver": {
       "dependency": "transitive",
       "description": {
         "name": "pub_semver",
-        "sha256": "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585",
+        "sha256": "261236774e8b1d69cfc6b9eabbc96c40f25e7a2d6b171f3385d4f65d5734fb24",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.0"
+      "version": "2.2.1"
     },
     "pubspec_parse": {
       "dependency": "transitive",
       "description": {
         "name": "pubspec_parse",
-        "sha256": "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082",
+        "sha256": "c38b81cbf34450b67e0265d73433569d12e34782e30ed769c9cc99c9d5f2e796",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "riverpod": {
       "dependency": "direct main",
       "description": {
         "name": "riverpod",
-        "sha256": "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959",
+        "sha256": "9026676260f31bb5279cc5e59ca292145d8bab4aabede9aa2555c2a626ec66f1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.6.1"
+      "version": "3.2.0"
     },
     "riverpod_analyzer_utils": {
       "dependency": "transitive",
       "description": {
         "name": "riverpod_analyzer_utils",
-        "sha256": "03a17170088c63aab6c54c44456f5ab78876a1ddb6032ffde1662ddab4959611",
+        "sha256": "947b05d04c52a546a2ac6b19ef2a54b08520ff6bdf9f23d67957a4c8df1c3bc0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.10"
+      "version": "1.0.0-dev.8"
     },
     "riverpod_annotation": {
       "dependency": "direct main",
       "description": {
         "name": "riverpod_annotation",
-        "sha256": "e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8",
+        "sha256": "cc1474bc2df55ec3c1da1989d139dcef22cd5e2bd78da382e867a69a8eca2e46",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.6.1"
+      "version": "4.0.0"
     },
     "riverpod_generator": {
       "dependency": "direct dev",
       "description": {
         "name": "riverpod_generator",
-        "sha256": "44a0992d54473eb199ede00e2260bd3c262a86560e3c6f6374503d86d0580e36",
+        "sha256": "e43b1537229cc8f487f09b0c20d15dba840acbadcf5fc6dad7ad5e8ab75950dc",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.6.5"
+      "version": "4.0.0+1"
     },
     "riverpod_lint": {
       "dependency": "direct dev",
       "description": {
         "name": "riverpod_lint",
-        "sha256": "89a52b7334210dbff8605c3edf26cfe69b15062beed5cbfeff2c3812c33c9e35",
+        "sha256": "4d2eb0d19bbe7e3323bd0ce4553b2e6170d161a13914bfdd85a3612329edcb43",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.6.5"
+      "version": "3.1.0"
     },
     "rxdart": {
       "dependency": "transitive",
@@ -946,91 +966,101 @@
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever",
-        "sha256": "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c",
+        "sha256": "ace919117a7520c13a50a6259e60c4a0d4cbe98809468792a91b5c5adada2aa6",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_linux": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_linux",
-        "sha256": "f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18",
+        "sha256": "7b52006a5ceae1f3d5af7f77188c3290d6e7d8ded16d99809bea84967c65c257",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_macos": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_macos",
-        "sha256": "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149",
+        "sha256": "a1489b99cce597c45a54b9aae1cd94c8d4705353b7e0bb2457a6e4de44e0ad8a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_platform_interface",
-        "sha256": "ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0",
+        "sha256": "94a5535277510a63184ca178ce12a1449bc0b38618879aa1c18bf57369c5064a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_windows": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_windows",
-        "sha256": "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13",
+        "sha256": "dafc6922b0bfbf1d48cf3ccbf519b4fff47bdcb820da1728ea6db675fecc9324",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "searchable_listview": {
       "dependency": "direct main",
       "description": {
         "name": "searchable_listview",
-        "sha256": "902c0038a10e11aa4cc9305dc9e7ec339fad6e5a23c484283f784b67ae6cf7d1",
+        "sha256": "2a24584e1b8022572fb9edda8ffd31d7bc400a6001f3da69e50c2ee85b2e7bde",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.19.4"
+      "version": "2.19.5"
+    },
+    "serial_csv": {
+      "dependency": "transitive",
+      "description": {
+        "name": "serial_csv",
+        "sha256": "2d62bb70cb3ce7251383fc86ea9aae1298ab1e57af6ef4e93b6a9751c5c268dd",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.5.2"
     },
     "shared_preferences": {
       "dependency": "direct main",
       "description": {
         "name": "shared_preferences",
-        "sha256": "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64",
+        "sha256": "c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.4"
+      "version": "2.5.5"
     },
     "shared_preferences_android": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_android",
-        "sha256": "cbc40be9be1c5af4dab4d6e0de4d5d3729e6f3d65b89d21e1815d57705644a6f",
+        "sha256": "1e12aafe408aa50da80edfd679a2a6bf63ba7ab37c7fa98286da459a757b3399",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.20"
+      "version": "2.4.28"
     },
     "shared_preferences_foundation": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_foundation",
-        "sha256": "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f",
+        "sha256": "2ec3934efa51e46117f23031cc141b8fc878e8525b94ec1ea4f7f586cf1b47ea",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.6"
+      "version": "2.5.7"
     },
     "shared_preferences_linux": {
       "dependency": "transitive",
@@ -1046,11 +1076,11 @@
       "dependency": "direct dev",
       "description": {
         "name": "shared_preferences_platform_interface",
-        "sha256": "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80",
+        "sha256": "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.1"
+      "version": "2.4.2"
     },
     "shared_preferences_web": {
       "dependency": "transitive",
@@ -1082,6 +1112,26 @@
       "source": "hosted",
       "version": "1.4.2"
     },
+    "shelf_packages_handler": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shelf_packages_handler",
+        "sha256": "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.2"
+    },
+    "shelf_static": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shelf_static",
+        "sha256": "c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.3"
+    },
     "shelf_web_socket": {
       "dependency": "transitive",
       "description": {
@@ -1102,41 +1152,61 @@
       "dependency": "direct main",
       "description": {
         "name": "slang",
-        "sha256": "81e277dc5e2305f53412b92afeb803620453259afe147d5cd6417700f998a7a6",
+        "sha256": "430749837528bb692b5ee03699fadab90d0d4a6dfbf42aab28e81df8da4c2fb8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.12.1"
+      "version": "4.19.0"
     },
     "slang_flutter": {
       "dependency": "direct main",
       "description": {
         "name": "slang_flutter",
-        "sha256": "0f0276c400660c8b67150005aa4df57643b86ce6ae9c824abee8e25f345d9abc",
+        "sha256": "2348a39432c48d7c890a2a1e3409b9faae3e49f117fe56d390d4236de8d064f4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.12.1"
+      "version": "4.19.0"
     },
     "source_gen": {
       "dependency": "transitive",
       "description": {
         "name": "source_gen",
-        "sha256": "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b",
+        "sha256": "a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.0"
+      "version": "4.2.4"
     },
     "source_helper": {
       "dependency": "transitive",
       "description": {
         "name": "source_helper",
-        "sha256": "a447acb083d3a5ef17f983dd36201aeea33fedadb3228fa831f2f0c92f0f3aca",
+        "sha256": "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.3.7"
+      "version": "1.3.8"
+    },
+    "source_map_stack_trace": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_map_stack_trace",
+        "sha256": "c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "source_maps": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_maps",
+        "sha256": "14c2945847669b44089bb1222f66873d7ff7103c58911917f2a63c5a62327898",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.10.14"
     },
     "source_span": {
       "dependency": "transitive",
@@ -1182,11 +1252,11 @@
       "dependency": "transitive",
       "description": {
         "name": "stream_transform",
-        "sha256": "ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871",
+        "sha256": "a00e5f18bffc764f923e7dec1038527f7fe7a1791361a7117f0358193f13d53a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     "string_scanner": {
       "dependency": "transitive",
@@ -1218,45 +1288,55 @@
       "source": "hosted",
       "version": "1.2.2"
     },
+    "test": {
+      "dependency": "transitive",
+      "description": {
+        "name": "test",
+        "sha256": "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.31.0"
+    },
     "test_api": {
       "dependency": "transitive",
       "description": {
         "name": "test_api",
-        "sha256": "ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55",
+        "sha256": "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.7"
+      "version": "0.7.11"
+    },
+    "test_core": {
+      "dependency": "transitive",
+      "description": {
+        "name": "test_core",
+        "sha256": "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.17"
     },
     "theme_tailor": {
       "dependency": "direct dev",
       "description": {
         "name": "theme_tailor",
-        "sha256": "ba98be1d04856deef932757a3ca8fa7a5e2a6f96c30466a59c48924eeb608b97",
+        "sha256": "1ed7eeb5362e61aac4719e3ca4cd701fd6a74a507a911424eb6caef9b28a7fef",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.3"
+      "version": "3.1.1"
     },
     "theme_tailor_annotation": {
       "dependency": "direct main",
       "description": {
         "name": "theme_tailor_annotation",
-        "sha256": "6219cff1c1c31f28d853e7b443e508b9b81e09581ea7d9403998b1d31356ff3b",
+        "sha256": "5329989c114020bc245cc39b8b0cfe44a7807ff79754fc914b0bd2dbd4df08d5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.1.2"
-    },
-    "timing": {
-      "dependency": "transitive",
-      "description": {
-        "name": "timing",
-        "sha256": "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.0.2"
+      "version": "3.1.3"
     },
     "typed_data": {
       "dependency": "transitive",
@@ -1282,41 +1362,41 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_android",
-        "sha256": "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611",
+        "sha256": "611e87fb320b70d1dd721dc46af89c98aceccea9b31fde49e084591414e0c610",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.28"
+      "version": "6.3.33"
     },
     "url_launcher_ios": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_ios",
-        "sha256": "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0",
+        "sha256": "8faa1aab294f1ab4040b43660c887b0418d5fa4f0cffef76a484e6aa1092eb4a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.4.1"
+      "version": "6.4.2"
     },
     "url_launcher_linux": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_linux",
-        "sha256": "d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a",
+        "sha256": "10f86fef4c2c43563fa6c211ff9cf757adf4d3ab762c56bd430664a947d70cd0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.2.2"
+      "version": "3.2.3"
     },
     "url_launcher_macos": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_macos",
-        "sha256": "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18",
+        "sha256": "5e835a3b869c2d70325349c81c5a45c28e20791265b67b2669da6b08c5cd5201",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.2.5"
+      "version": "3.2.6"
     },
     "url_launcher_platform_interface": {
       "dependency": "direct dev",
@@ -1332,41 +1412,41 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_web",
-        "sha256": "d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f",
+        "sha256": "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.2"
+      "version": "2.4.3"
     },
     "url_launcher_windows": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_windows",
-        "sha256": "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f",
+        "sha256": "6c5ad3f22cd4c38e089b81963b3cd7bb83b111b2df5dce008bb066162f42e429",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.1.5"
+      "version": "3.1.6"
     },
     "uuid": {
       "dependency": "transitive",
       "description": {
         "name": "uuid",
-        "sha256": "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489",
+        "sha256": "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.5.3"
+      "version": "4.6.0"
     },
     "vector_graphics": {
       "dependency": "transitive",
       "description": {
         "name": "vector_graphics",
-        "sha256": "a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6",
+        "sha256": "9d0e3b9cb16542ad660daee871e726a10d13a93b7b5391677c3160e8f5e83935",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.19"
+      "version": "1.2.3"
     },
     "vector_graphics_codec": {
       "dependency": "transitive",
@@ -1382,11 +1462,11 @@
       "dependency": "transitive",
       "description": {
         "name": "vector_graphics_compiler",
-        "sha256": "5a88dd14c0954a5398af544651c7fb51b457a2a556949bfb25369b210ef73a74",
+        "sha256": "4dca4feb77dc3ec7f6e27e49c53241eb8217f55e4f9b12599a27f8903bca5682",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.2.0"
+      "version": "1.3.0"
     },
     "vector_math": {
       "dependency": "transitive",
@@ -1402,11 +1482,11 @@
       "dependency": "transitive",
       "description": {
         "name": "vm_service",
-        "sha256": "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60",
+        "sha256": "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "15.0.2"
+      "version": "15.3.0"
     },
     "watcher": {
       "dependency": "transitive",
@@ -1458,25 +1538,35 @@
       "source": "hosted",
       "version": "3.1.0"
     },
+    "webkit_inspection_protocol": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webkit_inspection_protocol",
+        "sha256": "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.1"
+    },
     "win32": {
       "dependency": "transitive",
       "description": {
         "name": "win32",
-        "sha256": "d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e",
+        "sha256": "a0b93865d5644f11cf6a8c3f6db909f1ec168958b5805f6cc684adea957cd63d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.15.0"
+      "version": "6.4.0"
     },
     "window_manager": {
       "dependency": "direct main",
       "description": {
         "name": "window_manager",
-        "sha256": "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd",
+        "sha256": "05c231fd7b23d2380f14c5cc10b7b93d60d4fa4a2fb4e0f032de27e44b5560e9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.1"
+      "version": "0.5.2"
     },
     "xdg_directories": {
       "dependency": "transitive",
@@ -1492,25 +1582,35 @@
       "dependency": "transitive",
       "description": {
         "name": "xml",
-        "sha256": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
+        "sha256": "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.6.1"
+      "version": "7.0.1"
     },
     "yaml": {
       "dependency": "transitive",
       "description": {
         "name": "yaml",
-        "sha256": "b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce",
+        "sha256": "f67cdd8e07d3c6329146aaef1ba043542b3134c12489f553ca9a7435d1068aea",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.1.3"
+      "version": "3.1.4"
+    },
+    "yaml_edit": {
+      "dependency": "transitive",
+      "description": {
+        "name": "yaml_edit",
+        "sha256": "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.4"
     }
   },
   "sdks": {
-    "dart": ">=3.10.0 <3.10.1",
-    "flutter": ">=3.38.0"
+    "dart": ">=3.12.0 <3.12.3",
+    "flutter": ">=3.44.0"
   }
 }


### PR DESCRIPTION
nordvpn: 5.3.0 -> 5.4.0

https://github.com/NordSecurity/nordvpn-linux/releases/tag/5.4.0

Refreshed `pkgs/by-name/no/nordvpn/pubspec.lock.json` from upstream
`gui/pubspec.lock` (5.4.0). Leaving the 5.3.0 lock makes the Flutter GUI
fail to compile (Riverpod generated sources).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests
  - [ ] Package tests at passthru.tests
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran nixpkgs-review on this PR
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking
- NixOS Release Notes
  - [ ] Module addition
  - [ ] Module update
- [x] Fits CONTRIBUTING.md / pkgs/README.md
- [x] Follows the automation/AI policy

Tested on x86_64-linux without switching the host generation (host stays on 5.3.0):
nix build --impure .#nordvpn
./result/bin/nordvpn version
→ NordVPN Version 5.4.0
binaries: nordvpn, nordvpnd, nordvpn-gui, norduserd
Throwaway QEMU VM from this branch (`services.nordvpn.enable`, SSH as alice):
nordvpn version → 5.4.0
systemctl is-active nordvpnd → active
which nordvpn-gui → /run/current-system/sw/bin/nordvpn-gui
Did not log in or run connect/disconnect.

Assisted-by: Grok 4.6 (xAI).
The version and hash changes themselves come from
`nix-shell maintainers/scripts/update.nix` and upstream `gui/pubspec.lock`.