### PR TITLE
actionlint: 1.7.12 -> 1.16.1, change fork due to new maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15212,6 +15212,12 @@
     githubId = 49951907;
     name = "Karl Zschiebsch";
   };
+  kjanat = {
+    email = "info@kajkowalski.nl";
+    github = "kjanat";
+    githubId = 6353477;
+    name = "Kaj Kowalski";
+  };
   kjeremy = {
     email = "kjeremy@gmail.com";
     name = "Jeremy Kolb";

--- a/pkgs/by-name/ac/actionlint/package.nix
+++ b/pkgs/by-name/ac/actionlint/package.nix
@@ -5,34 +5,70 @@
   installShellFiles,
   makeWrapper,
   python3Packages,
-  ronn,
+  pandoc,
   shellcheck,
+  nix-update-script,
+  git,
+  bash,
+  zsh,
+  fish,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "actionlint";
-  version = "1.7.12";
+  version = "1.16.1";
 
   subPackages = [ "cmd/actionlint" ];
 
   src = fetchFromGitHub {
-    owner = "rhysd";
+    owner = "kjanat";
     repo = "actionlint";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mACSb3sYQtkijzk10mPi2ndy3zakonW1jlU7D/DV+SM=";
+    hash = "sha256-zlBSx7zFUEmTMmCL8J0SSUGN8kQrWPlmq84BzYqsuXw=";
   };
 
-  vendorHash = "sha256-bPhjeC6xcemV4KZx+Kc/Wbdz6Be6WsiolFTrJ7TURA0=";
+  env.CGO_ENABLED = 0;
+  ldflags = [
+    "-s"
+    "-w"
+    "-X actionlint.kjanat.dev.version=${finalAttrs.version}"
+    "-X actionlint.kjanat.dev.installedFrom=Nix"
+  ];
+
+  vendorHash = "sha256-PVEf1pJvwQu/2dFS0YhWoXahnTqvqmRdYjVfujjs04k=";
 
   nativeBuildInputs = [
     makeWrapper
-    ronn
+    pandoc
     installShellFiles
   ];
 
+  nativeCheckInputs = [
+    git
+    bash
+    zsh
+    fish
+    shellcheck
+    python3Packages.pyflakes
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+    go test ./...
+    runHook postCheck
+  '';
+
   postInstall = ''
-    ronn --roff man/actionlint.1.ronn
+    make man/actionlint.1 PANDOC='pandoc --standalone --from=markdown-smart ${
+      if lib.versionOlder pandoc.version "3.8" then "--no-highlight" else "--syntax-highlighting=none"
+    }'
     installManPage man/actionlint.1
+    installShellCompletion --cmd actionlint \
+      --bash <("$out/bin/actionlint" -completion bash) \
+      --zsh <("$out/bin/actionlint" -completion zsh) \
+      --fish <("$out/bin/actionlint" -completion fish)
+    install -Dm644 actionlint.schema.json "$out/share/actionlint/actionlint.schema.json"
     wrapProgram "$out/bin/actionlint" \
       --prefix PATH : ${
         lib.makeBinPath [
@@ -42,18 +78,14 @@ buildGoModule (finalAttrs: {
       }
   '';
 
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/rhysd/actionlint.version=${finalAttrs.version}"
-  ];
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "https://rhysd.github.io/actionlint/";
+    homepage = "https://kjanat.github.io/actionlint/";
     description = "Static checker for GitHub Actions workflow files";
-    changelog = "https://github.com/rhysd/actionlint/raw/v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/kjanat/actionlint/raw/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ voidlily ];
     mainProgram = "actionlint";
   };
 })

--- a/pkgs/by-name/ac/actionlint/package.nix
+++ b/pkgs/by-name/ac/actionlint/package.nix
@@ -85,7 +85,10 @@ buildGoModule (finalAttrs: {
     description = "Static checker for GitHub Actions workflow files";
     changelog = "https://github.com/kjanat/actionlint/raw/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ voidlily ];
+    maintainers = with lib.maintainers; [
+      kjanat
+      voidlily
+    ];
     mainProgram = "actionlint";
   };
 })


### PR DESCRIPTION
https://github.com/rhysd/actionlint/issues/719#issuecomment-5526734416

due to inactivity on the original actionlint repo, a volunteer (@kjanat) stepped up to maintain a fork (thank you for doing this!)

the currently maintained fork is at https://github.com/kjanat/actionlint

changes: https://github.com/kjanat/actionlint/blob/master/CHANGELOG.md (includes divider for all changes new since last upstream release)

however, consensus has not been established yet among other distros, with arch being the only other distro on this fork, and calling it actionlint-kjanat. most distros are still packaging 1.7.12

open points for discussion:
* what establishes consensus for kjanat's fork being the "canonical" one? see above note, and [current state of repology](https://repology.org/projects/?search=actionlint&maintainer=&category=&inrepo=&notinrepo=&repos=&families=&repos_newest=&families_newest=)
* should actionlint itself be updated to point at the fork, or should there be a new package named after the fork instead?

nice to have (but not required for merge):
* pandoc>=3.8 - https://github.com/NixOS/nixpkgs/issues/461018


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
