### PR TITLE
tor: 0.4.9.11 -> 0.4.9.12

### DIFF
--- a/pkgs/by-name/to/tor/package.nix
+++ b/pkgs/by-name/to/tor/package.nix
@@ -46,11 +46,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tor";
-  version = "0.4.9.11";
+  version = "0.4.9.12";
 
   src = fetchurl {
     url = "https://dist.torproject.org/tor-${finalAttrs.version}.tar.gz";
-    hash = "sha256-LmwXIBGMgSrPAHn9R8+Rtr+rpddmwyHE09KijWoRqO0=";
+    hash = "sha256-wNMHydza7khIqMpT6dbE7JKCPk8wvhJ5Cw+938ZRX1s=";
   };
 
   outputs = [


### PR DESCRIPTION
release notes: https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.9.12/ReleaseNotes
diff: https://gitlab.torproject.org/tpo/core/tor/-/compare/tor-0.4.9.11...tor-0.4.9.12
trove: https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/TROVE

as per TROVE identifiers, this fixes eight high severity security issues.

Fixes: TROVE-2026-032, TROVE-2026-033, TROVE-2026-034, TROVE-2026-035, TROVE-2026-036, TROVE-2026-040, TROVE-2026-042, TROVE-2026-043

tested:
- running a relay with the NixOS module
- usage as a SOCKS5 proxy with curl
- usage as a standalone instance with Tor Browser
- running a full mini-network in the NixOS test

corresponding tor-browser update: #561469

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (x86_64-linux)
  - [x] [Package tests] at `passthru.tests`. (x86_64-linux)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
