### PR TITLE
python3Packages.mlflow: 3.15.2 -> 3.16.0

### DIFF
--- a/pkgs/development/python-modules/mlflow-skinny/default.nix
+++ b/pkgs/development/python-modules/mlflow-skinny/default.nix
@@ -8,6 +8,7 @@
   setuptools,
 
   # dependencies
+  anyio,
   cachetools,
   click,
   cloudpickle,
@@ -40,7 +41,7 @@ buildPythonPackage (finalAttrs: {
     owner = "mlflow";
     repo = "mlflow";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-G5PybKonwsAg1MLOF9wc10RJE0x948+EVbcDq1+94mc=";
+    hash = "sha256-2nWu+P9bGAl+1p3ZfxO2XdBMrfePJI6EBk82r99w480=";
   };
 
   postPatch = ''
@@ -55,6 +56,7 @@ buildPythonPackage (finalAttrs: {
   build-system = [ setuptools ];
 
   dependencies = [
+    anyio
     cachetools
     click
     cloudpickle

--- a/pkgs/development/python-modules/mlflow-tracing/default.nix
+++ b/pkgs/development/python-modules/mlflow-tracing/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage (finalAttrs: {
     owner = "mlflow";
     repo = "mlflow";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-G5PybKonwsAg1MLOF9wc10RJE0x948+EVbcDq1+94mc=";
+    hash = "sha256-2nWu+P9bGAl+1p3ZfxO2XdBMrfePJI6EBk82r99w480=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -6,6 +6,7 @@
   # dependencies
   aiohttp,
   alembic,
+  anyio,
   cryptography,
   docker,
   flask,
@@ -27,7 +28,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mlflow";
-  version = "3.15.2";
+  version = "3.16.0";
   format = "wheel";
   __structuredAttrs = true;
 
@@ -39,7 +40,7 @@ buildPythonPackage (finalAttrs: {
     format = "wheel";
     dist = "py3";
     python = "py3";
-    hash = "sha256-eqWWZDUaqm9jR4zzwml3wYXbpg0ovKi5pRJb46K0MRw=";
+    hash = "sha256-xKxehjSqytGj19WhoxvpJ5WT69SLhCcoQ2gtsRlwz3E=";
   };
 
   # Nix-wrapped python populates sys.path via NIX_PYTHONPATH/site hooks,
@@ -50,17 +51,10 @@ buildPythonPackage (finalAttrs: {
     patch -p1 -d "$out/lib/python"*/site-packages < ${./subprocess-pythonpath.patch}
   '';
 
-  pythonRelaxDeps = [
-    "cryptography"
-
-    # 3.14.0 dependency check fails with pandas >= 3.0. But the code changes required are minimal
-    # (strings are now `str` instead of `numpy.object`.)
-    "pandas"
-  ];
-
   dependencies = [
     aiohttp
     alembic
+    anyio
     cryptography
     docker
     flask


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added new dependency `anyio`, removed unnecessary relaxs. Full upstream changelog: https://github.com/mlflow/mlflow/releases/tag/v3.16.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
