### PR TITLE
xgboost: modernize, remove use of `cudatoolkit`

### DIFF
--- a/pkgs/by-name/xg/xgboost/package.nix
+++ b/pkgs/by-name/xg/xgboost/package.nix
@@ -64,8 +64,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     cmake
   ]
   ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [ llvmPackages.openmp ]
-  ++ lib.optionals cudaSupport [ cudaPackages.cudatoolkit ]
-  ++ lib.optionals cudaSupport [ autoAddDriverRunpath ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+    autoAddDriverRunpath
+  ]
   ++ lib.optionals rLibrary [ R ];
 
   buildInputs = [

--- a/pkgs/by-name/xg/xgboost/package.nix
+++ b/pkgs/by-name/xg/xgboost/package.nix
@@ -14,7 +14,7 @@
   llvmPackages,
   R,
   rPackages,
-}@inputs:
+}:
 
 assert ncclSupport -> (cudaSupport && cudaPackages.nccl.meta.available);
 # Disable regular tests when building the R package
@@ -28,9 +28,7 @@ let
   # This ensures xgboost gets the correct libstdc++ when
   # built with cuda support. This may be removed once
   # #226165 rewrites cudaStdenv
-  effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else inputs.stdenv;
-  # Ensures we don't use the stdenv value by accident.
-  stdenv = throw "Use effectiveStdenv instead of stdenv in xgboost derivation.";
+  effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
 in
 
 effectiveStdenv.mkDerivation (finalAttrs: {
@@ -88,16 +86,17 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags =
-    lib.optionals doCheck [ "-DGOOGLE_TEST=ON" ]
+    lib.optionals doCheck [ (lib.cmakeBool "GOOGLE_TEST" true) ]
     ++ lib.optionals cudaSupport [
-      "-DUSE_CUDA=ON"
+      (lib.cmakeBool "USE_CUDA" true)
       # Their CMakeLists.txt does not respect CUDA_HOST_COMPILER, instead using the CXX compiler.
       # https://github.com/dmlc/xgboost/blob/ccf43d4ba0a94e2f0a3cc5a526197539ae46f410/CMakeLists.txt#L145
-      "-DCMAKE_C_COMPILER=${effectiveStdenv.cc}/bin/gcc"
-      "-DCMAKE_CXX_COMPILER=${effectiveStdenv.cc}/bin/g++"
+      (lib.cmakeFeature "CMAKE_C_COMPILER" "${effectiveStdenv.cc}/bin/gcc")
+      (lib.cmakeFeature "CMAKE_CXX_COMPILER" "${effectiveStdenv.cc}/bin/g++")
+      (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
     ]
-    ++ lib.optionals ncclSupport [ "-DUSE_NCCL=ON" ]
-    ++ lib.optionals rLibrary [ "-DR_LIB=ON" ];
+    ++ lib.optionals ncclSupport [ (lib.cmakeBool "USE_NCCL" true) ]
+    ++ lib.optionals rLibrary [ (lib.cmakeBool "R_LIB" true) ];
 
   preConfigure = lib.optionalString rLibrary ''
     substituteInPlace cmake/RPackageInstall.cmake.in --replace "CMD INSTALL" "CMD INSTALL -l $out/library"
@@ -113,7 +112,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   '';
 
   env = {
-    # on Darwin, cmake uses find_library to locate R instead of using the PATH
+    # on Darwin, cmake uses find_libraryto locate R instead of using the PATH
     NIX_LDFLAGS = lib.optionalString rLibrary "-L${R}/lib/R/lib";
 
     # Disable finicky tests from dmlc core that fail in Hydra. XGboost team

--- a/pkgs/by-name/xg/xgboost/package.nix
+++ b/pkgs/by-name/xg/xgboost/package.nix
@@ -33,7 +33,7 @@ let
   stdenv = throw "Use effectiveStdenv instead of stdenv in xgboost derivation.";
 in
 
-effectiveStdenv.mkDerivation rec {
+effectiveStdenv.mkDerivation (finalAttrs: {
   pnameBase = "xgboost";
   # prefix with r when building the R library
   # The R package build results in a special xgboost.so file
@@ -50,10 +50,14 @@ effectiveStdenv.mkDerivation rec {
   pname = lib.optionalString rLibrary "r-" + "xgboost";
   version = "3.0.5";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+  __darwinAllowLocalNetworking = true;
+
   src = fetchFromGitHub {
     owner = "dmlc";
     repo = "xgboost";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-khaD9gvKfUyWhkrIZXzGzKw/nfgeTcp9akCi5X3IORo=";
   };
@@ -62,15 +66,20 @@ effectiveStdenv.mkDerivation rec {
     cmake
   ]
   ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [ llvmPackages.openmp ]
+  ++ lib.optionals cudaSupport [ cudaPackages.cudatoolkit ]
   ++ lib.optionals cudaSupport [ autoAddDriverRunpath ]
   ++ lib.optionals rLibrary [ R ];
 
   buildInputs = [
     gtest
   ]
-  ++ lib.optional cudaSupport cudaPackages.cudatoolkit
-  ++ lib.optional cudaSupport cudaPackages.cuda_cudart
-  ++ lib.optional ncclSupport cudaPackages.nccl;
+  ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp # 'omp.h' file not found
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart # cuda_runtime.h
+  ]
+  ++ lib.optionals ncclSupport [ cudaPackages.nccl ];
 
   propagatedBuildInputs = lib.optionals rLibrary [
     rPackages.data_table
@@ -203,4 +212,4 @@ effectiveStdenv.mkDerivation rec {
       nviets
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
