### PR TITLE
woof-doom: 15.3.0 -> 16.0.0, modernize

### DIFF
--- a/pkgs/by-name/wo/woof-doom/package.nix
+++ b/pkgs/by-name/wo/woof-doom/package.nix
@@ -17,6 +17,7 @@
   yyjson,
   discord-rpc,
   nix-update-script,
+  versionCheckHook,
   withDiscordRpc ? true,
 }:
 
@@ -53,11 +54,15 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional withDiscordRpc discord-rpc;
 
+  __structuredAttrs = true;
   strictDeps = true;
 
   cmakeFlags = [
     (lib.cmakeBool "WITH_DISCORD_RPC" withDiscordRpc)
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/wo/woof-doom/package.nix
+++ b/pkgs/by-name/wo/woof-doom/package.nix
@@ -3,14 +3,16 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  SDL2,
-  SDL2_net,
+  pkg-config,
+  sdl3,
   openal,
   libsndfile,
   fluidsynth,
   alsa-lib,
   libxmp,
   libebur128,
+  libspng,
+  miniz,
   python3,
   yyjson,
   discord-rpc,
@@ -20,27 +22,29 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "woof-doom";
-  version = "15.3.0";
+  version = "16.0.0";
 
   src = fetchFromGitHub {
     owner = "fabiangreffrath";
     repo = "woof";
     tag = "woof_${finalAttrs.version}";
-    hash = "sha256-G9exAJivfZnT2eWQhFYT8ZVRUU1QT0VAZF1CDCXmJ04=";
+    hash = "sha256-YiMLaAfMmLBLG5Zhl7hAhHVSWpUFUqH/CR4G3jwCFHk=";
   };
 
   nativeBuildInputs = [
     cmake
+    pkg-config
     python3
   ];
 
   buildInputs = [
-    SDL2
-    SDL2_net
+    sdl3
     fluidsynth
     libsndfile
+    libspng
     libxmp
     libebur128
+    miniz
     openal
     yyjson
   ]


### PR DESCRIPTION
Changelog: https://github.com/fabiangreffrath/woof/releases/tag/woof_16.0.0
Diff: https://github.com/fabiangreffrath/woof/compare/woof_15.3.0...woof_16.0.0

- Bump to 16.0.0, add necessary dependencies
- Modernize with `__structuredAttrs`, `versionCheckHook`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
