### PR TITLE
rust-bindgen: compare platforms with systems.equals

### DIFF
--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -133,7 +133,7 @@
       libclang = (lib.getLib clang.cc);
       inherit clang;
       targetFlag = lib.optionalString (
-        stdenv.targetPlatform != stdenv.hostPlatform
+        !lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform
       ) "--target=${stdenv.targetPlatform.config}";
     };
     meta.license = lib.licenses.mit;

--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -2,6 +2,7 @@
   rust-bindgen-unwrapped,
   zlib,
   bash,
+  lib,
   runCommand,
   runCommandCC,
   stdenv,
@@ -9,7 +10,7 @@
 let
   clang = rust-bindgen-unwrapped.clang;
   targetFlag =
-    if stdenv.targetPlatform != stdenv.hostPlatform then
+    if (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform) then
       "--target=${stdenv.targetPlatform.config}"
     else
       "";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Follow-up to #558886. Replace direct host and target platform comparisons in `rust-bindgen` and `rustPlatform.bindgenHook` with `lib.systems.equals`, as suggested by @OPNA2608.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
