### PR TITLE
Rovr init at 0.10.1.post1 (Includes package's specific python packages)

### DIFF
--- a/pkgs/by-name/ro/rovr/package.nix
+++ b/pkgs/by-name/ro/rovr/package.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  rustPlatform,
+
+  # dependencies
+  file,
+
+  optionalDeps ? [
+    bat
+    fd
+    poppler-utils
+    ripgrep
+    wl-clipboard-rs
+    xclip
+    xdg-utils
+    zoxide
+  ],
+  extraPackages ? [ ],
+
+  # optional dependencies
+  bat,
+  fd,
+  poppler-utils,
+  ripgrep,
+  wl-clipboard-rs,
+  xclip,
+  xdg-utils,
+  zoxide,
+}:
+
+let
+  runtimePaths = [ file ] ++ optionalDeps ++ extraPackages;
+
+  # needs >= 0.12.0; nixpkgs is 0.11.28
+  # TODO: drop this override once https://github.com/NixOS/nixpkgs/pull/554025
+  # ([python-updates] major updates 2026-08-18) reaches master and replace with default `uv_build`
+  uv-build-0_12 = python3.pkgs.uv-build.overrideAttrs (
+    finalAttrs: _oldAttrs: {
+      version = "0.12.5";
+
+      src = fetchFromGitHub {
+        owner = "astral-sh";
+        repo = "uv";
+        tag = finalAttrs.version;
+        hash = "sha256-tKdqciPQnteeTqkXtWY8mliWUDv5gMdU8x0UPadQZlQ=";
+      };
+
+      cargoDeps = rustPlatform.fetchCargoVendor {
+        inherit (finalAttrs) pname version src;
+        hash = "sha256-27NzA/YXYbcGO6ehXP9OgvgLJQG/YP/I+eeflLmzxRQ=";
+      };
+    }
+  );
+
+  # needs >= 2.2.0; nixpkgs is 1.30
+  # TODO: drop this override once https://github.com/NixOS/nixpkgs/pull/554025
+  # ([python-updates] major updates 2026-08-18) reaches master and replace with default `puremagic`
+  puremagic-2 = python3.pkgs.puremagic.overrideAttrs (
+    finalAttrs: oldAttrs: {
+      version = "2.2.0";
+
+      src = fetchFromGitHub {
+        owner = "cdgriffith";
+        repo = "puremagic";
+        tag = finalAttrs.version;
+        hash = "sha256-Mvhn/1xcgYgVkWok2qZXAe40pocfu6nJo5xuPruw2dc=";
+      };
+
+      passthru = oldAttrs.passthru // {
+        build-system = with python3.pkgs; [
+          setuptools
+          setuptools-scm
+        ];
+      };
+    }
+  );
+in
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "rovr";
+  version = "0.10.1.post1";
+  pyproject = true;
+
+  disabled = python3.pkgs.pythonOlder "3.13";
+
+  src = fetchFromGitHub {
+    owner = "NSPC911";
+    repo = "rovr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fgeU1KavaJ3bdRnq+236c5B37Qs8n3/eB8fXhN8BY3Q=";
+  };
+
+  __structuredAttrs = true;
+
+  build-system = [
+    uv-build-0_12
+  ];
+
+  # NOTE: backports-zstd is also a dependency, but only below Python 3.14
+  dependencies = with python3.pkgs; [
+    fastjsonschema
+    humanize
+    multiarchive
+    pathvalidate
+    pillow
+    platformdirs
+    puremagic-2
+    pygments
+    pytrash
+    rarfile
+    resvg-py
+    rich
+    textual
+    textual-autocomplete
+    textual-drivers
+    textual-image
+    tomli
+    typing-extensions
+  ];
+
+  # Upstream pins rich==14.2.0; nixpkgs is 15.
+  pythonRelaxDeps = [
+    "rich"
+  ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath runtimePaths)
+  ];
+
+  pythonImportsCheck = [
+    "rovr"
+  ];
+
+  meta = {
+    description = "Terminal file manager built with Python's Textual framework";
+    homepage = "https://github.com/NSPC911/rovr";
+    changelog = "https://github.com/NSPC911/rovr/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "rovr";
+    maintainers = with lib.maintainers; [ kangazero ];
+  };
+})

