### PR TITLE
libnice: 0.1.23 -> 0.1.24

### DIFF
--- a/pkgs/by-name/li/libnice/package.nix
+++ b/pkgs/by-name/li/libnice/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   testers,
   fetchFromGitLab,
-  fetchpatch,
   nix-update-script,
   meson,
   ninja,
@@ -27,7 +26,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libnice";
-  version = "0.1.23";
+  version = "0.1.24";
 
   outputs = [
     "bin"
@@ -41,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libnice";
     repo = "libnice";
     tag = finalAttrs.version;
-    hash = "sha256-UPppE5kBois0jJwsHKefBC8iTfSIkPZXV6XnUBnEFn8=";
+    hash = "sha256-7y+yTf/kp4uy9LZCbcMisA1892csBjdXQU5mOVnrxRY=";
   };
 
   patches = [
@@ -51,12 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   # TODO: investigate what's wrong
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    (fetchpatch {
-      name = "freebsd.patch";
-      url = "https://gitlab.freedesktop.org/libnice/libnice/-/commit/479f0813a571ff035bf00de679db452a0441125b.patch";
-      hash = "sha256-rr8pAb8TjU85jYWUjsMMKkLxxXVE3B+IjfAyOw9suo0=";
-    })
-
     # https://gitlab.freedesktop.org/libnice/libnice/-/merge_requests/353
     ./musl.patch
   ];


### PR DESCRIPTION
libnice release 0.1.24: https://lists.freedesktop.org/archives/nice/2026-September/001517.html
Also enabled tests, just had to patch out two tests that don't work in the sandbox. (~~Not sure whether they work on Darwin yet, will try to check that in a moment~~ there were more failures on Darwin, I feel like the necessary patching would outweigh the benefits)

If you're interested in a better disabledTests experience for meson, please review my other PR that would provide direct `disabledTests` support for meson: #552282
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
