### PR TITLE
mcap-cli: 0.0.62 -> 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27777,6 +27777,12 @@
     name = "Steve Streza";
     keys = [ { fingerprint = "DFED 4E42 34E7 348C 57D4  6568 C4DC 30F8 5ABC 6FA1"; } ];
   };
+  stfl = {
+    email = "nixpkgs@stfl.dev";
+    github = "stfl";
+    githubId = 1321542;
+    name = "Stefan Lendl";
+  };
   stianlagstad = {
     email = "stianlagstad@gmail.com";
     github = "stianlagstad";

--- a/pkgs/by-name/mc/mcap-cli/package.nix
+++ b/pkgs/by-name/mc/mcap-cli/package.nix
@@ -1,64 +1,52 @@
 {
-  stdenv,
   lib,
-  buildGoModule,
+  stdenv,
   buildPackages,
+  rustPlatform,
   fetchFromGitHub,
   installShellFiles,
   nix-update-script,
 }:
-let
-  version = "0.0.62";
-in
-buildGoModule {
 
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mcap-cli";
-
-  inherit version;
+  version = "0.3.0";
 
   src = fetchFromGitHub {
-    repo = "mcap";
     owner = "foxglove";
-    rev = "releases/mcap-cli/v${version}";
-    hash = "sha256-lVTL+pa+gTPQWj7+RmaJUIdfOlPhlGtHujBalR+GDsI=";
+    repo = "mcap";
+    tag = "releases/mcap-cli/v${finalAttrs.version}";
+    hash = "sha256-QVJA/RZPamkBYkFNJn9uB1/cok6lEF/U7ssmdmzp4og=";
   };
 
-  vendorHash = "sha256-Q1TjUlS7+fV2HBQk108c+o/9IRpDc9C8jzBk048Mkig=";
+  cargoHash = "sha256-7WsGJd+KNNCke9pmvwN6zi0bDXBGfQcEotIxyYdUWAo=";
 
-  nativeBuildInputs = [
-    installShellFiles
-  ];
+  # The repository root is a Cargo workspace of the `mcap` library and this CLI;
+  # build and test only the CLI member.
+  buildAndTestSubdir = "rust/cli";
 
-  modRoot = "go/cli/mcap";
-
-  tags = [
-    "sqlite_omit_load_extension"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    "netgo"
-    "osusergo"
-  ];
-
-  ldflags = [ "-X github.com/foxglove/mcap/go/cli/mcap/cmd.Version=${version}" ];
-
-  env = {
-    CGO_ENABLED = "1";
-    GOWORK = "off";
-  };
-
-  # copy the local versions of the workspace modules
-  postConfigure = ''
-    chmod -R u+w vendor
-    rm -rf vendor/github.com/foxglove/mcap/go/{mcap,ros}
-    cp -r ../../{mcap,ros} vendor/github.com/foxglove/mcap/go
-  '';
-
+  # The tests these skip read fixtures under testdata/ and tests/conformance/data/, which
+  # are Git LFS objects: a source tarball carries the pointer files, not the payload.
+  # https://github.com/foxglove/mcap/issues/895
   checkFlags = [
-    # requires git-lfs and network
-    # https://github.com/foxglove/mcap/issues/895
-    "-skip=TestCat|TestInfo|TestRequiresDuplicatedSchemasForIndexedMessages|TestPassesIndexedMessagesWithRepeatedSchemas|TestSortFile"
+    "--skip=commands::cat::tests::cat_falls_back_for_summary_channel_with_in_chunk_schema"
+    "--skip=commands::cat::tests::cat_indexed_applies_topic_filter_to_chunk_local_channels"
+    "--skip=commands::cat::tests::cat_indexed_reads_chunk_index_without_message_indexes_and_in_chunk_channels"
+    "--skip=commands::cat::tests::cat_indexed_reads_message_index_with_in_chunk_channels"
+    "--skip=commands::cat::tests::chunk_local_channels_keep_remote_topic_plan_conservative"
+    "--skip=commands::convert::ros1_bag::tests::convert_real_bz2_ros1_bag_fixture"
+    "--skip=commands::convert::ros1_bag::tests::convert_real_uncompressed_ros1_bag_fixture"
+    "--skip=commands::convert::ros2_db3::tests::converts_iron_talker_db3_with_embedded_schemas"
+    "--skip=commands::convert::ros2_db3::tests::rejects_humble_talker_db3_without_embedded_schemas"
+    "--skip=commands::convert::ros2_db3::tests::rejects_humble_talker_db3_without_truncating_existing_output"
+    "--skip=commands::convert::tests::convert_command_handles_noetic_generated_ros1_bags"
   ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
+  # Completions come out of the built binary, so a cross build needs an emulator to
+  # run it. Guarding on emulatorAvailable rather than canExecute keeps all three
+  # shells installed when one exists, and skips them only when none does.
   postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
     let
       emulator = stdenv.hostPlatform.emulator buildPackages;
@@ -70,18 +58,23 @@ buildGoModule {
         --zsh <(${emulator} $out/bin/mcap completion zsh)
     ''
   );
-  passthru = {
-    updateScript = nix-update-script { };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "releases/mcap-cli/v(.*)"
+    ];
   };
 
   meta = {
     description = "MCAP CLI tool to inspect and fix MCAP files";
     homepage = "https://github.com/foxglove/mcap";
+    changelog = "https://github.com/foxglove/mcap/releases/tag/releases/mcap-cli/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       therishidesai
+      stfl
     ];
     mainProgram = "mcap";
   };
-
-}
+})


