### PR TITLE
open-fonts: use installFonts

### DIFF
--- a/pkgs/by-name/op/open-fonts/package.nix
+++ b/pkgs/by-name/op/open-fonts/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchurl,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -13,14 +14,7 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-NJKbdrvgZz9G7mjAJYzN7rU/fo2xRFZA2BbQ+A56iPw=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/share/fonts/truetype
-    install *.ttf $out/share/fonts/truetype
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Collection of beautiful free and open source fonts";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- https://github.com/NixOS/nixpkgs/issues/495640

- After switching to the `installFonts` hook it persists with the same exact `truetype` fonts list
- Now `opentype` fonts are also available, as follows:
- ➜  opentype ls -l
total 5748
-r--r--r-- 1 root root 512780 dez 31  1969 LibertinusMath-Regular.otf
-r--r--r-- 1 root root 237260 dez 31  1969 LibertinusSerif-BoldItalic.otf
-r--r--r-- 1 root root 279816 dez 31  1969 LibertinusSerif-Bold.otf
-r--r--r-- 1 root root 315896 dez 31  1969 LibertinusSerif-Italic.otf
-r--r--r-- 1 root root 298224 dez 31  1969 LibertinusSerif-Regular.otf
-r--r--r-- 1 root root 371432 dez 31  1969 LibertinusSerif-SemiboldIt.otf
-r--r--r-- 1 root root 314816 dez 31  1969 LibertinusSerif-Semibold.otf
-r--r--r-- 1 root root 808220 dez 31  1969 STIXTwoMath.otf
-r--r--r-- 1 root root 390908 dez 31  1969 STIXTwoText-BoldItalic.otf
-r--r--r-- 1 root root 368288 dez 31  1969 STIXTwoText-Bold.otf
-r--r--r-- 1 root root 387080 dez 31  1969 STIXTwoText-Italic.otf
-r--r--r-- 1 root root 366380 dez 31  1969 STIXTwoText-Regular.otf
-r--r--r-- 1 root root 112820 dez 31  1969 XITS-BoldItalic.otf
-r--r--r-- 1 root root 154292 dez 31  1969 XITS-Bold.otf
-r--r--r-- 1 root root 116744 dez 31  1969 XITS-Italic.otf
-r--r--r-- 1 root root 548096 dez 31  1969 XITSMath-Regular.otf
-r--r--r-- 1 root root 270632 dez 31  1969 XITS-Regular.otf

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
