### PR TITLE
moon-child-fe: 1.0.5 -> 1.1.1

### DIFF
--- a/pkgs/by-name/mo/moon-child-fe/package.nix
+++ b/pkgs/by-name/mo/moon-child-fe/package.nix
@@ -21,13 +21,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "moon-child-fe";
-  version = "1.0.5";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "MorsGames";
     repo = "MoonChildFE";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SqoCSAFkQKcEbwDwHqicYXnQ8/HC523c+ePQFB+6rus=";
+    hash = "sha256-aWiLOHDBGIEmQD7HZVOT9yk1QzLsUlhEYLcAPi61aYE=";
   };
 
   __structuredAttrs = true;
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     mv ./Bin/Release $out/share/MoonChildFE
     icoFileToHiColorTheme game.ico MoonChildFE $out
 
-    ln -s $out/share/MoonChildFE/MoonChildFE $out/bin/MoonChildFE
+    ln -s "$out/share/MoonChildFE/Moon Child FE" $out/bin/MoonChildFE
 
     runHook postInstall
   '';


### PR DESCRIPTION
Simple update, also upstream deciding to make their binary have spaces in the name is a choice that is silly. I'm reverting that for us, that's just ridiculous frankly.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
