### PR TITLE
nixos/tests/spacecookie: fix

### DIFF
--- a/nixos/tests/spacecookie.nix
+++ b/nixos/tests/spacecookie.nix
@@ -47,8 +47,10 @@ in
     # sanity check on the directory listing: we serve a directory and a file
     # via gopher, so the directory listing should have exactly two entries,
     # one with gopher file type 0 (file) and one with file type 1 (directory).
+    # note that the menu is CRLF-terminated and ends with a "." line
+    # which is not a directory entry, but the end of the response.
     dirResponse = ${gopherClient}.succeed("curl -f -s gopher://${gopherHost}")
-    dirEntries = [l[0] for l in dirResponse.split("\n") if len(l) > 0]
+    dirEntries = [l[0] for l in dirResponse.split("\r\n") if len(l) > 0 and l != "."]
     dirEntries.sort()
 
     if not (["0", "1"] == dirEntries):


### PR DESCRIPTION
Version 1.1.0.1 contained a fix that terminated responses with the lastlinse pattern, i.e. a single `.` at the end of the response.

The test compensates for this by stripping it from the response before sorting the directory entries.

See https://github.com/sternenseemann/spacecookie/releases/tag/1.1.0.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
