### PR TITLE
libffi-wasm: init at 20260905

### DIFF
--- a/pkgs/by-name/li/libffi-wasm/package.nix
+++ b/pkgs/by-name/li/libffi-wasm/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  buildPackages,
+  callPackage,
+  clang-tools,
+  fetchFromGitLab,
+  stdenv,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libffi-wasm";
+  version = "20260905";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.haskell.org";
+    owner = "haskell-wasm";
+    repo = "libffi-wasm";
+    tag = finalAttrs.version;
+    hash = "sha256-VBsLHSWoq32qwuQOR1dkPIMm3gJiNwThpjEMR4CGOf0=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    (buildPackages.haskellPackages.ghcWithPackages (p: [
+      p.async
+      p.language-c
+    ]))
+    clang-tools
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wall"
+    "-Wextra"
+    "-mcpu=mvp"
+    "-Oz"
+    "-DNDEBUG"
+    "-Icbits"
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    runghc -isrc app/Main.hs
+
+    for f in cbits/*.c; do
+      $CC -c "$f" -o "''${f%.c}.o"
+    done
+    $AR rcs libffi.a cbits/*.o
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 -t "$dev/include" cbits/*.h
+    install -Dm444 -t "$out/lib" libffi.a
+
+    mkdir -p "$dev/lib/pkgconfig"
+    cat > "$dev/lib/pkgconfig/libffi.pc" <<EOF
+    prefix=$out
+    libdir=\''${prefix}/lib
+    includedir=$dev/include
+
+    Name: libffi-wasm
+    Description: ${finalAttrs.meta.description}
+    Version: ${finalAttrs.version}
+    Libs: -L\''${libdir} -lffi
+    Cflags: -I\''${includedir}
+    EOF
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests = {
+      pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
+      upstream = callPackage ./test.nix { libffi-wasm = finalAttrs.finalPackage; };
+    };
+    updateScript = buildPackages.nix-update-script { };
+  };
+
+  meta = {
+    description = "Limited implementation of libffi for wasm32";
+    longDescription = ''
+      A limited libffi implementation for wasm32. Supports up to 4 arguments
+      and 16 closures per function type. Structures and variadic functions are
+      unsupported. The closure API differs from upstream libffi.
+    '';
+    homepage = "https://gitlab.haskell.org/haskell-wasm/libffi-wasm";
+    changelog = "https://gitlab.haskell.org/haskell-wasm/libffi-wasm/-/tags/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ilkecan ];
+    platforms = [ "wasm32-wasip1" ];
+    pkgConfigModules = [ "libffi" ];
+  };
+})

--- a/pkgs/by-name/li/libffi-wasm/test.nix
+++ b/pkgs/by-name/li/libffi-wasm/test.nix
@@ -1,0 +1,33 @@
+{
+  buildPackages,
+  libffi-wasm,
+  stdenv,
+}:
+
+buildPackages.runCommand "libffi-wasm-upstream-tests"
+  {
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    nativeBuildInputs = [
+      stdenv.cc
+      buildPackages.wasmtime
+    ];
+
+    buildInputs = [
+      libffi-wasm
+    ];
+
+    env = {
+      NIX_CFLAGS_COMPILE = "-mcpu=mvp";
+      NIX_LDFLAGS = "-lffi";
+    };
+  }
+  ''
+    cp -r ${libffi-wasm.src}/cbits_test cbits_test
+    pushd cbits_test
+    chmod +w .
+    HOME=$TMPDIR ./test.sh
+    popd
+    touch $out
+  ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5944,7 +5944,15 @@ with pkgs;
   # merged upstream. This is needed by some packages (such as cffi).
   #
   # `libffiReal` is provided in case the upstream libffi package is needed on Darwin instead of the fork.
-  libffi = if stdenv.hostPlatform.isDarwin then darwin.libffi else libffiReal;
+  #
+  # wasm32-wasi uses a limited libffi implementation because upstream libffi's wasm backend requires Emscripten.
+  libffi =
+    if stdenv.hostPlatform.isDarwin then
+      darwin.libffi
+    else if stdenv.hostPlatform.isWasi && stdenv.hostPlatform.is32bit then
+      libffi-wasm
+    else
+      libffiReal;
 
   # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=blob;f=README;h=fd6e1a83f55696c1f7a08f6dfca08b2d6b7617ec;hb=70058cd9f944d620764e57c838209afae8a58c78#l118
   libgpg-error-gen-posix-lock-obj = libgpg-error.override {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [libffi-wasm](https://gitlab.haskell.org/haskell-wasm/libffi-wasm) as `libffi` for `wasm32-wasip1`. Upstream libffi's WebAssembly backend requires Emscripten and can't be built for WASI.

This provides a usable subset of `libffi` (not full API compatibility) and allow us to provide a buildable `pkgsCross.wasi32.libffi`.

For reference, this unblocks one of the two dependency build failures for the GHC wasm target mentioned in https://github.com/NixOS/nixpkgs/pull/558928.

Also related: https://github.com/NixOS/nixpkgs/issues/220835, https://github.com/NixOS/nixpkgs/pull/225000 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
