### PR TITLE
pulseaudio: replace systemd dependency with systemdLibs

### DIFF
--- a/pkgs/by-name/pu/pulseaudio/package.nix
+++ b/pkgs/by-name/pu/pulseaudio/package.nix
@@ -29,7 +29,7 @@
   fftwFloat,
   soxr,
   speexdsp,
-  systemd,
+  systemdLibs,
   webrtc-audio-processing_1,
   gst_all_1,
   check,
@@ -43,7 +43,7 @@
 
   x11Support ? false,
 
-  useSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  useSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
 
   # Whether to support the JACK sound system as a backend.
   jackaudioSupport ? false,
@@ -150,7 +150,7 @@ stdenv.mkDerivation rec {
       libxi
       libxtst
     ]
-    ++ lib.optional useSystemd systemd
+    ++ lib.optional useSystemd systemdLibs
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       alsa-lib
       udev


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

more [cleanup](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Aaanderse+systemdLibs)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
