### PR TITLE
nixos/llama-cpp: improve cli to commandline handling

### DIFF
--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -111,7 +111,13 @@ in
         ExecStart = toString [
           (lib.getExe' cfg.package "llama-server")
           (lib.cli.toCommandLine (optionName: {
-            option = if builtins.stringLength optionName > 1 then "--${optionName}" else "-${optionName}";
+            option =
+              if lib.hasPrefix "-" optionName then
+                optionName
+              else if builtins.stringLength optionName > 1 then
+                "--${optionName}"
+              else
+                "-${optionName}";
             sep = " ";
             explicitBool = false;
             formatArg = lib.generators.mkValueStringDefault { };


### PR DESCRIPTION
I've recently started using llama cpp and I see this small issue with `settings` opt. Please read below.

Two reasons for this change:
- Param "ngl" has a length of 3, so it incorrectly renders --ngl
- Param "hf" has a length of 2, so it incorrectly renders --hf

After this change, users will be able to
- Explicit hyphen: "-hf" -> outputs: -hf
- Explicit double hyphen: "--ngl" -> outputs: --ngl
- No hyphen: "n-gpu-layers" -> outputs: --n-gpu-layers
- Single-character fallback: "c" -> outputs: -c

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
