### PR TITLE
pythonDocs: 3.14.6 -> 3.14.7

### DIFF
--- a/pkgs/development/interpreters/python/cpython/docs/3.14-texinfo.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/3.14-texinfo.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation {
   pname = "python314-docs-texinfo";
-  version = "3.14.6";
+  version = "3.14.7";
 
   src = fetchurl {
-    url = "https://www.python.org/ftp/python/doc/3.14.6/python-3.14.6-docs-texinfo.tar.bz2";
-    sha256 = "0nwdvgnxs6sik0d1kkl6fnnhxrvmj356i92abp84i33d4dy6i9hw";
+    url = "https://www.python.org/ftp/python/doc/3.14.7/python-3.14.7-docs-texinfo.tar.bz2";
+    sha256 = "sha256-FezukFw4rQTPbc8CUB1Afn3VgEDCvgaZAUGp+wv7AmI=";
   };
   installPhase = ''
     mkdir -p $out/share/info

--- a/pkgs/development/interpreters/python/cpython/docs/3.14-text.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/3.14-text.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation {
   pname = "python314-docs-text";
-  version = "3.14.6";
+  version = "3.14.7";
 
   src = fetchurl {
-    url = "https://www.python.org/ftp/python/doc/3.14.6/python-3.14.6-docs-text.tar.bz2";
-    sha256 = "0flqq4k9fq948gb3zim04znyxr21pfv8i4mrhh3qwna13fh897zg";
+    url = "https://www.python.org/ftp/python/doc/3.14.7/python-3.14.7-docs-text.tar.bz2";
+    sha256 = "sha256-CTat/lWLaXZ/50nMy/mddBxMG8CS13g6pGW2V0jRMoo=";
   };
   installPhase = ''
     mkdir -p $out/share/doc/python314

--- a/pkgs/development/interpreters/python/cpython/docs/generate.sh
+++ b/pkgs/development/interpreters/python/cpython/docs/generate.sh
@@ -50,6 +50,7 @@ EOF
         echo "Generating ${outfile}"
         url=$(echo -n $URL |sed -e "s,VERSION,${version},g" -e "s,TYPE,${type},")
         sha=$(nix-prefetch-url ${url} ${hash})
+        sha=$(nix hash convert --from nix32 --to sri --hash-algo sha256 "$sha")
 
 
         sed -e "s,VERSION,${version}," \


### PR DESCRIPTION
Updates the remaining sub-pkgs or pythonDocs. `pythonDocs.html.python314` (and only that) was already bumped in #550514.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `5de6d42bcb5de2cfe99c72854091f23bce62136d`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>pythonDocs.texinfo.python314</li>
    <li>pythonDocs.text.python314</li>
  </ul>
</details>