### PR TITLE
teamviewer: fix screen sharing by adding pipewire to LD_LIBRARY_PATH

### DIFF
--- a/pkgs/by-name/te/teamviewer/package.nix
+++ b/pkgs/by-name/te/teamviewer/package.nix
@@ -20,6 +20,7 @@
   icu63,
   nss,
   minizip,
+  pipewire,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -131,6 +132,8 @@ stdenv.mkDerivation (finalAttrs: {
         libxfixes
         dbus
         icu63
+        # dlopen'd by TeamViewer_Desktop for the Wayland ScreenCast portal
+        pipewire
       ]
     }"
   ];


### PR DESCRIPTION
On Wayland, `TeamViewer_Desktop` captures the screen through `org.freedesktop.portal.ScreenCast` and receives frames via PipeWire. It loads `libpipewire-0.3.so.0` lazily using `dlopen()`, but the library was in neither the RPATH nor the wrapper's `LD_LIBRARY_PATH`. Consequently, every incoming connection failed with:

```
PipeWire: required library version 0.3x not available/installed Session is not ready for screen sharing, aborting connection
```

This is easy to miss because `teamviewerd` and the GUI otherwise work normally. The only hint are the log entries in `~/.local/share/teamviewer15/logfiles/TeamViewer15_Logfile.log`:

```
    DW4!! LateBinding [libpipewire-0.3.so.0, libpipewire-0.3.so]:
          Could not open libraries, Errorcode=115
    DW4   PipeWire: required library version 0.3x not available/installed
    DW4!  FreedesktopPortalScreenPlatformInterface::CanRun:
          Can not run, unsupported Pipewire Version
    DW4!! CLoginServer::runServer:
          Session is not ready for screen sharing, aborting connection
```

 `autoPatchelfHook` cannot detect the dependency because a library loaded via `dlopen()` does not appear in `DT_NEEDED`. `vivaldi` and `zoom-us` handle the same runtime dependency by including `pipewire`.

Add `pipewire` to the wrapper's `LD_LIBRARY_PATH` so TeamViewer can resolve `libpipewire-0.3.so.0` at runtime.

Could a maintainer add the `backport release-26.05` label? 26.05 ships 15.74.3, which is affected identically.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
