### PR TITLE
[26.05] gcc14: 14.3.0 -> 14.4.0; gccNGPackages_15.gcc: 15.2.0 -> 15.3.0

### DIFF
--- a/pkgs/development/compilers/gcc/ng/default.nix
+++ b/pkgs/development/compilers/gcc/ng/default.nix
@@ -14,7 +14,7 @@
 }@packageSetArgs:
 let
   versions = {
-    "15.2.0".officialRelease.sha256 = "sha256-Q4/ZloJrDIJIWinaA6ctcdbjVBqD7HAt9Ccfb+Al0k4=";
+    "15.3.0".officialRelease.sha256 = "sha256-+lnBvu+JlfJ8TXHB3yJ1hxiTFdPm+v8btDBuYbDFMOs=";
   }
   // gccVersions;
 

--- a/pkgs/development/compilers/gcc/patches/14/libgcc-darwin-detection.patch
+++ b/pkgs/development/compilers/gcc/patches/14/libgcc-darwin-detection.patch
@@ -7,7 +7,8 @@ index 7332903704..27a8b5bedb 100644
    tmake_file="$tmake_file t-slibgcc-darwin"
    case ${host} in
 -    *-*-darwin2*)
+-      tmake_file="t-darwin-min-11 $tmake_file"
 +    *-*-darwin2* | *-*-darwin)
-       tmake_file="t-darwin-min-11 $tmake_file"
++      tmake_file="t-darwin-min-11 t-darwin-libgccs1 $tmake_file"
        ;;
      *-*-darwin1[89]*)

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -81,7 +81,6 @@ optionals noSysDirs (
       "14" = [
         ./13/no-sys-dirs-riscv.patch
         ./13/mangle-NIX_STORE-in-__FILE__.patch
-        ./13/libsanitizer-fix-with-glibc-2.42.patch
       ];
       "13" = [
         ./13/no-sys-dirs-riscv.patch
@@ -163,14 +162,11 @@ optionals noSysDirs (
       })
     ];
     "14" = [
-      # Patches from https://github.com/iains/gcc-14-branch/compare/04696df09633baf97cdbbdd6e9929b9d472161d3..gcc-14.2-darwin-r2
+      # Patches from https://github.com/iains/gcc-14-branch
       (fetchpatch {
-        # There are no upstream release tags nor a static branch for 14.3.0 in https://github.com/iains/gcc-14-branch.
-        # aa4cd614456de65ee3417acb83c6cff0640144e9 is the merge base of https://github.com/iains/gcc-14-branch/tree/gcc-14-3-darwin-pre-0 and https://github.com/gcc-mirror/gcc/releases/tag/releases%2Fgcc-14.3.0
-        # 3e1d48d240f4aa5223c701b5c231c66f66ab1126 is the newest commit of https://github.com/iains/gcc-14-branch/tree/gcc-14-3-darwin-pre-0
         name = "gcc-14-darwin-aarch64-support.patch";
-        url = "https://github.com/iains/gcc-14-branch/compare/aa4cd614456de65ee3417acb83c6cff0640144e9..3e1d48d240f4aa5223c701b5c231c66f66ab1126.diff";
-        hash = "sha256-BSTSYnkBJBEm++mGerVVyaCUC4dUyXq0N1tqbk25bO4=";
+        url = "https://raw.githubusercontent.com/Homebrew/homebrew-core/d23df58f83aeb2c3f43bdcc277a9fac0bbe3e896/Patches/gcc/gcc-14.4.0.diff";
+        hash = "sha256-NU95q0xkP4wEi6XLJRWEhcMcL49gDuIHgZubC05QzRE=";
       })
     ];
     # Patches from https://github.com/iains/gcc-13-branch/compare/b71f1de6e9cf7181a288c0f39f9b1ef6580cf5c8..gcc-13-3-darwin

--- a/pkgs/development/compilers/gcc/versions.nix
+++ b/pkgs/development/compilers/gcc/versions.nix
@@ -2,7 +2,7 @@ let
   majorMinorToVersionMap = {
     "16" = "16.2.0";
     "15" = "15.2.0";
-    "14" = "14.3.0";
+    "14" = "14.4.0";
     "13" = "13.4.0";
   };
 
@@ -16,7 +16,7 @@ let
       # 4 digits: snapshots (14.2.1.20250322)
       "16.2.0" = "sha256-5nOOKVl/czJwcxqpBgDzf/3ARQed/CfsfoGSzIEIXD4=";
       "15.2.0" = "sha256-Q4/ZloJrDIJIWinaA6ctcdbjVBqD7HAt9Ccfb+Al0k4=";
-      "14.3.0" = "sha256-4Nx3KXYlYxrI5Q+pL//v6Jmk63AlktpcMu8E4ik6yjo=";
+      "14.4.0" = "sha256-dStvVnvqyDFZx3p2gLExa914Rzi/+anQcBEsCdqQ9tk=";
       "13.4.0" = "sha256-nEzm27BAVo/cVFWIrAPFy8lajb8MeqSQFwhDr7WcqPU=";
     }
     ."${version}";


### PR DESCRIPTION
Taking a subset of PR https://github.com/NixOS/nixpkgs/pull/557566 (for now)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
