### PR TITLE
[26.05] umami: 3.2.0 -> 3.3.1

### DIFF
--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -9,7 +9,7 @@
   nodejs,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_11,
   prisma_7,
   prisma-engines_7,
   openssl,
@@ -20,7 +20,7 @@
   basePath ? "",
 }:
 let
-  pnpm = pnpm_10;
+  pnpm = pnpm_11;
 
   sources = lib.importJSON ./sources.json;
 
@@ -46,14 +46,14 @@ let
   # to guarantee compatibility.
   prisma-engines' = prisma-engines_7.overrideAttrs (
     finalAttrs: prevAttrs: {
-      version = "7.8.0";
+      version = "7.9.1";
       src = fetchFromGitHub {
         owner = "prisma";
         repo = "prisma-engines";
         tag = finalAttrs.version;
-        hash = "sha256-nquIcOmFz+ikD0x/YEPZ5NVKCFPCdR5MSCHldn+b9jI=";
+        hash = "sha256-bGtVKGoWZc/3s0lhTXksp+6fM/Q461ve/HQsRPxWD0Q=";
       };
-      cargoHash = "sha256-uiFvzxwVJXCW9LUDFRC6ZkzSa7LQk+9ZJcaJw8mrBX4=";
+      cargoHash = "sha256-zLl2ErsCTXZVShPFLH94GLJ0q2FrMnfnecnfKD7VDL4=";
 
       cargoDeps = rustPlatform.fetchCargoVendor {
         inherit (prevAttrs) pname;
@@ -63,25 +63,31 @@ let
       };
     }
   );
-  prisma' = (prisma_7.override { prisma-engines_7 = prisma-engines'; }).overrideAttrs (
-    finalAttrs: prevAttrs: {
-      version = "7.8.0";
-      src = fetchFromGitHub {
-        owner = "prisma";
-        repo = "prisma";
-        tag = finalAttrs.version;
-        hash = "sha256-89q5433z54h3oGX+lEYDQykN2mNltGz4+LWlYSE75/E=";
-      };
-      pnpmDeps = prevAttrs.pnpmDeps.override {
-        inherit (finalAttrs) src version;
-        hash = "sha256-mrFU5SAF4QuTBJj5TP8tUkYDG4zchttjcQMLtx6OBnI=";
-      };
-    }
-  );
+  prisma' =
+    (prisma_7.override {
+      prisma-engines_7 = prisma-engines';
+      pnpm_10 = pnpm_11;
+    }).overrideAttrs
+      (
+        finalAttrs: prevAttrs: {
+          version = "7.9.1";
+          src = fetchFromGitHub {
+            owner = "prisma";
+            repo = "prisma";
+            tag = finalAttrs.version;
+            hash = "sha256-h89lJbGG2ZkK3Viipsqe8hqTSTZk6vEulaMLPPkgn8c=";
+          };
+          pnpmDeps = prevAttrs.pnpmDeps.override {
+            inherit (finalAttrs) src version;
+            fetcherVersion = 4;
+            hash = "sha256-EEfVAdF6QawXV95NUmEL9IqzPqazCz47Y9Hg/F6IybU=";
+          };
+        }
+      );
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "umami";
-  version = "3.2.0";
+  version = "3.3.1";
 
   nativeBuildInputs = [
     makeWrapper
@@ -94,17 +100,21 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "umami-software";
     repo = "umami";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0nfCcaST06cTg43Rz1rCV8GYYDjQLP+6TrVRJF2/Yuk=";
+    hash = "sha256-LldK8dv3mkgEB9LWzt4X/bfh474G4LWOtJghTo5/n7A=";
   };
 
-  # Umami uses next/font/google, which tries to download from Google Fonts at build time.
-  # Replace that code with a copy of the required font(s) from nixpkgs instead.
   postPatch = ''
+    # Umami uses next/font/google, which tries to download from Google Fonts at build time.
+    # Replace that code with a copy of the required font(s) from nixpkgs instead.
     substituteInPlace ./src/app/layout.tsx \
       --replace-fail "import { Inter } from 'next/font/google';" "import localFont from 'next/font/local';" \
       --replace-fail 'const inter = Inter({' "const inter = localFont({ src: './Inter.ttf',"
 
     cp "${inter}/share/fonts/truetype/InterVariable.ttf" src/app/Inter.ttf
+
+    # Biome executable needs to be patched to run, but we don't need to format code anyway, so just skip it.
+    substituteInPlace ./package.json \
+      --replace-fail ' && biome format --write src/tracker/index.d.ts' '''
   '';
 
   pnpmDeps = fetchPnpmDeps {
@@ -115,7 +125,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 4;
-    hash = "sha256-6ho5xoVdqZdihThL5q8+RhVPfaSwu1y3+p9d8DnfO3o=";
+    hash = "sha256-253jfz20wXwh/8/d7KVEl4jlaj7IURWJrW2/F0FS4BI=";
   };
 
   env.NODE_ENV = "production";

--- a/pkgs/by-name/um/umami/sources.json
+++ b/pkgs/by-name/um/umami/sources.json
@@ -1,7 +1,7 @@
 {
   "geocities": {
-    "rev": "04017f13909e499135afea605a1e07427e845641",
-    "date": "2026-07-02",
-    "hash": "sha256-4IYGsxNGdzilI0mYXlwEo43auqNug307pYyPuilR3aw="
+    "rev": "f9f57fe9861c93e7dacf53671b22ea3afe4768ba",
+    "date": "2026-08-20",
+    "hash": "sha256-4B78nMlzsXTAosnTgjYrl2YiWLYEWs3Xois8o6BZIuM="
   }
 }


### PR DESCRIPTION
Backport of:
- https://github.com/NixOS/nixpkgs/pull/554406

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