--- a/pkgs/development/python-modules/multiarchive/default.nix
+++ b/pkgs/development/python-modules/multiarchive/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  uv-build,
+
+  # tests
+  pytestCheckHook,
+  rarfile,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "multiarchive";
+  version = "0.1.4.post1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "NSPC911";
+    repo = "multiarchive";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7YOcB0z3ZzYATPAbBZIHOvLDrc/Dl2K9TBQtaG9+58o=";
+  };
+
+  #TODO: target uv_build>=0.12.0 when https://github.com/NixOS/nixpkgs/pull/554025
+  # ([python-updates] major updates 2026-08-18) reaches master
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.12.0,<0.13.0' 'uv_build'
+  '';
+
+  build-system = [
+    uv-build
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    rarfile
+  ];
+
+  pythonImportsCheck = [ "multiarchive" ];
+
+  meta = {
+    changelog = "https://github.com/NSPC911/multiarchive/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/NSPC911/multiarchive";
+    description = "Unified interface for reading multiple archive formats";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kangazero ];
+  };
+})

--- a/pkgs/development/python-modules/pytrash/default.nix
+++ b/pkgs/development/python-modules/pytrash/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  uv-build,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytrash";
+  version = "0.4.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NSPC911";
+    repo = "pytrash";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-a52iwyV8wMzkw9O2ga9vSCbXjqpshd89qTmJbOrOj9k=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.11.28,<0.12.0' 'uv_build>=0.11.28'
+  '';
+
+  build-system = [
+    uv-build
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pytrash" ];
+
+  meta = {
+    changelog = "https://github.com/NSPC911/pytrash/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/NSPC911/pytrash";
+    description = "High level Cross-platform API for trash and recycle bin library";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kangazero ];
+  };
+})

--- a/pkgs/development/python-modules/textual-drivers/default.nix
+++ b/pkgs/development/python-modules/textual-drivers/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  uv-build,
+
+  # dependencies
+  textual,
+
+  # tests
+  pytest-benchmark,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "textual-drivers";
+  version = "0.10.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "NSPC911";
+    repo = "textual-drivers";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zEsjBVa+G9Qq+Hfcuq7nFcji+3tD+rmFlzHAmamRZC8=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.11.16,<0.12.0' 'uv_build>=0.11.16'
+  '';
+
+  build-system = [
+    uv-build
+  ];
+
+  dependencies = [
+    textual
+  ];
+
+  nativeCheckInputs = [
+    pytest-benchmark
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "textual_drivers" ];
+
+  meta = {
+    changelog = "https://github.com/NSPC911/textual-drivers/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/NSPC911/textual-drivers";
+    description = "Additional terminal drivers for Textual applications";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kangazero ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11297,6 +11297,8 @@ self: super: with self; {
 
   multiaddr = callPackage ../development/python-modules/multiaddr { };
 
+  multiarchive = callPackage ../development/python-modules/multiarchive { };
+
   multidict = callPackage ../development/python-modules/multidict { };
 
   multimethod = callPackage ../development/python-modules/multimethod { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20575,6 +20575,8 @@ self: super: with self; {
 
   textual-dev = callPackage ../development/python-modules/textual-dev { };
 
+  textual-drivers = callPackage ../development/python-modules/textual-drivers { };
+
   textual-fastdatatable = callPackage ../development/python-modules/textual-fastdatatable { };
 
   textual-image = callPackage ../development/python-modules/textual-image { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17328,6 +17328,8 @@ self: super: with self; {
 
   pytransportnswv2 = callPackage ../development/python-modules/pytransportnswv2 { };
 
+  pytrash = callPackage ../development/python-modules/pytrash { };
+
   pytricia = callPackage ../development/python-modules/pytricia { };
 
   pytrydan = callPackage ../development/python-modules/pytrydan { };


### PR DESCRIPTION
`rovr` is a terminal file manager built with Python's Textual framework.

Edit: Raised issue for `multiarchive` init Python module at https://github.com/NSPC911/multiarchive/issues/1 -> fixed -> changed multiarchive pkg to latest fixed release
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
