### PR TITLE
[26.05] treewide: remove `optional cond [...]`

### DIFF
--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -270,7 +270,7 @@ in
           popd
         '';
 
-        restartTriggers = lib.optional (!cfg.mutableConfig) [ printerConfig ];
+        restartTriggers = lib.optionals (!cfg.mutableConfig) [ printerConfig ];
 
         serviceConfig = {
           ExecStart = "${cfg.package}/bin/klippy ${klippyArgs} ${cfg.configDir}/printer.cfg";

--- a/nixos/modules/services/misc/pinchflat.nix
+++ b/nixos/modules/services/misc/pinchflat.nix
@@ -16,6 +16,7 @@ let
     getExe
     literalExpression
     optional
+    optionals
     attrValues
     mapAttrs
     ;
@@ -158,7 +159,7 @@ in
           "LOG_LEVEL=${cfg.logLevel}"
           "PHX_SERVER=true"
         ]
-        ++ optional cfg.selfhosted [ "RUN_CONTEXT=selfhosted" ]
+        ++ optionals cfg.selfhosted [ "RUN_CONTEXT=selfhosted" ]
         ++ optional (!isNull config.time.timeZone) "TZ=${config.time.timeZone}"
         ++ attrValues (mapAttrs (name: value: name + "=" + toString value) cfg.extraConfig);
         EnvironmentFile = optional (cfg.secretsFile != null) cfg.secretsFile;

--- a/nixos/modules/services/monitoring/prometheus/exporters/restic.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/restic.nix
@@ -16,7 +16,7 @@ let
     mapAttrs'
     splitString
     toUpper
-    optional
+    optionals
     optionalAttrs
     nameValuePair
     ;
@@ -145,7 +145,7 @@ in
       LoadCredential = [
         "RESTIC_PASSWORD_FILE:${cfg.passwordFile}"
       ]
-      ++ optional (cfg.repositoryFile != null) [ "RESTIC_REPOSITORY:${cfg.repositoryFile}" ];
+      ++ optionals (cfg.repositoryFile != null) [ "RESTIC_REPOSITORY:${cfg.repositoryFile}" ];
     };
     environment =
       let

--- a/nixos/modules/services/monitoring/vmagent.nix
+++ b/nixos/modules/services/monitoring/vmagent.nix
@@ -152,7 +152,7 @@ in
           startCLIList
           ++ lib.optionals (cfg.prometheusConfig != { }) [ "-promscrape.config=${prometheusConfigYml}" ]
         );
-        LoadCredential = lib.optional (cfg.remoteWrite.basicAuthPasswordFile != null) [
+        LoadCredential = lib.optionals (cfg.remoteWrite.basicAuthPasswordFile != null) [
           "remote_write_basic_auth_password:${cfg.remoteWrite.basicAuthPasswordFile}"
         ];
       };

--- a/nixos/modules/services/web-servers/garage.nix
+++ b/nixos/modules/services/web-servers/garage.nix
@@ -133,7 +133,7 @@ in
             # if data_dir is a list, the actual path will in in the `path` attribute of each item
             # see https://garagehq.deuxfleurs.fr/documentation/reference-manual/configuration/#data_dir
             ++ lib.optional (lib.isList data_dir) (map (item: item.path) data_dir)
-            ++ lib.optional (lib.isString data_dir) [ data_dir ]
+            ++ lib.optionals (lib.isString data_dir) [ data_dir ]
           );
           isDefault = lib.hasPrefix "/var/lib/garage";
           isDefaultStateDirectory = lib.any isDefault paths;

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1578,7 +1578,7 @@ in
           SystemCallFilter = [
             "~@cpu-emulation @debug @keyring @mount @obsolete @privileged @setuid"
           ]
-          ++ optional cfg.enableQuicBPF [ "bpf" ];
+          ++ optionals cfg.enableQuicBPF [ "bpf" ];
         };
       };
 

--- a/nixos/modules/services/web-servers/stargazer.nix
+++ b/nixos/modules/services/web-servers/stargazer.nix
@@ -271,7 +271,7 @@ in
           "~CAP_SYS_BOOT"
           "~CAP_NET_ADMIN"
         ]