### PR DESCRIPTION
Upstream rewrote the `mcap` CLI in Rust and continued the same release line, so this replaces the existing `buildGoModule` derivation rather than adding a second attribute.

The version jump crosses a language and builder change, which is why the update bot has not carried it and the package has sat at 0.0.62 since March:

| Tag | |
|---|---|
| `releases/mcap-cli/v0.0.62` | Go, 2026-02-25 — what nixpkgs packages today |
| `releases/mcap-cli/v0.1.0` | Rust rewrite, 2026-06-11 |
| `releases/mcap-cli/v0.2.0` | 2026-06-15 |
| `releases/mcap-cli/v0.3.0` | 2026-07-15 — this PR |

One tag namespace, no fork in the release line. The [v0.1.0 notes](https://github.com/foxglove/mcap/releases/tag/releases%2Fmcap-cli%2Fv0.1.0) open with:

> The `mcap` CLI has been rewritten in Rust. It is a drop-in replacement for the previous release (v0.0.x) with the same commands, a smaller binary, new remote and read capabilities, and a number of other changes described below.

and `go/cli` no longer exists in the repository as of the `v0.3.0` tag, so there is no Go CLI left to package separately.

## What changed in the derivation

- `buildGoModule` → `rustPlatform.buildRustPackage`, with `buildAndTestSubdir = "rust/cli"` because the repository root is a Cargo workspace holding the `mcap` library alongside the CLI.
- `cargoHash` rather than `cargoLock.lockFile`, so the derivation stays free of IFD.
- The `checkFlags` skips are the Rust-side spelling of the ones the Go derivation already carried, and they have the same cause: those tests `include_bytes!` fixtures from `testdata/` and `tests/conformance/data/`, which are Git LFS objects, and the source tarball carries the pointer files rather than the payload (foxglove/mcap#895). 338 unit tests and 13 integration tests still run.
- Shell completions keep the existing emulator-guarded `installShellFiles` block unchanged.
- `passthru.updateScript` gains `--version-regex 'releases/mcap-cli/v(.*)'` so `nix-update` follows this tag series rather than the other release lines in the monorepo.
- `meta` gains a `changelog`. `meta.platforms` stays unset, as in the derivation this replaces, so each builder contributes its own toolchain's list: 30 platforms via Go, 38 via Rust. Both include `aarch64-linux` and `aarch64-darwin`, so no platform loses the package.

## Overlap with #560711

@joe-saronic — #560711 adds `passthru.tests.full` to the Go derivation and touches the same file, so these two cannot both land as written, and I would rather not steamroll work that is already open. Your reasoning about the LFS fixtures carries over directly: the same class of tests is skipped here, for the same reason. A `passthru.tests` that fetches the LFS payload would be a strict improvement on top of this. Happy to defer, rebase on top of yours, or fold an equivalent in — whichever you and @therishidesai prefer.

## Maintainers

@therishidesai — you are the current maintainer. I have kept you in `meta.maintainers` and added myself alongside rather than replacing you; say the word if you would rather not carry a Rust package and I will take it on solo.

## Disclosure

Per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy): the derivation, the commit messages and this description were prepared with Claude Code (Claude Opus 5, `claude-opus-5`). Both commits carry `Assisted-by:` trailers. I have reviewed the change myself before marking it ready, and I am accountable for it.

Verification actually run and read, rather than assumed:

- `nix-build -A mcap-cli` on x86_64-linux against this branch.
- `mcap --version` reports `mcap 0.3.0 (21755244b) mcap-rust/0.25.0` from the built output.
- All three completion files are installed and non-empty (`share/bash-completion/completions/mcap.bash`, `share/zsh/site-functions/_mcap`, `share/fish/vendor_completions.d/mcap.fish`).
- Build log shows `338 passed; 0 failed; 11 filtered out` plus `13 passed`.
- `nix-build -A pkgsCross.aarch64-multiplatform.mcap-cli` also succeeds, covering aarch64-linux by cross-compilation. The result is an `ELF 64-bit LSB pie executable, ARM aarch64`, and all three completions are present in it, so the emulator-guarded `postInstall` still fires under cross. Caveat worth stating: `doCheck` evaluates to `false` for the cross derivation and `true` for the native one, so this proves compilation and installation on aarch64 but not the tests — the 338 + 13 tests ran only in the native x86_64-linux build. It is a cross-build, not a native aarch64 build, so I have left that checkbox unticked.
- `nixpkgs-review rev HEAD` on x86_64-linux, merged onto current `master` in a clean worktree: `1 package updated: mcap-cli (0.0.62 -> 0.3.0)` and `1 package built: mcap-cli`, nothing failed. That also confirms the blast radius independently of the grep below.
- `nixfmt` clean on both changed files.
- Nothing else in the tree references `mcap-cli`, so this replacement has no reverse dependencies.

aarch64-darwin is **not** built — I have no darwin machine — so that platform is unproven here. Worth flagging that CI will not close that gap either: the `Build /` jobs build the CI shell, docs, lib and tarball rather than changed packages, and the `Eval /` jobs only evaluate. A reviewer running `nixpkgs-review` on darwin, or Hydra post-merge, is what would actually prove it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux — cross-built from x86_64-linux (see verification above), not built natively
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
