### PR TITLE
cisco-packet-tracer_9: 9.0.0 -> 9.0.1

### DIFF
--- a/pkgs/by-name/ci/cisco-packet-tracer_9/package.nix
+++ b/pkgs/by-name/ci/cisco-packet-tracer_9/package.nix
@@ -6,7 +6,7 @@
   libxkbfile,
   requireFile,
   stdenvNoCC,
-  version ? "9.0.0",
+  version ? "9.0.1",
 }:
 
 let
@@ -17,9 +17,9 @@ let
     src =
       let
         sources = {
-          "9.0.0" = {
-            name = "CiscoPacketTracer_900_Ubuntu_64bit.deb";
-            hash = "sha256-3ZrA1Mf8N9y2j2J/18fm+m1CAMFEklJuVhi5vRcu2SA=";
+          "9.0.1" = {
+            name = "CiscoPacketTracer_901_Ubuntu_64bit.deb";
+            hash = "sha256-NoPdh+d5iFNyrpo1wabllNEvST5knnxpdAhynBRZR5s=";
           };
         };
       in
@@ -66,8 +66,8 @@ appimageTools.wrapType2 rec {
     ''
       mv $out/bin/${pname} $out/bin/packettracer9
 
-      install -Dm444 ${contents}/CiscoPacketTracer-9.0.0.desktop $out/share/applications/cisco-packet-tracer-9.desktop
-      install -Dm444 ${contents}/CiscoPacketTracerPtsa-9.0.0.desktop $out/share/applications/cisco-packet-tracer-ptsa-9.desktop
+      install -Dm444 ${contents}/CiscoPacketTracer-9.0.1.desktop $out/share/applications/cisco-packet-tracer-9.desktop
+      install -Dm444 ${contents}/CiscoPacketTracerPtsa-9.0.1.desktop $out/share/applications/cisco-packet-tracer-ptsa-9.desktop
       substituteInPlace $out/share/applications/* \
         --replace-fail "Exec=@EXEC_PATH@" "Exec=packettracer9" \
         --replace-fail "Icon=app" "Icon=cisco-packet-tracer-9"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
changelog: www.netacad.com/articles/news/download-packet-tracer-9-0-1?courseLang=en-US
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
