### PR TITLE
discord: fix macOS "app is damaged" issue

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -40,6 +40,15 @@ let
 
   src = fetchurl { inherit (source.distro) url hash; };
 
+  # Keep the modules outside the .app. Discord ships a notarized Developer ID
+  # signature whose sealed resource envelope covers everything under Contents/,
+  # so extracting them in there invalidates it and macOS refuses to launch the
+  # app through LaunchServices, reporting that it is damaged. Nothing reads them
+  # from the bundle: stageModules uses this directory only as the source for the
+  # symlinks it puts in the user data directory, which is where Discord's module
+  # loader looks.
+  modulesDir = "share/${pname}/modules";
+
   fixDistroSymlinks = writeScript "discord-fix-distro-symlinks.py" ''
     #!${python3.interpreter}
     import pathlib
@@ -102,8 +111,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     ${lib.concatStringsSep "\n" (
       lib.mapAttrsToList (name: src: ''
-        mkdir -p "$out/Applications/${desktopName}.app/Contents/Resources/modules/${name}"
-        extractDistro ${src} "$out/Applications/${desktopName}.app/Contents/Resources/modules/${name}"
+        mkdir -p "$out/${modulesDir}/${name}"
+        extractDistro ${src} "$out/${modulesDir}/${name}"
       '') moduleSrcs
     )}
 
@@ -111,7 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/bin
     makeWrapper "$out/Applications/${desktopName}.app/Contents/MacOS/${binaryName}" "$out/bin/${binaryName}" \
       ${lib.strings.optionalString disableUpdates "--run ${lib.getExe finalAttrs.disableBreakingUpdates}"} \
-      --run "${finalAttrs.stageModules} \"$out/Applications/${desktopName}.app/Contents/Resources/modules\"" \
+      --run "${finalAttrs.stageModules} \"$out/${modulesDir}\"" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
     runHook postInstall


### PR DESCRIPTION
Fixes: #544338

### Root cause

Discord's `.app` carries a notarized Developer ID signature from Discord, Inc. Its sealed resource envelope covers everything below `Contents/`. However, currently the nixpkgs package extracts the native modules into `Contents/Resources/modules`, which invalidates the signature:

```console
$ codesign --verify --deep --strict Discord.app
Discord.app: a sealed resource is missing or invalid
file added: .../Contents/Resources/modules/discord_rpc/index.js
file added: .../Contents/Resources/modules/discord_arborium/index.js
[...]
```

### The fix

Extract the modules to `$out/share/<pname>/modules` instead of into the bundle.

With this, the signature verifies again, untouched:

```console
$ codesign --verify --deep --strict Discord.app
Discord.app: valid on disk
Discord.app: satisfies its Designated Requirement

$ spctl -a -t exec -vvv Discord.app
Discord.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Discord, Inc. (53Q6R32WPB)
```

## AI disclosure

The code change is written by Claude Opus 5. I reproduced the failure on my own machine, verified the fix works, and reviewed the diff and the reasoning. I have been running the patched package as my daily Discord.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

`nixpkgs-review` on `aarch64-darwin`, 4 packages built: `discord`, `discord-canary`, `discord-development`, `discord-ptb`. Each places its modules under its own `share/<pname>/modules`, and each is accepted by `spctl`. Only `darwin.nix` changes, so Linux is unaffected.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
