### PR TITLE
buildNimPackage, buildNimSbom: use lib.extendMkDerivation

### DIFF
--- a/pkgs/build-support/build-nim-package.nix
+++ b/pkgs/build-support/build-nim-package.nix
@@ -80,10 +80,19 @@ let
 in
 buildNimPackageArgs:
 let
-  composition =
-    finalAttrs:
+  # Normalize the user-provided arguments to a fixed-point function.
+  # This supports both the plain attribute set and the function styles,
+  # where the function may either take only `finalAttrs`, or take a
+  # second argument receiving `baseAttrs`.
+  fpargs = finalAttrs: (asFunc ((asFunc buildNimPackageArgs) finalAttrs)) baseAttrs;
+in
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  extendDrvArgs =
+    finalAttrs: previousAttrs:
     let
-      postPkg = baseAttrs // (asFunc ((asFunc buildNimPackageArgs) finalAttrs)) baseAttrs;
+      postPkg = baseAttrs // previousAttrs;
 
       lockAttrs = lib.attrsets.optionalAttrs (builtins.hasAttr "lockFile" postPkg) (
         builtins.fromJSON (builtins.readFile postPkg.lockFile)
@@ -163,6 +172,4 @@ let
     lib.trivial.warnIf (builtins.hasAttr "nimBinOnly" attrs)
       "the nimBinOnly attribute is deprecated for buildNimPackage"
       attrs;
-
-in
-stdenv.mkDerivation composition
+} fpargs

--- a/pkgs/build-support/build-nim-sbom.nix
+++ b/pkgs/build-support/build-nim-sbom.nix
@@ -188,18 +188,30 @@ let
         prevAttrs
     ) prevAttrs prevAttrs.passthru.sbom.components;
 
-  compose =
-    callerArg: sbom: finalAttrs:
-    let
-      callerAttrs = if builtins.isAttrs callerArg then callerArg else callerArg finalAttrs;
-      sbomAttrs = callerAttrs // (applySbom sbom callerAttrs);
-      overrideAttrs = sbomAttrs // (applyOverrides sbomAttrs);
-    in
-    overrideAttrs;
 in
 callerArg: sbomArg:
 let
   sbom = if builtins.isAttrs sbomArg then sbomArg else builtins.fromJSON (builtins.readFile sbomArg);
-  overrideSbom = f: stdenv.mkDerivation (compose callerArg (sbom // (f sbom)));
+
+  mkNimSbomDerivation =
+    sbom':
+    lib.extendMkDerivation {
+      constructDrv = stdenv.mkDerivation;
+
+      extendDrvArgs =
+        finalAttrs: previousAttrs:
+        let
+          sbomAttrs = previousAttrs // (applySbom sbom' previousAttrs);
+        in
+        sbomAttrs // (applyOverrides sbomAttrs);
+
+      transformDrv =
+        drv:
+        drv
+        // {
+          # Allow overriding the SBOM before the derivation is composed.
+          overrideSbom = f: mkNimSbomDerivation (sbom' // (f sbom'));
+        };
+    } callerArg;
 in
-(stdenv.mkDerivation (compose callerArg sbom)) // { inherit overrideSbom; }
+mkNimSbomDerivation sbom


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Converts `buildNimPackage` & `buildNimSbom` to use `lib.extendMkDerivation`.

Ref: https://github.com/NixOS/nixpkgs/issues/460877 & https://github.com/NixOS/nixpkgs/issues/489490

> Disclaimer: I used a coding agent in the creation of this patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux 
  - [x] aarch64-linux (`nix build -f . nim_lk mosdepth --system "aarch64-linux"`)
  - [x] aarch64-darwin (`nix build -f . nim_lk`)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests]. (`nixpkgs-review -- rev HEAD --systems "aarch64-linux darwin" --tests`)
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality. (`nix-build --attr tests.writers`)
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
