### PR TITLE
python3Packages.wandb: 0.29.0 -> 0.30.0

### DIFF
--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -135,6 +135,10 @@ buildPythonPackage (finalAttrs: {
     #   assert eval["nel_macro_f"] > 0
     #   assert 0.0 > 0
     "test_overfitting_IO_with_ner"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # AssertionError: assert 'V' == 'N'
+    "test_tok2vec_frozen_overfitting"
   ];
 
   pythonImportsCheck = [ "spacy" ];

--- a/pkgs/development/python-modules/sweeps/default.nix
+++ b/pkgs/development/python-modules/sweeps/default.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  jsonref,
+  jsonschema,
+  numpy,
+  pydantic,
+  pyyaml,
+  scikit-learn,
+  scipy,
+
+  # tests
+  pytest-xdist,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "sweeps";
+  version = "0.2.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "wandb";
+    repo = "sweeps";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QqtyYpPChPNFN+3Rlpp1x1H0FFgxHPO3zFGcY6Pl24A=";
+  };
+
+  # Requires unpackaged pytest-profiling
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace-fail "--profile" ""
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    jsonref
+    jsonschema
+    numpy
+    pydantic
+    pyyaml
+    scikit-learn
+    scipy
+  ];
+
+  pythonImportsCheck = [ "sweeps" ];
+
+  nativeCheckInputs = [
+    pytest-xdist
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTests = [
+    # AssertionError: assert [] == [SweepRun(nam...running=None)]
+    "test_5runs_band1_stop_2"
+    "test_5runs_band1_stop_2_1stnoband"
+    "test_eta_3"
+    "test_eta_3_max"
+
+    # AssertionError: assert [] == [10, 6, 1]
+    "test_skipped_steps"
+
+    # ValueError: Cannot extract metric loss from run
+    "test_runs_bayes_runs2"
+
+    # KeyError: 'loss is not a summary metric of this run.'
+    "test_summary_metric_none"
+
+    # AssertionError: Not equal to tolerance rtol=1e-07, atol=0.01
+    "test_bayes_impute_best"
+    "test_bayes_impute_latest"
+  ];
+
+  meta = {
+    description = "W&B Hyperparameter Sweep Engine";
+    homepage = "https://github.com/wandb/sweeps";
+    changelog = "https://github.com/wandb/sweeps/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -25,13 +25,14 @@
   # dependencies
   click,
   opentelemetry-api,
+  opentelemetry-exporter-otlp-proto-http,
+  opentelemetry-sdk,
   packaging,
   platformdirs,
   protobuf,
   pydantic,
   pyyaml,
   requests,
-  sentry-sdk,
   setproctitle,
   typing-extensions,
   xxhash,
@@ -73,6 +74,7 @@
   responses,
   scikit-learn,
   soundfile,
+  sweeps,
   tenacity,
   torch,
   torchvision,
@@ -80,12 +82,12 @@
 }:
 
 let
-  version = "0.29.0";
+  version = "0.30.0";
   src = fetchFromGitHub {
     owner = "wandb";
     repo = "wandb";
     tag = "v${version}";
-    hash = "sha256-5YkJB5uS9GalNKL+MPf5GVQX/jgWM62nxMVmdnzOXGs=";
+    hash = "sha256-4ccIM8bXbz8IkZeMBdr5zqoG7IxwwW8lb/VKIOOJWeE=";
   };
 
   wandb-xpu = rustPlatform.buildRustPackage {
@@ -95,7 +97,7 @@ let
 
     sourceRoot = "${src.name}/xpu";
 
-    cargoHash = "sha256-YKuXtttLam4NmJsJPQH8sFbj1Qs5Gc2uoFJEvTYxkew=";
+    cargoHash = "sha256-arb96ajbju/CeAglgvTjD5/omrEpigEORjXVAVSSV2Q=";
 
     checkFlags = [
       # fails in sandbox
@@ -239,13 +241,14 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     click
     opentelemetry-api
+    opentelemetry-exporter-otlp-proto-http
+    opentelemetry-sdk
     packaging
     platformdirs
     protobuf
     pydantic
     pyyaml
     requests
-    sentry-sdk
     setproctitle
     typing-extensions
     xxhash
@@ -291,11 +294,12 @@ buildPythonPackage (finalAttrs: {
     responses
     scikit-learn
     soundfile
+    sweeps
     tenacity
-    versionCheckHook
     torch
     torchvision
     tqdm
+    versionCheckHook
     writableTmpDirAsHomeHook
   ];
 
@@ -307,9 +311,6 @@ buildPythonPackage (finalAttrs: {
   disabledTestPaths = [
     # Require docker access
     "tests/system_tests"
-
-    # broke somewhere between sentry-sdk 2.15.0 and 2.22.0
-    "tests/unit_tests/test_analytics/test_sentry.py"
 
     # Server connection times out under load
     "tests/unit_tests/test_wandb_login.py"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20150,6 +20150,8 @@ self: super: with self; {
 
   swcgeom = callPackage ../development/python-modules/swcgeom { };
 
+  sweeps = callPackage ../development/python-modules/sweeps { };
+
   swh-auth = callPackage ../development/python-modules/swh-auth { };
 
   swh-core = callPackage ../development/python-modules/swh-core { };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/wandb/wandb/compare/v0.29.0...v0.30.0
Changelog: https://github.com/wandb/wandb/blob/v0.30.0/CHANGELOG.md

cc @samuela

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test