### PR TITLE
baekmuk-ttf: use installFonts

### DIFF
--- a/pkgs/by-name/ba/baekmuk-ttf/package.nix
+++ b/pkgs/by-name/ba/baekmuk-ttf/package.nix
@@ -2,29 +2,31 @@
   lib,
   stdenvNoCC,
   fetchurl,
+  installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "baekmuk-ttf";
   version = "2.2";
 
   src = fetchurl {
-    url = "http://kldp.net/baekmuk/release/865-${pname}-${version}.tar.gz";
+    url = "http://kldp.net/baekmuk/release/865-baekmuk-ttf-${finalAttrs.version}.tar.gz";
     hash = "sha256-CKt9/7VdWIfMlCzjcPXjO3VqVfu06vC5DyRAcOjVGII=";
   };
 
   installPhase = ''
     runHook preInstall
 
-    install -m444 -Dt $out/share/fonts        ttf/*.ttf
-    install -m444 -Dt $out/share/doc/${pname}-${version}  COPYRIGHT*
+    install -m444 -Dt $out/share/doc/baekmuk-ttf-${finalAttrs.version}  COPYRIGHT*
 
     runHook postInstall
   '';
+
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Korean font";
     homepage = "http://kldp.net/projects/baekmuk/";
     license = lib.licenses.baekmuk;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- https://github.com/NixOS/nixpkgs/issues/495640

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