-        ++ lib.lists.optional (!cfg.allowCgiUser) [
+        ++ lib.lists.optionals (!cfg.allowCgiUser) [
           "~CAP_SETGID"
           "~CAP_SETUID"
         ];
@@ -279,7 +279,7 @@ in
         SystemCallFilter = [
           "~@cpu-emulation @debug @keyring @mount @obsolete"
         ]
-        ++ lib.lists.optional (!cfg.allowCgiUser) [ "@privileged @setuid" ];
+        ++ lib.lists.optionals (!cfg.allowCgiUser) [ "@privileged @setuid" ];
       };
     };
 

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -295,7 +295,7 @@ stdenv.mkDerivation (
     dontConfigure = true;
     noDumpEnvVars = true;
 
-    stripExclude = lib.optional hasVsceSign [
+    stripExclude = lib.optionals hasVsceSign [
       # vsce-sign is a single executable application built with Node.js, and it becomes non-functional if stripped
       "lib/vscode/resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign"
     ];

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -185,7 +185,7 @@ mkDerivation rec {
     "-DQGIS_MACAPP_BUNDLE=0" # Don't copy Qt into bundle; we fix paths in postFixup
     "-DSQLITE3_INCLUDE_DIR=${sqlite.dev}/include" # FindSqlite3.cmake incorrectly assumes framework
   ]
-  ++ lib.optional withServer [
+  ++ lib.optionals withServer [
     "-DWITH_SERVER=True"
     "-DQGIS_CGIBIN_SUBDIR=${placeholder "out"}/lib/cgi-bin"
   ]

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -190,7 +190,7 @@ stdenv.mkDerivation rec {
     "-DSQLITE3_INCLUDE_DIR=${sqlite.dev}/include"
     "-DUSE_OPENCL=OFF"
   ]
-  ++ lib.optional withServer [
+  ++ lib.optionals withServer [
     "-DWITH_SERVER=True"
     "-DQGIS_CGIBIN_SUBDIR=${placeholder "out"}/lib/cgi-bin"
   ]

--- a/pkgs/build-support/teleport/default.nix
+++ b/pkgs/build-support/teleport/default.nix
@@ -162,10 +162,10 @@ buildGoModule (finalAttrs: {
     ++ [
       ./rdpclient.patch
     ]
-    ++ lib.optional (lib.versionOlder version "18.8.0") [
+    ++ lib.optionals (lib.versionOlder version "18.8.0") [
       ./0001-fix-add-nix-path-to-exec-env.patch
     ]
-    ++ lib.optional (lib.versionAtLeast version "18.8.0") [
+    ++ lib.optionals (lib.versionAtLeast version "18.8.0") [
       ./0001-fix-add-nix-path-to-exec-env-reexec.patch
     ];
 

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -192,7 +192,7 @@ stdenv.mkDerivation {
     license =
       with lib.licenses;
       [ mit ]
-      ++ lib.optional enableVCVRack [
+      ++ lib.optionals enableVCVRack [
         gpl3Plus
         cc-by-nc-40
         unfreeRedistributable

--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "STOP_BUILD_ON_WARNING" stdenv.hostPlatform.isLinux)
     (lib.cmakeBool "INSTALL_VENDORED_LIBS" false)
   ]
-  ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     # Fix (RiscV) cross-compilation
     # See https://github.com/apache/orc/issues/2334
     (lib.cmakeFeature "HAS_PRE_1970_EXITCODE" "0")

--- a/pkgs/by-name/as/astyle/package.nix
+++ b/pkgs/by-name/as/astyle/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   # upstream repo includes a build/ directory
   cmakeBuildDir = "_build";
 
-  cmakeFlags = lib.optional asLibrary [
+  cmakeFlags = lib.optionals asLibrary [
     "-DBUILD_SHARED_LIBS=ON"
   ];
 

--- a/pkgs/by-name/bo/bowtie2/package.nix
+++ b/pkgs/by-name/bo/bowtie2/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     perl
   ];
 
-  cmakeFlags = lib.optional (!stdenv.hostPlatform.isx86) [
+  cmakeFlags = lib.optionals (!stdenv.hostPlatform.isx86) [
     "-DCMAKE_CXX_FLAGS=-I${finalAttrs.src}/third_party"
   ];
 

--- a/pkgs/by-name/co/cogl/package.nix
+++ b/pkgs/by-name/co/cogl/package.nix
@@ -116,11 +116,11 @@ stdenv.mkDerivation rec {
     );
     NIX_CFLAGS_COMPILE = toString (
       [ ]
-      ++ lib.optional stdenv.cc.isGNU [
+      ++ lib.optionals stdenv.cc.isGNU [
         # Fix build with gcc15
         "-std=gnu17"
       ]
-      ++ lib.optional stdenv.cc.isClang [
+      ++ lib.optionals stdenv.cc.isClang [
         "-Wno-error=implicit-function-declaration"
       ]
     );

--- a/pkgs/by-name/cr/crispy-doom/package.nix
+++ b/pkgs/by-name/cr/crispy-doom/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     for script in $(grep -lr '^#!/usr/bin/env python3$'); do patchShebangs $script; done
   '';
 
-  configureFlags = lib.optional enableTruecolor [ "--enable-truecolor" ];
+  configureFlags = lib.optionals enableTruecolor [ "--enable-truecolor" ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/cu/cup-docker/package.nix
+++ b/pkgs/by-name/cu/cup-docker/package.nix
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildFeatures = [
     "cli"
   ]
-  ++ lib.optional withServer [
+  ++ lib.optionals withServer [
     "server"
   ];
 

--- a/pkgs/by-name/dh/dhtbsign/package.nix
+++ b/pkgs/by-name/dh/dhtbsign/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   strictDeps = true;
 
   env.NIX_CFLAGS_COMPILE = toString (
-    lib.optional stdenv.cc.isGNU [
+    lib.optionals stdenv.cc.isGNU [
       # Required with newer GCC
       "-Wno-error=stringop-overflow"
     ]

--- a/pkgs/by-name/fi/fireplace/package.nix
+++ b/pkgs/by-name/fi/fireplace/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     hash = "sha256-2NUE/zaFoGwkZxgvVCYXxToiL23aVUFwFNlQzEq9GEc=";
   };
 
-  makeFlags = lib.optional stdenv.hostPlatform.isDarwin [ "CC=cc" ];
+  makeFlags = lib.optionals stdenv.hostPlatform.isDarwin [ "CC=cc" ];
 
   meta = {
     description = "Cozy fireplace in your terminal";

--- a/pkgs/by-name/fr/frankenphp/package.nix
+++ b/pkgs/by-name/fr/frankenphp/package.nix
@@ -80,7 +80,7 @@ buildGoModule (finalAttrs: {
     "-X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ${finalAttrs.version} PHP ${phpUnwrapped.version} Caddy'"
     # pie mode is only available with pkgsMusl, it also automatically add -buildmode=pie to $GOFLAGS
   ]
-  ++ (lib.optional pieBuild [ "-static-pie" ]);
+  ++ (lib.optionals pieBuild [ "-static-pie" ]);
 
   preBuild = ''
     export CGO_CFLAGS="$(${phpConfig} --includes)"

--- a/pkgs/by-name/kt/ktls-utils/package.nix
+++ b/pkgs/by-name/kt/ktls-utils/package.nix
@@ -42,9 +42,9 @@ stdenv.mkDerivation (finalAttrs: {
     "man"
   ];
 
-  configureFlags = lib.optional withSystemd [ "--with-systemd" ];
+  configureFlags = lib.optionals withSystemd [ "--with-systemd" ];
 
-  makeFlags = lib.optional withSystemd [ "unitdir=$(out)/lib/systemd/system" ];
+  makeFlags = lib.optionals withSystemd [ "unitdir=$(out)/lib/systemd/system" ];
 
   doCheck = true;
 

--- a/pkgs/by-name/ma/matrix-tuwunel/package.nix
+++ b/pkgs/by-name/ma/matrix-tuwunel/package.nix
@@ -140,7 +140,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "url_preview"
     "zstd_compression"
   ]
-  ++ lib.optional enableJemalloc [
+  ++ lib.optionals enableJemalloc [
     "jemalloc"
     "jemalloc_conf"
   ]

--- a/pkgs/by-name/mk/mkbootimg-osm0sis/package.nix
+++ b/pkgs/by-name/mk/mkbootimg-osm0sis/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   strictDeps = true;
 
   env.NIX_CFLAGS_COMPILE = toString (
-    lib.optional stdenv.cc.isGNU [
+    lib.optionals stdenv.cc.isGNU [
       # Required with newer GCC
       "-Wstringop-overflow=0"
     ]

--- a/pkgs/by-name/mo/monero-cli/package.nix
+++ b/pkgs/by-name/mo/monero-cli/package.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     "-Wno-dev"
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin "-DBoost_USE_MULTITHREADED=OFF"
-  ++ lib.optional trezorSupport [
+  ++ lib.optionals trezorSupport [
     "-DUSE_DEVICE_TREZOR=ON"
   ];
 

--- a/pkgs/by-name/mo/monero-gui/package.nix
+++ b/pkgs/by-name/mo/monero-gui/package.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DARCH=default"
   ]
-  ++ lib.optional trezorSupport [
+  ++ lib.optionals trezorSupport [
     # fix build on recent gcc versions
     "-DCMAKE_CXX_FLAGS=-fpermissive"
   ];

--- a/pkgs/by-name/px/pxa-mkbootimg/package.nix
+++ b/pkgs/by-name/px/pxa-mkbootimg/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   env.NIX_CFLAGS_COMPILE = toString (
-    lib.optional stdenv.cc.isGNU [
+    lib.optionals stdenv.cc.isGNU [
       # Required with newer GCC
       "-Wno-error=stringop-overflow"
     ]

--- a/pkgs/by-name/re/refind/package.nix
+++ b/pkgs/by-name/re/refind/package.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     "HOSTARCH=${hostarch}"
     "ARCH=${hostarch}"
   ]
-  ++ lib.optional stdenv.hostPlatform.isAarch64 [
+  ++ lib.optionals stdenv.hostPlatform.isAarch64 [
     # aarch64 is special for GNU-EFI, see BUILDING.txt
     "GNUEFI_ARM64_TARGET_SUPPORT=y"
   ];

--- a/pkgs/by-name/ry/ryubing/package.nix
+++ b/pkgs/by-name/ry/ryubing/package.nix
@@ -100,7 +100,7 @@ buildDotnetModule rec {
     "Ryujinx"
   ];
 
-  makeWrapperArgs = lib.optional stdenv.hostPlatform.isLinux [
+  makeWrapperArgs = lib.optionals stdenv.hostPlatform.isLinux [
     # Without this Ryujinx fails to start on wayland. See https://github.com/Ryujinx/Ryujinx/issues/2714
     "--set SDL_VIDEODRIVER x11"
   ];

--- a/pkgs/by-name/s7/s7/package.nix
+++ b/pkgs/by-name/s7/s7/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
       "-lpthread"
       "--export-all-symbols"
     ]
-    ++ lib.optional (!static && stdenv.hostPlatform.isMinGW) [ "--out-implib,libs7dll.a" ]
+    ++ lib.optionals (!static && stdenv.hostPlatform.isMinGW) [ "--out-implib,libs7dll.a" ]
     ++ lib.optional withArb "-lflint"
     ++ lib.optionals withGMP [
       "-lgmp"

--- a/pkgs/by-name/sf/sfml/package.nix
+++ b/pkgs/by-name/sf/sfml/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   # Only unvendor miniaudio on non-Darwin as Darwin cannot build the miniaudio package.
-  patches = lib.optional (!stdenv.hostPlatform.isDarwin) [
+  patches = lib.optionals (!stdenv.hostPlatform.isDarwin) [
     # Not upstreamble in the near future, see https://github.com/SFML/SFML/pull/3555
     ./unvendor-miniaudio.patch
   ];

--- a/pkgs/by-name/si/simple-completion-language-server/package.nix
+++ b/pkgs/by-name/si/simple-completion-language-server/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-RgRmbQVZK/4U37CO8AjNQOqR/SXvL1TQU03LX7LnqPY=";
 
-  buildFeatures = lib.optional withCitation [ "citation" ];
+  buildFeatures = lib.optionals withCitation [ "citation" ];
 
   meta = {
     description = "Language server to enable word completion and snippets for Helix editor";

--- a/pkgs/by-name/sp/spla/package.nix
+++ b/pkgs/by-name/sp/spla/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
   ]
   ++ lib.optional (gpuBackend == "cuda") "-DSPLA_GPU_BACKEND=CUDA"
-  ++ lib.optional (gpuBackend == "rocm") [ "-DSPLA_GPU_BACKEND=ROCM" ];
+  ++ lib.optionals (gpuBackend == "rocm") [ "-DSPLA_GPU_BACKEND=ROCM" ];
 
   preFixup = ''
     substituteInPlace $out/lib/cmake/SPLA/SPLASharedTargets-release.cmake \

--- a/pkgs/by-name/te/textadept/package.nix
+++ b/pkgs/by-name/te/textadept/package.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = lib.optionals withQt [ libsForQt5.qtbase ] ++ lib.optionals withCurses ncurses;
 
   cmakeFlags =
-    lib.optional withQt [ "-DQT=ON" ]
-    ++ lib.optional withCurses [
+    lib.optionals withQt [ "-DQT=ON" ]
+    ++ lib.optionals withCurses [
       "-DCURSES=ON"
       "-DQT=OFF"
     ];

--- a/pkgs/by-name/vt/vtk-dicom/package.nix
+++ b/pkgs/by-name/vt/vtk-dicom/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
     (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
   ]
-  ++ lib.optional finalAttrs.finalPackage.doCheck [
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
     # vtkBool does not accept TRUE, we have to use STRING "ON"
     (lib.cmakeFeature "BUILD_TESTING" "ON")
   ];

--- a/pkgs/by-name/xp/xpra/package.nix
+++ b/pkgs/by-name/xp/xpra/package.nix
@@ -238,7 +238,7 @@ effectiveBuildPythonApplication rec {
     "--with-pam"
     "--with-vsock"
   ]
-  ++ lib.optional withNvenc [
+  ++ lib.optionals withNvenc [
     "--with-nvenc"
     "--with-nvjpeg_encoder"
   ];

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (
     patches = [
       ./gnu-install-dirs.patch
     ]
-    ++ lib.optional (lib.versions.major release_version == "18") [
+    ++ lib.optionals (lib.versions.major release_version == "18") [
       # Fix build with gcc15
       # https://github.com/llvm/llvm-project/commit/bb59f04e7e75dcbe39f1bf952304a157f0035314
       ./lldb-add-include-cstdint.patch

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./gnu-install-dirs.patch
   ]
-  ++ lib.optional (lib.versionOlder release_version "20") [
+  ++ lib.optionals (lib.versionOlder release_version "20") [
     # Fix build with gcc15
     # https://github.com/llvm/llvm-project/commit/41eb186fbb024898bacc2577fa3b88db0510ba1f
     # https://github.com/llvm/llvm-project/commit/101109fc5460d5bb9bb597c6ec77f998093a6687

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -290,7 +290,7 @@ let
             ++ lib.optional valgrindSupport "--with-valgrind=${valgrind.dev}"
             ++ lib.optional ztsSupport "--enable-zts"
             ++ lib.optional staticSupport "--enable-static"
-            ++ lib.optional (!zendSignalsSupport) [ "--disable-zend-signals" ]
+            ++ lib.optionals (!zendSignalsSupport) [ "--disable-zend-signals" ]
             ++ lib.optional zendMaxExecutionTimersSupport "--enable-zend-max-execution-timers"
 
             # Sendmail

--- a/pkgs/development/libraries/libxmlxx/v3.nix
+++ b/pkgs/development/libraries/libxmlxx/v3.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     docbook5
     docbook-xsl-ns
   ]
-  ++ lib.lists.optional withPDF [
+  ++ lib.lists.optionals withPDF [
     fop
     dblatex
   ];

--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DUDEVRULES_INSTALL_DIR=lib/udev/rules.d"
   ]
-  ++ lib.optional finalAttrs.finalPackage.doCheck [
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
     "-DINDI_BUILD_UNITTESTS=ON"
     "-DINDI_BUILD_INTEGTESTS=ON"
   ];

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -77,7 +77,7 @@ let
           "-DRULES_INSTALL_DIR=lib/udev/rules.d"
           "-DINDI_DATA_DIR=share/indi/"
         ]
-        ++ lib.optional doCheck [
+        ++ lib.optionals doCheck [
           "-DINDI_BUILD_UNITTESTS=ON"
           "-DINDI_BUILD_INTEGTESTS=ON"
         ]

--- a/pkgs/development/python-modules/deal/default.nix
+++ b/pkgs/development/python-modules/deal/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
     # assert basically correct but fails in string match due to '' removed
     "test_unknown_command"
   ]
-  ++ lib.optional (pythonAtLeast "3.13") [
+  ++ lib.optionals (pythonAtLeast "3.13") [
     # assert basically correct but string match fails in due to
     # ('pathlib._local', 'Path.write_text') != ('pathlib', 'Path.write_text')
     "test_infer"

--- a/pkgs/development/python-modules/ffmpeg-progress-yield/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-progress-yield/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     procps
   ];
 
-  disabledTests = lib.optional stdenv.hostPlatform.isDarwin [
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # cannot access /usr/bin/pgrep from the sandbox
     "test_context_manager"
     "test_context_manager_with_exception"

--- a/pkgs/development/python-modules/inkex/default.nix
+++ b/pkgs/development/python-modules/inkex/default.nix
@@ -71,7 +71,7 @@ buildPythonPackage {
     "test_extract_multiple"
     "test_lookup_and"
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "test_image_extract"
     "test_path_number_nodes"
     "test_plotter" # Hangs

--- a/pkgs/development/python-modules/mpl-typst/default.nix
+++ b/pkgs/development/python-modules/mpl-typst/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     "test_draw_image_spy"
   ];
 
-  disabledTestPaths = lib.optional stdenv.hostPlatform.isDarwin [
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
     # fatal error when matplotlib creates a canvas
     "mpl_typst/backend_test.py"
   ];

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -221,7 +221,7 @@ let
       # These tests are unreliable on aarch64-darwin. See https://github.com/pandas-dev/pandas/issues/38921.
       "test_rolling"
     ]
-    ++ lib.optional stdenv.hostPlatform.is32bit [
+    ++ lib.optionals stdenv.hostPlatform.is32bit [
       # https://github.com/pandas-dev/pandas/issues/37398
       "test_rolling_var_numerical_issues"
     ];

--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -149,7 +149,7 @@ buildPythonPackage (finalAttrs: {
     # Do not lint code
     "tests/test_typing.py"
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Trace/BPT trap: 5 when getting widget options
     "tests/test_4505.py"
     "tests/test_widgets.py"

--- a/pkgs/development/python-modules/uqbar/default.nix
+++ b/pkgs/development/python-modules/uqbar/default.nix
@@ -63,11 +63,11 @@ buildPythonPackage (finalAttrs: {
     # https://github.com/supriya-project/uqbar/issues/107
     "SummarizingRootDocumenter"
   ]
-  ++ lib.optional (pythonAtLeast "3.11") [
+  ++ lib.optionals (pythonAtLeast "3.11") [
     # assert not '\x1b[91m/build/uqbar-0.7.0/tests/fake_package/enums.py:docstring
     "test_sphinx_style"
   ]
-  ++ lib.optional (pythonAtLeast "3.12") [
+  ++ lib.optionals (pythonAtLeast "3.12") [
     # https://github.com/supriya-project/uqbar/issues/93
     "objects.get_vars"
   ]

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -325,7 +325,7 @@ let
 
                     # stripping dlls results in:
                     # Failed to load System.Private.CoreLib.dll (error code 0x8007000B)
-                    stripExclude = lib.optional withMono [ "*.dll" ];
+                    stripExclude = lib.optionals withMono [ "*.dll" ];
 
                     runtimeDependencies =
                       prev.runtimeDependencies or [ ]

--- a/pkgs/os-specific/cygwin/newlib-cygwin/default.nix
+++ b/pkgs/os-specific/cygwin/newlib-cygwin/default.nix
@@ -41,7 +41,7 @@
       # declared. Backport of https://cygwin.com/cgit/newlib-cygwin/commit/?id=73600d68227e125af24b7de7c3fccbd4eb66ee03
       ./fix-winsize.patch
     ]
-    ++ lib.optional (!headersOnly) [
+    ++ lib.optionals (!headersOnly) [
       # https://cygwin.com/pipermail/cygwin-developers/2020-September/011970.html
       # This is required for boost coroutines to work. After we get to the point
       # where nix runs on cygwin, we can attempt to upstream this again.


### PR DESCRIPTION
Backport of #560097

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
