### PR TITLE
lib.types.submoduleWith: add cancel parameter

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -349,6 +349,9 @@ checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-attrsOfSub-if-foo-e
 checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-attrsOfSub-foo-if-enable.nix
 checkConfigOutput '^true$' "$@" ./define-enable.nix ./define-attrsOfSub-foo-enable-if.nix
 
+# Check wholly mkIf-disabled submodule in lazyAttrsOf.
+checkConfigOutput '^"ok"$' config.result ./submoduleWith-cancel.nix
+
 # Check importApply
 checkConfigOutput '"abc"' config.value ./importApply.nix
 # importApply does not set a key.

--- a/lib/tests/modules/submoduleWith-cancel.nix
+++ b/lib/tests/modules/submoduleWith-cancel.nix
@@ -1,0 +1,89 @@
+{ config, lib, ... }:
+let
+  inherit (lib) types mkOption;
+  inherit (types)
+    attrsOf
+    lazyAttrsOf
+    submoduleWith
+    listOf
+    int
+    ;
+
+  widget = { ... }: {
+    options.enable = mkOption { default = true; };
+    options.extra = mkOption {
+      type = listOf int;
+      description = "just evidence for type merging";
+    };
+  };
+in
+{
+  imports = [
+    {
+      options.typeMerged = mkOption {
+        type = lazyAttrsOf (submoduleWith {
+          modules = [ ];
+          cancel = {
+            enable = false;
+            extra = [ 2 ];
+          };
+        });
+      };
+    }
+  ];
+  options = {
+    widgets = mkOption {
+      type = lazyAttrsOf (submoduleWith {
+        modules = [ widget ];
+        cancel = {
+          enable = false;
+        };
+      });
+    };
+    typeMerged = mkOption {
+      type = lazyAttrsOf (submoduleWith {
+        modules = [ widget ];
+        cancel = {
+          enable = false;
+          extra = [ 1 ];
+        };
+      });
+    };
+    unmitigated = mkOption {
+      type = lazyAttrsOf (submoduleWith {
+        modules = [ widget ];
+      });
+    };
+    unused = mkOption {
+      type = attrsOf (submoduleWith {
+        modules = [ widget ];
+        cancel = abort "must not use";
+      });
+    };
+    result = mkOption { };
+  };
+  config = {
+    widgets.default = { };
+    widgets.disabled = {
+      enable = false;
+    };
+    widgets.self-referential.enable = config.widgets.default.enable;
+    widgets.cancelled = lib.mkIf false (abort "must not use");
+    unmitigated.cancelled = lib.mkIf false (abort "must not use");
+    unused.disappeared = lib.mkIf false (abort "must not use");
+    typeMerged.it = lib.mkIf false (abort "must not use");
+    result =
+      assert config.widgets.default.enable;
+      assert !config.widgets.disabled.enable;
+      assert !config.widgets.cancelled.enable; # the main assertion
+      assert config.widgets.self-referential.enable;
+      assert config.unmitigated.cancelled.enable; # could warn/deprecate/error later
+      assert config.unused == { };
+      assert
+        config.typeMerged.it.extra == [
+          1
+          2
+        ];
+      "ok";
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1395,6 +1395,7 @@ rec {
       shorthandOnlyDefinesConfig ? false,
       description ? null,
       class ? null,
+      cancel ? { },
     }@attrs:
     let
       inherit (lib.modules) evalModules;
@@ -1486,7 +1487,12 @@ rec {
           };
       };
       emptyValue = {
-        value = base.config;
+        value =
+          if cancel == { } then
+            # avoid small extendModules detour
+            base.config
+          else
+            (base.extendModules { modules = [ cancel ]; }).config;
       };
       getSubOptions =
         prefix:
@@ -1529,6 +1535,7 @@ rec {
             specialArgs
             shorthandOnlyDefinesConfig
             description
+            cancel
             ;
         };
         binOp = lhs: rhs: {
@@ -1570,6 +1577,20 @@ rec {
               lhs.description
             else
               throw "A submoduleWith option is declared multiple times with conflicting descriptions";
+          cancel =
+            # avoid constructing a module if possible
+            if lhs.cancel == { } then
+              rhs.cancel
+            else if rhs.cancel == { } then
+              lhs.cancel
+            else
+              # combine the modules
+              {
+                imports = [
+                  lhs.cancel
+                  rhs.cancel
+                ];
+              };
         };
       };
     };

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -282,7 +282,7 @@ Submodules are detailed in [Submodule](#section-option-types-submodule).
     options. This is equivalent to
     `types.submoduleWith { modules = toList o; shorthandOnlyDefinesConfig = true; }`.
 
-`types.submoduleWith` { *`modules`*, *`specialArgs`* ? {}, *`shorthandOnlyDefinesConfig`* ? false }
+`types.submoduleWith` { *`modules`*, *`specialArgs`* ? {}, *`shorthandOnlyDefinesConfig`* ? false, *`cancel`* ? { } }
 
 :   Like `types.submodule`, but more flexible and with better defaults.
     It has parameters
@@ -321,6 +321,26 @@ Submodules are detailed in [Submodule](#section-option-types-submodule).
         With this option enabled, defining a non-`config` section
         requires using a function:
         `the-submodule = { ... }: { options = { ... }; }`.
+
+    -   *`cancel`* A module that disables the submodule in a user-defined way.
+
+        This module is added to `modules` when the submodule has no definitions.
+
+        The motivating use case is *lazily typed attrset*, such as one produced by [`lazyAttrsOf`].
+        However, it is also used when a "bare" submodule does not have a default, e.g. `options.foo = mkOption { type = submoduleWith ...; };`.
+
+        Since a lazily typed attribute set can not make an attribute disappear
+        when the only definition is `mkIf false <...>`, you may use the `cancel`
+        parameter to provide a way to compensate for this lack of filtering.
+
+        When the submodule is asked to return a value for such a completely
+        definitionless evaluation, it will evaluate the `cancel` module instead.
+
+        A common definition is `{ enable = false; }`, but any valid module can
+        be provided here.
+
+        When all consumers of the lazy attribute set correctly [filter](https://nixos.org/manual/nixpkgs/stable/#function-library-lib.attrsets.filterAttrs) out
+        the cancelled modules, both self-referential and `mkIf false` definitions work correctly.
 
 `types.deferredModule`
 
@@ -468,6 +488,11 @@ Composed types are types that take a type as parameter. `listOf
     that value will be returned instead of throwing an error. So if the
     type of `foo.attr` was `lazyAttrsOf (nullOr int)`, `null` would be
     returned instead for the same `mkIf false` definition.
+    :::
+
+    ::: {.warning}
+    When evaluating a `mkIf false <...>` attribute definition in `lazyAttrsOf (submoduleWith a)`,
+    neither `a.cancel` nor `a.modules` modules have access to a valid `name` module argument.
     :::
 
 `types.attrsWith` { *`elemType`*, *`lazy`* ? false, *`placeholder`* ? "name" }
@@ -864,3 +889,5 @@ The only required parameter is `name`.
     :   A binary operation that can merge the payloads of two same
         types. Defined as a function that take two payloads as
         parameters and return the payloads merged.
+
+[`lazyAttrsOf`]: #sec-option-types-composed


### PR DESCRIPTION
`mkIf` is a gift that keeps on giving.

- Make self-referential (fixpoint) definitions and `mkIf false` work simultaneously, if the module author chooses to support this.
- Add missing warning about `mkIf false` `name` issue.

The latter *could* be solved, but not sure if worthwhile.
A cancelled module shouldn't do much anyway.
Maybe it should be an abort, cutting short any odious outcomes and debugging detours. Separate change.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
