### PR TITLE
oneuptime-{app,cli,infrastructure-agent,kubernetes-cost-agent,kubernetes-log-tailer,probe,runner}: init at 12.0.33

### DIFF
--- a/pkgs/by-name/on/oneuptime-app/package.nix
+++ b/pkgs/by-name/on/oneuptime-app/package.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  makeWrapper,
+  nodejs_26,
+  npm-lockfile-fix,
+}:
+
+let
+  # Common and the six frontends are separate npm projects that depend on each other by path, so each needs its own deps
+  workspaces = {
+    "Common" = "sha256-ilohCaFFNPbJ/wBxpUx7HkCFulPjZAPwWfIa9RHMyAU=";
+    "App/FeatureSet/Accounts" = "sha256-d6OU3XLmi6R5mHMThfrGsq4st46bFzhEv+9zudWbuQg=";
+    "App/FeatureSet/AdminDashboard" = "sha256-7Xo3HQUDM9/0V8bUIWmi5nwBRWwleLqlW1d21s/CeJE=";
+    "App/FeatureSet/BrowserRecorder" = "sha256-H+1Byqx8m0ZAHiFDu+6pS5IdaNSfSCEz1vU4ZWzsV10=";
+    "App/FeatureSet/Dashboard" = "sha256-LOkjrCcMxAWVzKXuemsgJ/Q9/ike+MmEuV6TarYZpMI=";
+    "App/FeatureSet/PublicDashboard" = "sha256-Bqpj3YOyAZNgMwoPU/GlJYKUZOAn7IU8/fg+qZ30Q3A=";
+    "App/FeatureSet/StatusPage" = "sha256-4qOJBGktwY1b6kY14tMLGdw3kYICSy9Z/xrwEpyzoms=";
+  };
+in
+buildNpmPackage (finalAttrs: {
+  pname = "oneuptime-app";
+  version = "12.0.33";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "OneUptime";
+    repo = "oneuptime";
+    tag = finalAttrs.version;
+    hash = "sha256-rbubW94htXyIV6vNxz8YWv4wkMX3a25Dg+IF2aitgMI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/App";
+
+  nodejs = nodejs_26;
+
+  npmDepsHash = "sha256-C3hyoVMFAPX7SNliuxizO2TJI2Nid9LsvdRW7SjIWk4=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # unpackPhase only makes sourceRoot writable, and Common sits outside it.
+  postPatch = ''
+    chmod -R u+w ..
+  '';
+
+  preBuild = lib.concatLines (
+    lib.mapAttrsToList (
+      dir: hash:
+      let
+        deps = fetchNpmDeps {
+          name = "oneuptime-${lib.toLower (baseNameOf dir)}-npm-deps-${finalAttrs.version}";
+          src = "${finalAttrs.src}/${dir}";
+          # Upstream ships some of these lockfiles without `resolved`/`integrity` on a chunk of their entries, which cannot be fetched
+          nativeBuildInputs = [ npm-lockfile-fix ];
+          preBuild = "npm-lockfile-fix package-lock.json";
+          inherit hash;
+        };
+      in
+      ''
+        (
+          cd ../${dir}
+          # npmConfigHook requires both lockfiles to be identical, so take the
+          # repaired one back out of the fetched deps.
+          cp ${deps}/package-lock.json package-lock.json
+          export npmDeps=${deps}
+          npmConfigHook
+        )
+      ''
+    ) workspaces
+  );
+
+  npmBuildScript = "build-frontends:prod";
+
+  # The Dashboard service worker bakes both into its cache key at build time,
+  # falling back to md5(Date.now()), which would make $out unreproducible.
+  env = {
+    GIT_SHA = finalAttrs.version;
+    APP_VERSION = finalAttrs.version;
+  };
+
+  postBuild = ''
+    # The same generator stamps a wall-clock timestamp nothing reads.
+    sed -i 's/^ \* Generated at: .*/ * Generated at: (reproducible build)/' \
+      FeatureSet/Dashboard/public/sw.js
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out/lib/oneuptime
+    cp -a ../Common $out/lib/oneuptime/Common
+    cp -a . $out/lib/oneuptime/App
+
+    # Some FeatureSets and Common resolve views, assets and docs against the Docker image's WORKDIR rather than their own location.
+    find $out/lib/oneuptime -type f \( -name '*.ts' -o -name '*.ejs' \) \
+      -not -path '*/node_modules/*' -not -path '*/Tests/*' \
+      -exec sed -i \
+        "s#/usr/src/app#$out/lib/oneuptime/App#g; s#/usr/src/Common#$out/lib/oneuptime/Common#g" {} +
+
+    makeWrapper ${lib.getExe nodejs_26} $out/bin/oneuptime-app \
+      --chdir $out/lib/oneuptime/App \
+      --add-flags "--no-node-snapshot --require ts-node/register $out/lib/oneuptime/App/Index.ts" \
+      --set TS_NODE_TRANSPILE_ONLY 1 \
+      --set APP_VERSION ${finalAttrs.version}
+
+    makeWrapper ${lib.getExe nodejs_26} $out/bin/oneuptime-app-migrate \
+      --chdir $out/lib/oneuptime/App \
+      --add-flags "--no-node-snapshot --require ts-node/register $out/lib/oneuptime/App/Migrate.ts" \
+      --set TS_NODE_TRANSPILE_ONLY 1 \
+      --set APP_VERSION ${finalAttrs.version}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "OneUptime server, dashboard, and status pages";
+    homepage = "https://github.com/OneUptime/oneuptime";
+    changelog = "https://github.com/OneUptime/oneuptime/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "oneuptime-app";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/on/oneuptime-cli/package.nix
+++ b/pkgs/by-name/on/oneuptime-cli/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildNpmPackage,
+  esbuild,
+  fetchFromGitHub,
+  nix-update-script,
+  nodejs_26,
+  versionCheckHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "oneuptime-cli";
+  version = "12.0.33";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "OneUptime";
+    repo = "oneuptime";
+    tag = finalAttrs.version;
+    hash = "sha256-rbubW94htXyIV6vNxz8YWv4wkMX3a25Dg+IF2aitgMI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/CLI";
+
+  nodejs = nodejs_26;
+
+  npmDepsHash = "sha256-ktF7nHccPrpyV20D+k0588guyFgSRxqCsX/IPQwNnk8=";
+
+  nativeBuildInputs = [
+    esbuild
+    versionCheckHook
+  ];
+
+  # Common ships ESM with extensionless relative imports, which Node's ESM resolver rejects.
+  postBuild = ''
+    (
+      cd node_modules/Common
+
+      find build/dist -name '*.js' -exec esbuild \
+        --format=cjs \
+        --platform=node \
+        --outbase=build/dist \
+        --outdir=. \
+        --log-level=error \
+        {} +
+
+      rm -rf build
+    )
+  '';
+
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command-line interface for managing OneUptime resources";
+    homepage = "https://github.com/OneUptime/oneuptime";
+    changelog = "https://github.com/OneUptime/oneuptime/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "oneuptime";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/on/oneuptime-infrastructure-agent/package.nix
+++ b/pkgs/by-name/on/oneuptime-infrastructure-agent/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "oneuptime-infrastructure-agent";
+  version = "12.0.33";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "OneUptime";
+    repo = "oneuptime";
+    tag = finalAttrs.version;
+    hash = "sha256-rbubW94htXyIV6vNxz8YWv4wkMX3a25Dg+IF2aitgMI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/InfrastructureAgent";
+
+  vendorHash = "sha256-CD+6MJgLf9IhlIhvbWCJBMRp/V+/25Z+4m88rYHhbHg=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Agent that reports host metrics to a OneUptime server";
+    homepage = "https://github.com/OneUptime/oneuptime";
+    changelog = "https://github.com/OneUptime/oneuptime/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "oneuptime-infrastructure-agent";
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})

