### PR TITLE
rufin: 0.13.1 -> 0.15.3

### DIFF
--- a/pkgs/by-name/ru/rufin/package.nix
+++ b/pkgs/by-name/ru/rufin/package.nix
@@ -1,20 +1,26 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   rustPlatform,
   cacert,
+  cargo,
+  cmake,
   glib,
+  glib-networking,
   gettext,
   gst_all_1,
   gtk4,
   libadwaita,
+  ninja,
   pkg-config,
+  rustc,
   wrapGAppsHook4,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rufin";
-  version = "0.13.1";
+  version = "0.15.3";
 
   __structuredAttrs = true;
 
@@ -22,21 +28,30 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "screwys";
     repo = "Rufin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BCn88jedL9+5rLjwHmOIiG6Yg6EZwcDOALEJgDvzfNs=";
+    hash = "sha256-XBLQjf1YpoOd4SsMVI9Th4Amfgaqb1wbjXtxwY7dC0Q=";
   };
 
-  cargoHash = "sha256-kAti4GinC/zcAuhuQi/t/VnbY0laie9BEeUphXLc/M8=";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-jRYkBcCA0P2wCsCmpg9vCJF0qy/YTa9XW1WJtPtOGhw=";
+  };
 
   strictDeps = true;
 
   nativeBuildInputs = [
+    cargo
+    cmake
     gettext
+    ninja
     pkg-config
+    rustPlatform.cargoSetupHook
+    rustc
     wrapGAppsHook4
   ];
 
   buildInputs = [
     glib
+    glib-networking
     gtk4
     libadwaita
   ]
@@ -49,49 +64,24 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gst-libav
   ]);
 
-  cargoBuildFlags = [
-    "-p"
-    "rufin"
-  ];
-
   doCheck = false;
 
+  env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  cmakeFlags = [
+    (lib.cmakeFeature "RUFIN_BUILD_IDENTITY" "stable")
+    (lib.cmakeBool "RUFIN_CARGO_FROZEN" true)
+  ];
+
   postInstall = ''
-    install -Dm644 data/japanese-readings.dic \
-      "$out/share/rufin/japanese-readings.dic"
-    install -Dm644 data/japanese-readings.LICENSE \
-      "$out/share/licenses/rufin/japanese-readings.LICENSE"
-    install -Dm644 data/io.github.screwys.Rufin.desktop \
-      "$out/share/applications/io.github.screwys.Rufin.desktop"
     substituteInPlace "$out/share/applications/io.github.screwys.Rufin.desktop" \
       --replace-fail "Exec=rufin" "Exec=$out/bin/rufin"
-    install -Dm644 data/io.github.screwys.Rufin.metainfo.xml \
-      "$out/share/metainfo/io.github.screwys.Rufin.metainfo.xml"
-    install -Dm644 data/icons/hicolor/scalable/apps/io.github.screwys.Rufin.svg \
-      "$out/share/icons/hicolor/scalable/apps/io.github.screwys.Rufin.svg"
-    install -Dm644 -t "$out/share/icons/hicolor/scalable/actions" \
-      data/icons/hicolor/scalable/actions/*.svg
-    install -Dm644 -t "$out/share/icons/hicolor/scalable/status" \
-      data/icons/hicolor/scalable/status/*.svg
-    install -Dm644 -t "$out/share/icons/hicolor/512x512/apps" \
-      data/icons/hicolor/512x512/apps/*.png
-    install -Dm644 -t "$out/share/icons/hicolor/64x64/apps" \
-      data/icons/hicolor/64x64/apps/*.png
-
-    for po_file in crates/localization/locales/*.po; do
-      if [ -f "$po_file" ]; then
-        lang="$(basename "$po_file" .po)"
-        mkdir -p "$out/share/locale/$lang/LC_MESSAGES"
-        msgfmt "$po_file" -o "$out/share/locale/$lang/LC_MESSAGES/rufin.mo"
-      fi
-    done
   '';
 
   preFixup = ''
     gappsWrapperArgs+=(
       --set-default RUFIN_LOCALEDIR "$out/share/locale"
       --set-default SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt"
-      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
     )
   '';
 


### PR DESCRIPTION
Rufin now uses CMake build system and has some dependency changes therefore I needed to open a PR manually instead of waiting update bot. 

[Release Notes 
](https://github.com/screwys/Rufin/releases/tag/v0.15.0)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
