### PR TITLE
colloid-cursors: use cursors subdir for updates

### DIFF
--- a/pkgs/by-name/co/colloid-cursors/package.nix
+++ b/pkgs/by-name/co/colloid-cursors/package.nix
@@ -2,18 +2,16 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gitUpdater,
 }:
-
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "colloid-cursors";
-  version = "2025-07-19";
+  version = "0-unstable-2023-03-28";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = "Colloid-icon-theme";
-    tag = finalAttrs.version;
-    hash = "sha256-x2SSaIkKm1415avO7R6TPkpghM30HmMdjMFUUyPWZsk=";
+    rev = "d8bfd7339e3ab97a0c08b3e373a895119cc78ca8";
+    hash = "sha256-DOli7Ze1op1liU9xWku9tmQO0I711CstyqC+PYXvbJM=";
   };
 
   installPhase = ''
@@ -27,7 +25,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Colloid cursor theme";

--- a/pkgs/by-name/co/colloid-cursors/update.sh
+++ b/pkgs/by-name/co/colloid-cursors/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq nix common-updater-scripts
+set -euo pipefail
+
+# check the `cursors/` directory for changes since it does not change with each upstream release
+
+owner=vinceliuice
+repo=Colloid-icon-theme
+path=cursors
+attr=colloid-cursors
+pkg_file=./pkgs/by-name/co/colloid-cursors/package.nix
+
+api_url_latest="https://api.github.com/repos/$owner/$repo/commits?path=$path&per_page=1"
+json_latest=$(curl -sSfL -H "Accept: application/vnd.github+json" ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "$api_url_latest")
+latest_rev=$(printf '%s' "$json_latest" | jq -r '.[0].sha')
+latest_date=$(printf '%s' "$json_latest" | jq -r '.[0].commit.committer.date' | cut -dT -f1)
+
+if [[ -z "${latest_rev:-}" || "$latest_rev" == "null" ]]; then
+  echo "Failed to fetch latest commit for path $path" >&2
+  exit 1
+fi
+
+current_rev=$(nix-instantiate --eval --strict -A "$attr.src.rev" | tr -d '"')
+if [[ "$latest_rev" == "$current_rev" ]]; then
+  echo "$attr is already at the latest cursors commit ($latest_rev)" >&2
+  echo "[]"
+  exit 0
+fi
+
+new_version="0-unstable-${latest_date}"
+
+update-source-version "$attr" "$new_version" --rev="$latest_rev" --file="$pkg_file" --ignore-same-version --print-changes


### PR DESCRIPTION
Adds an update script instead of the gitUpdater to the package. Upstream was updated which opened #554908 but the [cursors directory](https://github.com/vinceliuice/Colloid-icon-theme/tree/main/cursors) from which this package derives from hasn't been updated in a while.
Also bumps the version from `2025-07-19` (previous upstream version) to `0-unstable-2023-03-28` (date of last cursors directory commit). This is open for suggestions as I wasn't entirely sure what to do with the version.
The update script is based off the one from `ee`: [update.sh](https://github.com/NixOS/nixpkgs/blob/0fcaa332669eb2d8c7067981d8f6603f646b6a07/pkgs/by-name/ee/ee/update.sh)

Part of the update script was created with "Big Pickle" via OpenCode. The Assisted-by commit trailer was added and I have reviewed/tested the code myself.

closes #554908

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
