### PR TITLE
truecrack: modernize and remove cudatoolkit

### DIFF
--- a/pkgs/by-name/tr/truecrack/package.nix
+++ b/pkgs/by-name/tr/truecrack/package.nix
@@ -2,6 +2,7 @@
   lib,
   gccStdenv,
   cudaPackages,
+  autoAddDriverRunpath,
   fetchFromGitLab,
   config,
   cudaSupport ? config.cudaSupport,
@@ -15,6 +16,9 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "truecrack";
   version = "3.6";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitLab {
     owner = "kalilinux";
@@ -32,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = (
     if cudaSupport then
       [
-        "--with-cuda=${cudaPackages.cudatoolkit}"
+        "--with-cuda=${lib.getLib cudaPackages.cuda_nvcc}"
       ]
     else
       [
@@ -42,10 +46,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+  ]
+  ++ lib.optionals cudaSupport [
+    autoAddDriverRunpath
   ];
 
   buildInputs = lib.optionals cudaSupport [
-    cudaPackages.cudatoolkit
     cudaPackages.cuda_cudart
   ];
 
@@ -67,28 +73,29 @@ stdenv.mkDerivation (finalAttrs: {
 
   installFlags = [ "prefix=$(out)" ];
 
-  doInstallCheck = !cudaSupport;
-
+  doInstallCheck = false;
+  nativeInstallCheckInputs = [ versionCheckHook ];
   installCheckPhase = ''
     runHook preInstallCheck
 
     echo "Cracking test volumes"
-    $out/bin/${finalAttrs.meta.mainProgram} -t test/ripemd160_aes.test.tc -w test/passwords.txt | grep -aF "Found password"
-    $out/bin/${finalAttrs.meta.mainProgram} -t test/ripemd160_aes.test.tc -c test/tes -m 4 | grep -aF "Found password"
-    $out/bin/${finalAttrs.meta.mainProgram} -t test/ripemd160_aes.test.tc -w test/passwords.txt | grep -aF "Found password"
-    $out/bin/${finalAttrs.meta.mainProgram} -t test/whirlpool_aes.test.tc -w test/passwords.txt -k whirlpool | grep -aF "Found password"
-    $out/bin/${finalAttrs.meta.mainProgram} -t test/sha512_aes.test.tc -w test/passwords.txt -k sha512 | grep -aF "Found password"
-    $out/bin/${finalAttrs.meta.mainProgram} -t test/ripemd160_aes.test.tc -w test/passwords.txt | grep -aF "Found password"
-    $out/bin/${finalAttrs.meta.mainProgram} -t test/ripemd160_serpent.test.tc -w test/passwords.txt -e serpent | grep -aF "Found password"
-    $out/bin/${finalAttrs.meta.mainProgram} -t test/ripemd160_twofish.test.tc -w test/passwords.txt -e twofish | grep -aF "Found password"
+    $out/bin/truecrack -t test/ripemd160_aes.test.tc -w test/passwords.txt | grep -aF "Found password"
+    $out/bin/truecrack -t test/ripemd160_aes.test.tc -c test/tes -m 4 | grep -aF "Found password"
+    $out/bin/truecrack -t test/ripemd160_aes.test.tc -w test/passwords.txt | grep -aF "Found password"
+    $out/bin/truecrack -t test/whirlpool_aes.test.tc -w test/passwords.txt -k whirlpool | grep -aF "Found password"
+    $out/bin/truecrack -t test/sha512_aes.test.tc -w test/passwords.txt -k sha512 | grep -aF "Found password"
+    $out/bin/truecrack -t test/ripemd160_aes.test.tc -w test/passwords.txt | grep -aF "Found password"
+    $out/bin/truecrack -t test/ripemd160_serpent.test.tc -w test/passwords.txt -e serpent | grep -aF "Found password"
+    $out/bin/truecrack -t test/ripemd160_twofish.test.tc -w test/passwords.txt -e twofish | grep -aF "Found password"
     echo "Finished cracking test volumes"
 
     runHook postInstallCheck
   '';
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+  passthru.gpuCheck = finalAttrs.finalPackage.overrideAttrs (oldAttrs: {
+    requiredSystemFeatures = [ "cuda" ];
+    doInstallCheck = true;
+  });
 
   meta = {
     description = "Brute-force password cracker for TrueCrypt volumes, optimized for Nvidia Cuda technology";


### PR DESCRIPTION
Signed-off-by: Ethan Carter Edwards <ethan@ethancedwards.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
