### PR TITLE
nixos/tests/suricata: fix flakiness

### DIFF
--- a/nixos/tests/suricata.nix
+++ b/nixos/tests/suricata.nix
@@ -66,14 +66,17 @@
     # check that configuration has been applied correctly with suricatasc
     with subtest("suricata configuration test"):
         ids.wait_for_unit("suricata.service")
-        assert '1' in ids.succeed("suricatasc -c 'iface-list' | ${pkgs.jq}/bin/jq .message.count")
+        ids.wait_for_file("/var/run/suricata/suricata-command.socket")
+        ids.wait_until_succeeds(
+            "suricatasc -c 'iface-list' | ${pkgs.jq}/bin/jq -e '.message.count == 1'"
+        )
 
     # test detection of events based on a static ruleset (output of id command)
     with subtest("suricata rule test"):
         helper.wait_for_unit("nginx.service")
-        ids.wait_for_unit("suricata.service")
-
-        ids.succeed("curl http://192.168.1.1/id/")
-        assert "id check returned root [**] [Classification: Potentially Bad Traffic]" in ids.succeed("tail -n 1 /var/log/suricata/fast.log"), "Suricata didn't detect the output of id comment"
+        ids.wait_until_succeeds(
+            "curl -sSf http://192.168.1.1/id/ && "
+            "grep -qF 'id check returned root [**] [Classification: Potentially Bad Traffic]' /var/log/suricata/fast.log"
+        )
   '';
 }


### PR DESCRIPTION
This has been flaky on hydra for quite a while now: https://hydra.nixos.org/job/nixos/unstable/nixos.tests.suricata.x86_64-linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
