### PR TITLE
rust-rpxy: 0.13.2 -> 0.14.0, adopt

### DIFF
--- a/pkgs/by-name/ru/rust-rpxy/package.nix
+++ b/pkgs/by-name/ru/rust-rpxy/package.nix
@@ -2,20 +2,27 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  cacert,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rust-rpxy";
-  version = "0.13.2";
+  version = "0.14.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "junkurihara";
     repo = "rust-rpxy";
     tag = finalAttrs.version;
-    hash = "sha256-fdpr6HWMuMT0nXj7V5JQbiLVOGoWaTsX1OI+yCEErDA=";
+    hash = "sha256-yXcC5c0OfsJrn4zMubNNo9OxEH9Sg6MEhvPVRNgPlSM=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-WsK7eQffO+Ehx6H2Jj99XWON1Wc3Ud5Yaq1Nyz/oeSY=";
+  nativeBuildInputs = [
+    cacert
+  ];
+
+  cargoHash = "sha256-sehnZSQnlb1yd8A7iE/D5kuGX45QeIB2jcndpIt2Nzg=";
 
   meta = {
     description = "Http reverse proxy serving multiple domain names and terminating TLS for http/1.1, 2 and 3, written in Rust";
@@ -25,6 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit
     ];
     maintainers = with lib.maintainers; [
+      kybe236
       jpteb
     ];
     mainProgram = "rpxy";


### PR DESCRIPTION
## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
