### PR TITLE
gix-of-theseus: init at 0-unstable-2025-11-04

### DIFF
--- a/pkgs/by-name/gi/gix-of-theseus/0001-invoke-script-directly.patch
+++ b/pkgs/by-name/gi/gix-of-theseus/0001-invoke-script-directly.patch
@@ -1,0 +1,130 @@
+From dc6a2f346fcef780e635fedb08e29af4cd30bd98 Mon Sep 17 00:00:00 2001
+From: Daniel Woffinden <daw@hey.com>
+Date: Tue, 8 Sep 2026 19:54:29 +0100
+Subject: [PATCH] invoke script directly
+
+---
+ src/main.rs | 19 ++++++-----------
+ src/plot.rs | 59 +++++------------------------------------------------
+ 2 files changed, 11 insertions(+), 67 deletions(-)
+
+diff --git a/src/main.rs b/src/main.rs
+index 149fe36..ddf6f26 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -64,7 +64,6 @@ fn main() -> Result<()> {
+     match args.subcommand {
+         Subcommands::Plot(args) => plot::run_stackplot(args.input_file, args.output_file, None),
+         Subcommands::Analyze(args) => {
+-            let python_runner = plot::get_python_runner();
+             let repo_path = Path::new(&args.repo_path);
+             let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+ 
+@@ -73,18 +72,12 @@ fn main() -> Result<()> {
+             let cohorts_file = analyze_repo(&args.repo_path, outdir.clone(), args.all_filetypes)
+                 .expect("Error analyzing repo");
+             if !args.no_plot {
+-                if python_runner.is_some() {
+-                    let image_file = outdir.join("stackplot.png");
+-                    plot::run_stackplot(
+-                        cohorts_file.display().to_string().clone(),
+-                        image_file.display().to_string(),
+-                        Some(repo_name.to_string()),
+-                    )?;
+-                } else {
+-                    println!(
+-                        "No Python PEP 723 script runner found (tried: uv, pipx), we won't be able to plot the chart automatically and will only save the raw to cohorts.json.\nYou can install uv with `pip install uv` or pipx with `pip install pipx`"
+-                    );
+-                }
++                let image_file = outdir.join("stackplot.png");
++                plot::run_stackplot(
++                    cohorts_file.display().to_string().clone(),
++                    image_file.display().to_string(),
++                    Some(repo_name.to_string()),
++                )?;
+             }
+             Ok(())
+         }
+diff --git a/src/plot.rs b/src/plot.rs
+index 017adbd..cc4d1df 100644
+--- a/src/plot.rs
++++ b/src/plot.rs
+@@ -1,70 +1,21 @@
+ use anyhow::Result;
+-use std::io::Write;
+ use std::process::Command;
+-use std::sync::OnceLock;
+-use std::{env, fs};
+ 
+-const STACKPLOT_SCRIPT: &str = include_str!("stackplot.py");
+-
+-static PYTHON_SCRIPT_RUNNER: OnceLock<Option<String>> = OnceLock::new();
+-
+-pub fn get_python_runner() -> Option<String> {
+-    PYTHON_SCRIPT_RUNNER
+-        .get_or_init(|| {
+-            let runners = ["uv", "pipx"];
+-
+-            for runner in runners {
+-                if Command::new(runner)
+-                    .arg("--version")
+-                    .output()
+-                    .map(|output| output.status.success())
+-                    .unwrap_or(false)
+-                {
+-                    return Some(runner.to_string());
+-                }
+-            }
+-
+-            None
+-        })
+-        .clone()
+-}
+ pub fn run_stackplot(input_file: String, output_file: String, title: Option<String>) -> Result<()> {
+-    let runner = get_python_runner().ok_or_else(|| anyhow::anyhow!("No Python runner found"))?;
++    let path = "stackplot.py";
+ 
+-    let mut path = env::temp_dir();
+-    path.push("stackplot.py");
+-
+-    let mut file = fs::File::create(&path)?;
+-    file.write_all(STACKPLOT_SCRIPT.as_bytes())?;
+-
+-    let status = if runner == "uv" {
+-        Command::new(&runner)
+-            .arg("run")
+-            .arg(&path)
+-            .arg("--outfile")
+-            .arg(output_file)
+-            .arg("--title")
+-            .arg(title.unwrap_or_default())
+-            .arg(input_file)
+-            .status()?
+-    } else if runner == "pipx" {
+-        Command::new(&runner)
+-            .arg("run")
+-            .arg(&path)
++    let status =
++        Command::new(&path)
+             .arg("--outfile")
+             .arg(output_file)
+             .arg("--title")
+             .arg(title.unwrap_or_default())
+             .arg(input_file)
+-            .status()?
+-    } else {
+-        anyhow::bail!("Unsupported runner: {}", runner);
+-    };
++            .status()?;
+ 
+     if !status.success() {
+-        anyhow::bail!("Failed to execute '{} run {}'", runner, path.display());
++        anyhow::bail!("Failed to execute '{}'", path);
+     }
+ 
+-    fs::remove_file(path)?;
+     Ok(())
+ }
+-- 
+2.54.0
+

--- a/pkgs/by-name/gi/gix-of-theseus/package.nix
+++ b/pkgs/by-name/gi/gix-of-theseus/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  python3Packages,
+  makeWrapper,
+}:
+let
+  version = "0-unstable-2025-11-04";
+  src = fetchFromGitHub {
+    owner = "amedeedaboville";
+    repo = "gix-of-theseus";
+    rev = "33ae4919c326cfcf6ab50fde5eaac425145b905c";
+    hash = "sha256-79JfmLlmUftdxw7NI/VWuDBFqaxLaG6eHIPuYip4hfg=";
+  };
+  stackplot = python3Packages.buildPythonApplication {
+    pname = "stackplot";
+    inherit src version;
+
+    pyproject = false;
+
+    dependencies = with python3Packages; [
+      matplotlib
+      numpy
+      python-dateutil
+    ];
+    dontWrapPythonPrograms = true;
+    nativeBuildInputs = [ makeWrapper ];
+
+    installPhase = ''
+      runHook preInstall
+
+      install -D src/stackplot.py -t $out/${python3Packages.python.sitePackages}
+
+      makeWrapper ${python3Packages.python.interpreter} $out/bin/stackplot \
+        --add-flags $out/${python3Packages.python.sitePackages}/stackplot.py \
+        --prefix PYTHONPATH : "$out/${python3Packages.python.sitePackages}:$PYTHONPATH"
+
+      runHook postInstall
+    '';
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gix-of-theseus";
+  __structuredAttrs = true;
+
+  inherit src version;
+
+  cargoHash = "sha256-GLfHQeJGAbFQVTek1hBZ8U2omyiuty2nnnHdbdlG0/4=";
+
+  passthru.updateScript = nix-update-script { };
+
+  patches = [
+    ./0001-invoke-script-directly.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace src/plot.rs \
+      --replace-fail \
+        'let path = "stackplot.py";' \
+        'let path = "'${stackplot}'/bin/stackplot";'
+  '';
+
+  meta = {
+    description = "A Rust rewrite of git-of-theseus";
+    homepage = "https://github.com/amedeedaboville/gix-of-theseus";
+    changelog = "https://github.com/amedeedaboville/gix-of-theseus/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.dwoffinden ];
+    mainProgram = "gix-of-theseus";
+  };
+})


### PR DESCRIPTION
https://amedee.me/introducing-gix-of-theseus

It's a Rust binary that invokes a PEP-723 script.
Upstream expects uv/pipx, so patch that out and package the embedded
python script directly.

- https://github.com/amedeedaboville/gix-of-theseus/blob/33ae4919c326cfcf6ab50fde5eaac425145b905c/src/plot.rs#L40
- https://github.com/amedeedaboville/gix-of-theseus/blob/33ae4919c326cfcf6ab50fde5eaac425145b905c/src/stackplot.py#L1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
