### PR TITLE
bbedit: preserve code signature by stripping APFS stream files

### DIFF
--- a/pkgs/by-name/bb/bbedit/package.nix
+++ b/pkgs/by-name/bb/bbedit/package.nix
@@ -18,6 +18,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ _7zz ];
 
+  # 7zz extracts APFS alternate data streams as separate files, breaking the seal
+  postUnpack = ''
+    find . -name "*:com.apple.*" -delete
+  '';
+
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
Resolves: #556684 #561539
Fixes: https://github.com/NixOS/nixpkgs/pull/558133

### Motivation

Update `bbedit` to version `16.0.3` and fix the long-standing bundle integrity issue on macOS.

Previously, `bbedit` was flagged as modified/broken when run from `/nix/store` (#320494). The root cause was `7zz` extracting APFS alternate data streams (`*:com.apple.*`) as regular files during `unpackPhase`, which corrupted the bundle's `CodeResources` seal and triggered Gatekeeper security alerts.

Stripping these stray metadata files in `postUnpack` fully preserves the original Developer ID signature and notarization ticket.

---

### Verification

* **Bundle integrity check:**
  ```text
  $ codesign -vvv --deep --strict result/Applications/BBEdit.app
  result/Applications/BBEdit.app: valid on disk
  result/Applications/BBEdit.app: satisfies its Designated Requirement

Assisted-by: Gemini 3.8 Flash <gemini@google.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
