### PR TITLE
fcitx5: 5.1.21 -> 5.1.22

### DIFF
--- a/pkgs/by-name/fc/fcitx5-rime/package.nix
+++ b/pkgs/by-name/fc/fcitx5-rime/package.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-rime";
-  version = "5.1.14";
+  version = "5.1.16";
 
   src = fetchurl {
     url = "https://download.fcitx-im.org/fcitx5/${pname}/${pname}-${version}.tar.zst";
-    hash = "sha256-dHiBH74dTnzabm23TrDAXV/oHSGMqdyBtrf0uyuwjWI=";
+    hash = "sha256-MlGoRCHE8ou69BZU108jgKUt4O3RuoAt5ZQMK/O/ps8=";
   };
 
   cmakeFlags = [

--- a/pkgs/by-name/fc/fcitx5-skk/package.nix
+++ b/pkgs/by-name/fc/fcitx5-skk/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-skk";
-  version = "5.1.10";
+  version = "5.1.11";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-4ApXom3SDwlT55lj0q3u5wBmKRGAzJCvpx1H30z3Ubo=";
+    hash = "sha256-DM0QNAgXnzOhrcNsnBPdI6hrKejMxPbYZCK+yaFqVPA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fc/fcitx5/package.nix
+++ b/pkgs/by-name/fc/fcitx5/package.nix
@@ -35,6 +35,7 @@
   libxkbfile,
   nixosTests,
   gettext,
+  librsvg,
 }:
 let
   enDictVer = "20121020";
@@ -45,13 +46,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fcitx5";
-  version = "5.1.21";
+  version = "5.1.22";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-IR5mKOsVJ/GPL2czdztLVXGJTNk1JXnWpzmqC/UIwuw=";
+    hash = "sha256-t0Xn15su7nij9ll7EbQeIC75ScSwCoPOgPtTbuP4xN8=";
     fetchSubmodules = true;
   };
 
@@ -94,6 +95,7 @@ stdenv.mkDerivation rec {
     xcb-imdkit
     xkeyboard_config
     libxkbfile
+    librsvg
   ];
 
   cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [

--- a/pkgs/by-name/li/libime/package.nix
+++ b/pkgs/by-name/li/libime/package.nix
@@ -18,26 +18,26 @@ let
     url = "https://download.fcitx-im.org/data/table-${tableVer}.tar.zst";
     hash = "sha256-Pp2HsEo5PxMXI0csjqqGDdI8N4o9T2qQBVE7KpWzYUs=";
   };
-  arpaVer = "20250113";
+  arpaVer = "20260629";
   arpa = fetchurl {
     url = "https://download.fcitx-im.org/data/lm_sc.arpa-${arpaVer}.tar.zst";
-    hash = "sha256-7oPs8g1S6LzNukz2zVcYPVPCV3E6Xrd+46Y9UPw3lt0=";
+    hash = "sha256-BoCDM7kXPlN0zyy1r8EtCPViW/mrtTZInKw3b8BfLn8=";
   };
-  dictVer = "20250327";
+  dictVer = "20260703";
   dict = fetchurl {
     url = "https://download.fcitx-im.org/data/dict-${dictVer}.tar.zst";
-    hash = "sha256-fKa+R1TA1MJ7p3AsDc5lFlm9LKH6pcvyhI2BoAU8jBM=";
+    hash = "sha256-xobKtt+JZMSNWW9X0gW6wx/HKHCwaoMBfkRQPfjAlpc=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "libime";
-  version = "1.1.14";
+  version = "1.1.16";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "libime";
     tag = finalAttrs.version;
-    hash = "sha256-q9OSY1q4MNlFqw6lRMrHO6QT9xP8Czz4b4M0BuIkp34=";
+    hash = "sha256-SDp7j37ZtIQ+YqOh+JKGaPgnrz0sVIom3lJx0Jmbk38=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   fetchFromGitHub,
   cmake,
   pkg-config,
@@ -19,6 +18,7 @@
   fmt,
   qtbase,
   luaSupport ? true,
+  nlohmann_json,
 }:
 
 let
@@ -36,13 +36,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-chinese-addons";
-  version = "5.1.12";
+  version = "5.1.14";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-bAx5m+tU8hT1WdaLChpQV3J0l+QJzDLzMEPTgjEGCuw=";
+    hash = "sha256-EtAoUoZQqxb049oD7r/UgdpJdS/kenMn3t1SHv+YIkg=";
   };
 
   nativeBuildInputs = [
@@ -68,6 +68,7 @@ stdenv.mkDerivation rec {
     qtwebengine
     fmt
     qtbase
+    nlohmann_json
   ]
   ++ lib.optional luaSupport fcitx5-lua;
 

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
@@ -16,13 +16,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fcitx5-qt${majorVersion}";
-  version = "5.1.14";
+  version = "5.1.15";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-qt";
     rev = version;
-    hash = "sha256-fyqejCb6c6VuPb44UPQDLrdZ93mHTxlX29jCN6KcZ5I=";
+    hash = "sha256-xmtFiWjjknDNN0RdI45GwiuBojRCRZiSGxP9asE5OeY=";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[release note](https://groups.google.com/g/fcitx/c/wGeWmDXeIDc/m/rItZXMEjAwAJ?pli=1)

This pr DOESN'T include #560530, #560535, #560540, #560738, #560742, #560743, and #560744.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
