### PR TITLE
nixos/ollama: fix shellcheck issues

### DIFF
--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -353,8 +353,8 @@ in
                 ''
             }
             if [ -n "$undeclared" ]; then
-              echo removing: $undeclared
-              '${ollama}' rm $undeclared
+              echo "removing: $undeclared"
+              echo "$undeclared" | '${xargs}' -r '${ollama}' rm
             fi
           ''}
 


### PR DESCRIPTION
Fixes when `systemd.enableStrictShellChecks = true` set

```
Output paths:
  /nix/store/dc6s6159hbnw60d876xnbzw945rplsxl-unit-script-ollama-model-loader-start
Last 18 log lines:
>
> In /nix/store/dc6s6159hbnw60d876xnbzw945rplsxl-unit-script-ollama-model-loader-start/bin/ollama-model-loader-start line 13:
>   echo removing: $undeclared
>                  ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
>
> Did you mean:
>   echo removing: "$undeclared"
>
>
> In /nix/store/dc6s6159hbnw60d876xnbzw945rplsxl-unit-script-ollama-model-loader-start/bin/ollama-model-loader-start line 14:
>   '/nix/store/n7lg2yyw1b35si3p35bz15kvmqya6jd0-ollama-0.33.1/bin/ollama' rm $undeclared
>                                                                             ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
>
> Did you mean:
>   '/nix/store/n7lg2yyw1b35si3p35bz15kvmqya6jd0-ollama-0.33.1/bin/ollama' rm "$undeclared"
>
> For more information:
>   https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
For full logs, run:
  nix log /nix/store/lbvhxk8l4fya7nnjv5xln03hhllmhmib-unit-script-ollama-model-loader-start.drv
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
