### PR TITLE
nixos/bulwark: avoid IFD in plugin registry

### DIFF
--- a/nixos/modules/services/web-apps/bulwark.nix
+++ b/nixos/modules/services/web-apps/bulwark.nix
@@ -17,7 +17,6 @@ let
     nameValuePair
     optionalAttrs
     recursiveUpdate
-    trivial
     ;
 
   inherit (lib.types)
@@ -44,6 +43,43 @@ let
     lib.mapAttrs' (
       name: value: lib.nameValuePair (lib.strings.toCamelCase "${parent}_${name}") value
     ) cfg.settings."${parent}";
+
+  pluginRegistry =
+    pkgs.runCommand "bulwark-plugin-registry.json"
+      {
+        nativeBuildInputs = [
+          pkgs.coreutils
+          pkgs.jq
+        ];
+      }
+      ''
+        ${lib.concatStringsSep "\n" (
+          lib.imap0 (index: plugin: ''
+            manifest=${lib.escapeShellArg "${plugin.package}/manifest.json"}
+            bundle=${lib.escapeShellArg "${plugin.package}/index.js"}
+            pluginId=${lib.escapeShellArg plugin.package.pluginName}
+
+            if ! jq --exit-status --arg pluginId "$pluginId" '.id == $pluginId' "$manifest" >/dev/null; then
+              echo "Bulwark plugin manifest ID does not match package pluginName: $pluginId" >&2
+              exit 1
+            fi
+
+            bundleHash=$(sha256sum "$bundle" | cut -d ' ' -f 1)
+            jq \
+              --arg bundleHash "$bundleHash" \
+              --argjson forceEnabled ${lib.escapeShellArg (builtins.toJSON plugin.forceEnabled)} \
+              '. + { enabled: true, forceEnabled: $forceEnabled, bundleHash: $bundleHash }' \
+              "$manifest" \
+              > "$TMPDIR/${toString index}.json"
+          '') cfg.plugins
+        )}
+        manifests=(
+          ${lib.concatStringsSep "\n" (
+            lib.imap0 (index: _: ''"$TMPDIR/${toString index}.json"'') cfg.plugins
+          )}
+        )
+        jq --slurp '{ plugins: . }' "''${manifests[@]}" > "$out"
+      '';
 
   brandingModule = {
     appName = mkOption {
@@ -742,16 +778,7 @@ in
                     [
                       {
                         name = "registry.json";
-                        path = format.generate "registry.json" {
-                          plugins = map (
-                            plugin:
-                            (trivial.importJSON "${plugin.package.outPath}/manifest.json")
-                            // {
-                              enabled = true;
-                              forceEnabled = plugin.forceEnabled;
-                            }
-                          ) cfg.plugins;
-                        };
+                        path = pluginRegistry;
                       }
                     ]
                     ++ (map (plugin: {

--- a/nixos/tests/bulwark.nix
+++ b/nixos/tests/bulwark.nix
@@ -11,6 +11,13 @@
     services.bulwark = {
       enable = true;
       settings.allowCustomJmapEndpoint = true;
+      plugins = with pkgs.bulwark-plugins; [
+        {
+          package = calendar-agenda;
+          forceEnabled = true;
+        }
+        { package = spam-score; }
+      ];
     };
   };
 
@@ -22,6 +29,27 @@
 
     status = machine.succeed("curl -f http://localhost:3000/api/health")
     assert json.loads(status)["status"] == "healthy", "The fetched config does not match"
+
+    environment = machine.succeed("systemctl show bulwark --property=Environment --value")
+    config_dir = next(
+        value.split("=", 1)[1]
+        for value in environment.split()
+        if value.startswith("ADMIN_CONFIG_DIR=")
+    )
+    registry = json.loads(machine.succeed(f"cat {config_dir}/plugins/registry.json"))
+    plugins = {plugin["id"]: plugin for plugin in registry["plugins"]}
+    assert set(plugins) == {"calendar-agenda", "spam-score"}
+    assert plugins["calendar-agenda"]["enabled"] is True
+    assert plugins["calendar-agenda"]["forceEnabled"] is True
+    assert plugins["spam-score"]["enabled"] is True
+    assert plugins["spam-score"]["forceEnabled"] is False
+
+    for plugin_id, plugin in plugins.items():
+        expected_hash = machine.succeed(
+            f"sha256sum {config_dir}/plugins/{plugin_id}.js"
+        ).split()[0]
+        assert plugin["bundleHash"] == expected_hash
+        assert len(plugin["bundleHash"]) == 64
 
     machine.wait_until_succeeds("journalctl -u bulwark | grep -q 'scheduler not started'")
     machine.fail("journalctl -u bulwark | grep -q 'init skipped'")


### PR DESCRIPTION
The Bulwark module currently reads plugin manifests from derivation outputs during evaluation, which prevents configurations using plugins from evaluating with `allow-import-from-derivation = false`. This moves registry generation to build time and adds a SHA-256 `bundleHash` calculated from the exact `index.js` bytes served by Bulwark, enabling client-side integrity checks without adding manually maintained hashes to plugin package definitions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
