### PR TITLE
[Backport release-26.05] netexec: fix broken ldap protocol

### DIFF
--- a/pkgs/by-name/ne/netexec/package.nix
+++ b/pkgs/by-name/ne/netexec/package.nix
@@ -15,7 +15,7 @@ let
           owner = "fortra";
           repo = "impacket";
           rev = "caba5facdd3a01b5d0decc6daf5871839f22f792";
-          hash = "sha256-jyn5qSSAipGYhHm2EROwDHa227mnmW+d+0H0/++i1OY=";
+          hash = "sha256-W7wXgUq34xzqbi/vEyUoKguaBmKeKGd6u3Oce39JHFc=";
         };
         # Fix version to be compliant with Python packaging rules
         postPatch = ''
@@ -23,6 +23,11 @@ let
             --replace 'version="{}.{}.{}.{}{}"' 'version="{}.{}.{}"'
         '';
       };
+      certipy-ad = super.certipy-ad.overridePythonAttrs (old: {
+        # NetExec pins impacket to a 0.14.0 dev revision; certipy-ad still
+        # declares impacket~=0.13.0, so relax it to build against 0.14.0.
+        pythonRelaxDeps = (old.pythonRelaxDeps or [ ]) ++ [ "impacket" ];
+      });
     };
   };
 in


### PR DESCRIPTION
Backport of #561330 to `release-26.05`.

`netexec`'s ldap protocol is broken at runtime: every `nxc ldap …` aborts with
`TypeError: LDAPConnection.__init__() got an unexpected keyword argument 'signing'`.
The impacket override's recorded `hash` does not match the pinned `rev`
(`caba5fac`); since a fetchFromGitHub FOD is content-addressed by its hash and that
output is cached, Nix substitutes a stale impacket 0.13.0 (no `signing` argument)
instead of the intended 0.14.0. Correcting the hash pulls in impacket 0.14.0, which
in turn requires relaxing `certipy-ad`'s `impacket~=0.13.0` constraint.

Cherry-picked cleanly from master; on this branch impacket's consumer is named
`bloodhound-py`, unaffected by the change.

### Verification (on `release-26.05`)

- `nix-build -A netexec` builds green, the 36 upstream tests pass.
- `nixfmt` reports no changes needed.
- `nxc ldap <dc> --users` against a test Samba AD DC now authenticates and
  enumerates users, no `TypeError`.

## Things done

- [x] Built on platform(s): x86_64-linux
- [x] Ran the package's tests (36 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
