### PR TITLE
mise: 2026.8.6 -> 2026.9.3

### DIFF
--- a/pkgs/by-name/mi/mise/0001-darwin-skip-codesign-for-disabled-notifications.patch
+++ b/pkgs/by-name/mi/mise/0001-darwin-skip-codesign-for-disabled-notifications.patch
@@ -1,0 +1,141 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Esteve Fernandez <esteve@apache.org>
+Date: Thu, 3 Sep 2026 12:22:43 +0000
+Subject: [PATCH 1/1] build: skip codesign when notification signing is disabled
+
+When notification signing is disabled, avoid invoking the macOS codesign
+binary or embedding its generated resources while preserving signing for
+real identities.
+
+Signed-off-by: Esteve Fernandez <esteve@apache.org>
+---
+ build.rs                            | 35 ++++++++++++++++++++----------------
+ src/system/history/notify/macos.rs | 36 +++++++++++++++++++++++++++++-------
+ 2 files changed, 48 insertions(+), 23 deletions(-)
+
+diff --git a/build.rs b/build.rs
+--- a/build.rs
++++ b/build.rs
+@@ -47,0 +48,1 @@ fn build_notification_helper() -> Result<()> {
++    println!("cargo:rustc-check-cfg=cfg(mise_notification_release_signed)");
+@@ -89,22 +89,24 @@ fn build_notification_helper() -> Result<()> {
+     let identity = env::var("MISE_NOTIFICATION_SIGN_IDENTITY").unwrap_or_else(|_| "-".into());
++    let release_signed = identity != "-";
+     println!(
+         "cargo:rustc-env=MISE_NOTIFICATION_RELEASE_SIGNED={}",
+-        if identity == "-" { "0" } else { "1" }
++        if release_signed { "1" } else { "0" }
+     );
+-    let mut codesign = Command::new("/usr/bin/codesign");
+-    codesign
+-        .args(["--force", "--sign"])
+-        .arg(&identity)
+-        .args(["--identifier", "dev.jdx.mise.notifications"]);
+-    if identity != "-" {
+-        codesign.args(["--options", "runtime", "--timestamp"]);
+-    }
+-    let signed = codesign.arg(&app).output()?;
+-    if !signed.status.success() {
+-        return Err(eyre!(
+-            "failed to sign the macOS notification helper: {}",
+-            String::from_utf8_lossy(&signed.stderr).trim()
+-        ));
+-    }
++    if release_signed {
++        println!("cargo:rustc-cfg=mise_notification_release_signed");
++        let mut codesign = Command::new("/usr/bin/codesign");
++        codesign
++            .args(["--force", "--sign"])
++            .arg(&identity)
++            .args(["--identifier", "dev.jdx.mise.notifications"])
++            .args(["--options", "runtime", "--timestamp"]);
++        let signed = codesign.arg(&app).output()?;
++        if !signed.status.success() {
++            return Err(eyre!(
++                "failed to sign the macOS notification helper: {}",
++                String::from_utf8_lossy(&signed.stderr).trim()
++            ));
++        }
++    }
+     Ok(())
+ }
+diff --git a/src/system/history/notify/macos.rs b/src/system/history/notify/macos.rs
+--- a/src/system/history/notify/macos.rs
++++ b/src/system/history/notify/macos.rs
+@@ -22,1 +22,2 @@
++#[cfg(mise_notification_release_signed)]
+ const CODE_RESOURCES: &[u8] = include_bytes!(concat!(
+@@ -31,10 +31,20 @@
++#[cfg(mise_notification_release_signed)]
++fn bundle_fingerprint() -> String {
++    crate::hash::hash_to_str(&(HELPER, INFO, ICON, CODE_RESOURCES))
++}
++
++#[cfg(not(mise_notification_release_signed))]
++fn bundle_fingerprint() -> String {
++    crate::hash::hash_to_str(&(HELPER, INFO, ICON))
++}
++
+ fn app_path(root: &Path) -> PathBuf {
+     // A versioned directory permits safe replacement without modifying a
+     // running helper. The bundle identifier remains stable across versions.
+-    let fingerprint = crate::hash::hash_to_str(&(HELPER, INFO, ICON, CODE_RESOURCES));
++    let fingerprint = bundle_fingerprint();
+     root.join(fingerprint).join("mise.app")
+ }
+ 
+ fn executable(app: &Path) -> PathBuf {
+     app.join("Contents/MacOS/mise-notify")
+ }
+@@ -42,8 +42,16 @@
+-fn complete(app: &Path) -> bool {
+-    executable(app).is_file()
+-        && app.join("Contents/Info.plist").is_file()
+-        && app.join("Contents/Resources/mise.icns").is_file()
+-        && app.join("Contents/_CodeSignature/CodeResources").is_file()
+-}
++#[cfg(mise_notification_release_signed)]
++fn complete(app: &Path) -> bool {
++    executable(app).is_file()
++        && app.join("Contents/Info.plist").is_file()
++        && app.join("Contents/Resources/mise.icns").is_file()
++        && app.join("Contents/_CodeSignature/CodeResources").is_file()
++}
++
++#[cfg(not(mise_notification_release_signed))]
++fn complete(app: &Path) -> bool {
++    executable(app).is_file()
++        && app.join("Contents/Info.plist").is_file()
++        && app.join("Contents/Resources/mise.icns").is_file()
++}
+ 
+ pub(super) fn notification(title: &str, body: &str) -> Result<Command> {
+@@ -78,14 +78,16 @@
+     let contents = staged.join("Contents");
+     std::fs::create_dir_all(contents.join("MacOS"))?;
+     std::fs::create_dir_all(contents.join("Resources"))?;
++    #[cfg(mise_notification_release_signed)]
+     std::fs::create_dir_all(contents.join("_CodeSignature"))?;
+     std::fs::write(executable(&staged), HELPER)?;
+     std::fs::set_permissions(executable(&staged), std::fs::Permissions::from_mode(0o755))?;
+     std::fs::write(contents.join("Info.plist"), INFO)?;
+     std::fs::write(contents.join("Resources/mise.icns"), ICON)?;
++    #[cfg(mise_notification_release_signed)]
+     std::fs::write(
+         contents.join("_CodeSignature/CodeResources"),
+         CODE_RESOURCES,
+     )?;
+     std::fs::create_dir_all(app.parent().unwrap())?;
+     if app.symlink_metadata().is_ok() {
+@@ -123,10 +123,11 @@
+         );
++        #[cfg(mise_notification_release_signed)]
+         assert!(
+             Command::new("/usr/bin/codesign")
+                 .args(["--verify", "--strict"])
+                 .arg(&app)
+                 .status()
+                 .unwrap()
+                 .success()
+         );
+         assert_eq!(ensure_app(temp.path()).unwrap(), app);

--- a/pkgs/by-name/mi/mise/package.nix
+++ b/pkgs/by-name/mi/mise/package.nix
@@ -5,33 +5,48 @@
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
+  writeShellScript,
   coreutils,
   bash,
   direnv,
-  git,
+  gitMinimal,
   pkg-config,
   openssl,
   cmake,
   cacert,
   tzdata,
+  python3,
   usage,
   testers,
   runCommand,
   jq,
 }:
 
+let
+  copyProbe = writeShellScript "mise-copy-probe" ''
+    if [ "$1" = "/bin/cp" ]; then
+      shift
+      set -- "${lib.getExe' coreutils "cp"}" "$@"
+    fi
+    exec ${lib.getExe' coreutils "cp"} "$@"
+  '';
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mise";
-  version = "2026.8.6";
+  version = "2026.9.3";
 
   src = fetchFromGitHub {
     owner = "jdx";
     repo = "mise";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dm+cIb6i+npYSIUfxaEi3ohumeT9lXXlQwYREndwZFE=";
+    hash = "sha256-o61fIIVKJrZd36O3sc1O9lEEoHMPH1sryasLXNckLWQ=";
   };
 
-  cargoHash = "sha256-VzRNo2fa4n4oOw27itjFebKpIhSdm8UmI/xdBBJIh9g=";
+  cargoHash = "sha256-22i9pURiN3CGgFRmG4VptpdR1MIryd3sCxtxOx9SMZA=";
+
+  patches = [
+    ./0001-darwin-skip-codesign-for-disabled-notifications.patch
+  ];
 
   nativeBuildInputs = [
     installShellFiles
@@ -47,11 +62,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ./src/cli/generate/git_pre_commit.rs \
       ./src/cli/generate/snapshots/*.snap
 
+    substituteInPlace ./src/agecrypt/fixtures/age-plugin-se.py \
+      --replace-fail '#!/usr/bin/env python3' '#!${lib.getExe python3}'
+
     substituteInPlace ./src/test.rs \
       --replace-fail '/usr/bin/env bash' '${lib.getExe bash}'
 
     substituteInPlace ./src/git.rs \
-      --replace-fail '"git"' '"${lib.getExe git}"'
+      --replace-fail '"git"' '"${lib.getExe gitMinimal}"'
 
     substituteInPlace ./src/env_diff.rs \
       --replace-fail '"bash"' '"${lib.getExe bash}"'
@@ -59,13 +77,25 @@ rustPlatform.buildRustPackage (finalAttrs: {
     substituteInPlace ./src/cli/direnv/exec.rs \
       --replace-fail '"env"' '"${lib.getExe' coreutils "env"}"' \
       --replace-fail 'cmd!("direnv"' 'cmd!("${lib.getExe direnv}"'
+
+    substituteInPlace ./src/backend/spm.rs \
+      --replace-fail 'symlink("/bin/cp", bin.join("copy-probe")).unwrap();' 'symlink("${copyProbe}", bin.join("copy-probe")).unwrap();'
+
+    substituteInPlace ./src/cmd.rs \
+      --replace-fail '.env("PATH", "/usr/bin:/bin")' '.env("PATH", "${lib.getBin coreutils}/bin:/usr/bin:/bin")'
+
+    substituteInPlace ./src/inline_command.rs \
+      --replace-fail '.env("PATH", "/usr/bin:/bin")' '.env("PATH", "${lib.getBin coreutils}/bin:/usr/bin:/bin")' \
+      --replace-fail 'Command::new("/bin/sh")' 'Command::new("${lib.getExe' bash "sh"}")'
   '';
 
   nativeCheckInputs = [
     cacert
     cmake
+    coreutils
     # gix spawns git-upload-pack by name in file:// clone tests.
-    git
+    gitMinimal
+    python3
     rustPlatform.bindgenHook
   ];
 
@@ -74,17 +104,25 @@ rustPlatform.buildRustPackage (finalAttrs: {
     NIX_CFLAGS_COMPILE = "-Wno-error";
     # tera date helper tests look up timezone data via TZDIR.
     TZDIR = "${tzdata}/share/zoneinfo";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    MISE_NOTIFICATION_SIGN_IDENTITY = "-";
   };
 
   checkFlags = [
     # last_modified will always be different in nix
     "--skip=tera::tests::test_last_modified"
+    # bootstrap node-gyp through aube requires network access
+    "--skip=mise_binary_services_aube_node_gyp_bootstrap_trampoline"
+    # we don't care about brew tests and a lot of them fails here
+    "--skip=system::packages::brew::cask::tests::"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
     # shell out to macOS system binaries that the darwin sandbox refuses to exec
     "--skip=system::defaults::tests::test_status_missing_keys_are_unset"
-    # we don't care about brew tests and a lot of them fails here
-    "--skip=system::packages::brew::cask::tests::"
+    # macOS's sandbox-exec is unavailable in the macOS Nix sandbox.
+    "--skip=cmd::tests::test_macos_sandbox_preserves_piped_stdin"
+    "--skip=sandbox::macos::tests::"
   ];
 
   cargoTestFlags = [ "--all-features" ];
@@ -96,10 +134,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postInstall = ''
     installManPage ./man/man1/mise.1
-
-    substituteInPlace ./completions/{mise.bash,mise.fish,_mise}  \
-      --replace-fail 'usage &> /dev/null' '${lib.getExe usage} &> /dev/null' \
-      --replace-fail 'usage complete-word' '${lib.getExe usage} complete-word'
 
     installShellCompletion \
       --bash ./completions/mise.bash \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/jdx/mise/releases/tag/v2026.9.3

I've added the following changes:

 - [mise](https://mise.jdx.dev/bootstrap/packages/brew.html) now supports Brew on Linux, so I skipped the tests no matter what the target platform is.
 - skipped bootstrapping node-gyp as it required network access
 - removed the substitutes in postInstall as they are no longer necessary
 - skipped tests that depend on sandbox-exec on macOS
 - added coreutils and python3 as dependencies for some of the tests
 - added a shell script to emulate cp as single binary in coreutils (instead of using `overrides single +Binary = false`, not worth it for a test)
 - patch out code signing for macOS
   - I used AI for this as I don't have access to a macOS machine

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