--- a/pkgs/by-name/on/oneuptime-kubernetes-cost-agent/package.nix
+++ b/pkgs/by-name/on/oneuptime-kubernetes-cost-agent/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+  nodejs_26,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "oneuptime-kubernetes-cost-agent";
+  version = "12.0.33";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "OneUptime";
+    repo = "oneuptime";
+    tag = finalAttrs.version;
+    hash = "sha256-rbubW94htXyIV6vNxz8YWv4wkMX3a25Dg+IF2aitgMI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/KubernetesCostAgent";
+
+  nodejs = nodejs_26;
+
+  npmDepsHash = "sha256-vX6cd/r0lZxCBimjfw/ZYRBAMTM+TkEvvZ2kbvdZDQo=";
+
+  npmBuildScript = "compile";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase =
+    let
+      libDir = "$out/lib/oneuptime-kubernetes-cost-agent";
+    in
+    ''
+      runHook preInstall
+
+      install -d ${libDir}
+      cp -a build/dist ${libDir}/
+
+      makeWrapper ${lib.getExe nodejs_26} $out/bin/oneuptime-kubernetes-cost-agent \
+        --add-flags ${libDir}/dist/Index.js
+
+      runHook postInstall
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Agent that reports Kubernetes workload cost allocations to OneUptime";
+    homepage = "https://github.com/OneUptime/oneuptime";
+    changelog = "https://github.com/OneUptime/oneuptime/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "oneuptime-kubernetes-cost-agent";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/on/oneuptime-kubernetes-log-tailer/package.nix
+++ b/pkgs/by-name/on/oneuptime-kubernetes-log-tailer/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+  nodejs_26,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "oneuptime-kubernetes-log-tailer";
+  version = "12.0.33";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "OneUptime";
+    repo = "oneuptime";
+    tag = finalAttrs.version;
+    hash = "sha256-rbubW94htXyIV6vNxz8YWv4wkMX3a25Dg+IF2aitgMI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/KubernetesLogTailer";
+
+  nodejs = nodejs_26;
+
+  npmDepsHash = "sha256-P0EqLkWh/Cspbz/DRR7/FK6nGenAPOjLtrA6WbhFoYc=";
+
+  npmBuildScript = "compile";
+
+  # Prevent inclusion of dev deps since we override installPhase
+  npmFlags = [ "--omit=dev" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase =
+    let
+      libDir = "$out/lib/oneuptime-kubernetes-log-tailer";
+    in
+    ''
+      runHook preInstall
+
+      install -d ${libDir}
+      cp -a build/dist node_modules ${libDir}/
+
+      makeWrapper ${lib.getExe nodejs_26} $out/bin/oneuptime-kubernetes-log-tailer \
+        --add-flags ${libDir}/dist/Index.js
+
+      runHook postInstall
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Agent that forwards Kubernetes pod logs to OneUptime via OTLP";
+    homepage = "https://github.com/OneUptime/oneuptime";
+    changelog = "https://github.com/OneUptime/oneuptime/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "oneuptime-kubernetes-log-tailer";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/on/oneuptime-probe/package.nix
+++ b/pkgs/by-name/on/oneuptime-probe/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  buildNpmPackage,
+  dnsutils,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  iputils,
+  makeWrapper,
+  nodejs_26,
+  playwright-driver,
+  playwright-test,
+  traceroute,
+}:
+
+let
+  version = "12.0.33";
+
+  src = fetchFromGitHub {
+    owner = "OneUptime";
+    repo = "oneuptime";
+    tag = version;
+    hash = "sha256-rbubW94htXyIV6vNxz8YWv4wkMX3a25Dg+IF2aitgMI=";
+  };
+
+  # Probe depends on Common as `file:../Common`, so npm symlinks it rather than installing it.
+  commonNpmDeps = fetchNpmDeps {
+    name = "oneuptime-common-npm-deps-${version}";
+    src = "${src}/Common";
+    hash = "sha256-rDw1lEtDiqJogkSCZKYaRJQwNqCnGSC6za0pV18RN+c=";
+  };
+in
+buildNpmPackage {
+  pname = "oneuptime-probe";
+  inherit version src;
+
+  __structuredAttrs = true;
+
+  sourceRoot = "${src.name}/Probe";
+
+  nodejs = nodejs_26;
+
+  npmDepsHash = "sha256-G3AAe4J4Yh/Fz6pHOgxpcWBbpPnnIeiKQHYd2Iyz3oM=";
+
+  # The one optional dependency is msnodesqlv8, a native driver needing unixODBC.
+  npmFlags = [ "--omit=optional" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Common still needs the optional dependencies Probe omits
+  preBuild = ''
+    chmod -R u+w ../Common
+
+    (
+      export npmRoot=../Common
+      export npmDeps=${commonNpmDeps}
+      npmFlags=""
+      npmFlagsArray=()
+
+      npmConfigHook
+    )
+  '';
+
+  dontNpmBuild = true;
+
+  # NPM's playwright fetches browsers from a postinstall the sandbox blocks. Replace it with nixpkgs's own
+  postBuild = ''
+    for pkg in playwright playwright-core; do
+      rm -rf node_modules/$pkg
+      cp -r --no-preserve=mode ${playwright-test}/lib/node_modules/$pkg node_modules/$pkg
+    done
+  '';
+
+  installPhase =
+    let
+      probeDir = "$out/lib/oneuptime/Probe";
+    in
+    ''
+      runHook preInstall
+
+      install -d $out/lib/oneuptime
+      cp -a ../Common $out/lib/oneuptime/Common
+      cp -a . ${probeDir}
+
+      makeWrapper ${lib.getExe nodejs_26} $out/bin/oneuptime-probe \
+        --chdir ${probeDir} \
+        --add-flags "--no-node-snapshot" \
+        --add-flags "--require ts-node/register" \
+        --add-flags ${probeDir}/Index.ts \
+        --set TS_NODE_TRANSPILE_ONLY 1 \
+        --set APP_VERSION ${version} \
+        --set PLAYWRIGHT_BROWSERS_PATH ${
+          # Synthetic monitoring doesn't use webkit and disabling reclaims 1GB
+          playwright-driver.browsers.override { withWebkit = false; }
+        } \
+        --prefix PATH : ${
+          # Monitors shell out to these for networking checks
+          lib.makeBinPath [
+            dnsutils
+            iputils
+            traceroute
+          ]
+        }
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "OneUptime monitoring probe";
+    homepage = "https://github.com/OneUptime/oneuptime";
+    changelog = "https://github.com/OneUptime/oneuptime/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "oneuptime-probe";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/on/oneuptime-runner/package.nix
+++ b/pkgs/by-name/on/oneuptime-runner/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  bash,
+  buildNpmPackage,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  git,
+  makeWrapper,
+  nodejs_26,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "oneuptime-runner";
+  version = "12.0.33";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "OneUptime";
+    repo = "oneuptime";
+    tag = finalAttrs.version;
+    hash = "sha256-rbubW94htXyIV6vNxz8YWv4wkMX3a25Dg+IF2aitgMI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/Runner";
+
+  nodejs = nodejs_26;
+
+  npmDepsHash = "sha256-5rbZYNqX6cyF13ULg9TWtCXmzk8w4IwZdVhvmJfNEqc=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # unpackPhase only makes sourceRoot writable, and Common sits outside it.
+  postPatch = ''
+    chmod -R u+w ..
+  '';
+
+  # Runner depends on Common as `file:../Common`, so npm symlinks it rather than installing it.
+  preBuild = ''
+    (
+      cd ../Common
+      export npmDeps=${
+        fetchNpmDeps {
+          name = "oneuptime-common-npm-deps-${finalAttrs.version}";
+          src = "${finalAttrs.src}/Common";
+          hash = "sha256-rDw1lEtDiqJogkSCZKYaRJQwNqCnGSC6za0pV18RN+c=";
+        }
+      }
+      npmConfigHook
+    )
+  '';
+
+  dontNpmBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out/lib/oneuptime
+    cp -a ../Common $out/lib/oneuptime/Common
+    cp -a . $out/lib/oneuptime/Runner
+
+    makeWrapper ${lib.getExe nodejs_26} $out/bin/oneuptime-runner \
+      --chdir $out/lib/oneuptime/Runner \
+      --add-flags "--no-node-snapshot --require ts-node/register $out/lib/oneuptime/Runner/Index.ts" \
+      --set TS_NODE_TRANSPILE_ONLY 1 \
+      --set APP_VERSION ${finalAttrs.version} \
+      --prefix PATH : ${
+        # Runbook steps run under bash, it also supports code fixes which run under git
+        lib.makeBinPath [
+          bash
+          git
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Self-hosted agent that runs OneUptime runbook steps and AI code fixes inside your own infrastructure";
+    homepage = "https://github.com/OneUptime/oneuptime";
+    changelog = "https://github.com/OneUptime/oneuptime/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "oneuptime-runner";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/oneuptime/oneuptime

OneUptime is a complete open-source monitoring and observability platform. This PR packages the bulk of their monorepo

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
