### PR TITLE
gnome-control-center: depend on gdm for the org.gnome.login-screen schema

### DIFF
--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -13,6 +13,7 @@
   docbook-xsl-nons,
   fontconfig,
   gdk-pixbuf,
+  gdm,
   gettext,
   glib,
   glib-networking,
@@ -114,6 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
     cups
     fontconfig
     gdk-pixbuf
+    gdm # org.gnome.login-screen schema, gates the fingerprint row in the Users panel
     glib
     glib-networking
     gcr_4


### PR DESCRIPTION
gnome-control-center's Users panel only shows the "Fingerprint Login" row when it can load GDM's `org.gnome.login-screen` schema (`panels/system/users/cc-user-page.c`, `update_fingerprint_row_state`); otherwise the row is hidden before fprintd is consulted. The schema is installed by `gdm` under `share/gsettings-schemas/gdm-<version>`, which the gnome-control-center wrapper did not carry. GNOME Shell's wrapper does, but `org.gnome.Settings.desktop` is `DBusActivatable=true`: the Shell starts Settings through D-Bus activation, it runs as `dbus-:1.x-org.gnome.Settings@N.service` under the user manager, and it gets the manager's environment rather than the Shell's. So on NixOS the row never appeared, even with `services.fprintd.enable = true` and a reader libfprint supports, which looks exactly like an unsupported reader.

This adds `gdm` to `buildInputs`, so the glib setup hook puts its schema directory on the wrapper's `XDG_DATA_DIRS` the same way the gtk3 and mutter schemas get there. The first revision did this in the GDM module through `environment.sessionVariables`; moved to the package wrapper per review.

Fixes #561267

Tested on NixOS 26.05 (GNOME 50, gnome-control-center 50.4, gdm 50.2, fprintd 1.94.10, HP EliteBook 845 G10 with an Elan MOC reader, USB 04f3:0c82), with this commit cherry-picked onto `nixos-26.05`:

- The new wrapper carries `…-gdm-50.2/share/gsettings-schemas/gdm-50.2` in its `XDG_DATA_DIRS` prefix; closure grows by about 22 MB / 10 paths (gdm, xorg-server, plymouth and their deps) on 1.95 GB, and on a system with GDM enabled those paths are already present.
- Visibility check without relying on the session: `update_fingerprint_row_state` shows the row iff `settings_or_null ("org.gnome.login-screen")` is non-NULL (for one's own local account, with the key's default of `true`), and GLib mmaps every `gschemas.compiled` it loads, so `/proc/<pid>/maps` of the panel tells whether the schema was found. Started `gnome-control-center users` under the user manager with every gdm entry removed from the session's `XDG_DATA_DIRS`: the patched build maps `gdm-50.2/…/glib-2.0/schemas/gschemas.compiled`, the unpatched build from the same store does not. With the unpatched build the row is missing from Settings → System → Users, as reported in the issue; with the workaround from the issue (or this change) it is shown and enrolment works.
- Why the Shell's environment does not cover this: a Settings started from the Shell runs as `dbus-:1.1-org.gnome.Settings@1.service` (parent `systemd --user`, D-Bus activation); its `/proc/<pid>/environ` has the g-c-c wrapper's mutter entries and the session's entries, but not the Shell wrapper's gdm entry.

Disclosure per the automation/AI policy: the change, commit message and this description were produced with Claude Code (Claude Fable 5.1) and reviewed by me; see the `Assisted-by:` trailer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
