### PR TITLE
coqPackages: {withPackage,rocq-core} should use coq from the scope

### DIFF
--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -59,13 +59,13 @@ let
           withPackages =
             f:
             (callPackage ../applications/science/logic/coq/with-packages.nix {
-              inherit coq;
+              inherit (self) coq;
             })
               (f self);
         };
       });
 
-      rocq-core = coq;
+      rocq-core = self.coq;
 
       contribs = lib.recurseIntoAttrs (callPackage ../development/rocq-modules/contribs { });
 


### PR DESCRIPTION

Previously if one override the coq package in the coqPackages scope, the withPackages and rocq-core attribute don't follow, and a wrong instance of coq will be used.
    
    
This should cause no rebuild. Will later backport because this is also present in 26.05.

<details>

<summary>Test with the following expression</summary>
Put the following expression in a local clone of nixpkgs and `nix-build` it.
It would crash, the two versions in the error message should match.

```nix
let
  version = "8.8.0";
  coqOverlay = final: prev: {
    inherit (final.myCoqPackages) coq;

    myCoqPackages = prev.coqPackages_8_8.overrideScope (
      _: prevCoqPkgs: {
        coq = prevCoqPkgs.coq.override (oldArgs: {
          buildIde = true;

          inherit version;
          rocqPackages = oldArgs.rocqPackages.overrideScope (
            _: oldRocqPackages: { rocq-core = oldRocqPackages.rocq-core.override { inherit version; }; }
          );
        });
      }
    );
  };

  pkgs = import ./. { overlays = [ coqOverlay ]; };
  lib = pkgs.lib;
in

throw ''
  withPackages returned a package of version ${lib.getVersion (pkgs.coq.withPackages (_: [ ]))}
  rocq-core returned a package of version ${lib.getVersion (pkgs.myCoqPackages.rocq-core)}
  we wanted the version ${version}
''
```

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
