### PR TITLE
rapg: init at 0.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14672,6 +14672,12 @@
     github = "KangaZero";
     githubId = 107836643;
   };
+  kanywst = {
+    email = "niwatakuma@icloud.com";
+    github = "kanywst";
+    githubId = 45947799;
+    name = "kt";
+  };
   kaptcha0 = {
     name = "J'C Kabunga";
     github = "kaptcha0";

--- a/pkgs/by-name/ra/rapg/package.nix
+++ b/pkgs/by-name/ra/rapg/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "rapg";
+  version = "0.3.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kanywst";
+    repo = "rapg";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-177xGyl63fJUntrBIfo04OS06oLosbzrX6p6bVZI3hw=";
+  };
+
+  vendorHash = "sha256-Q3o2q3T9rDrmepw9eS4wlrfhj61Aau/VQ8KpX8xOc14=";
+
+  subPackages = [ "cmd/rapg" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/kanywst/rapg/internal/version.Version=${finalAttrs.version}"
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd rapg \
+      --bash <($out/bin/rapg completion bash) \
+      --fish <($out/bin/rapg completion fish) \
+      --zsh <($out/bin/rapg completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Local-first secret manager that injects secrets into child processes";
+    longDescription = ''
+      rapg keeps development secrets in an encrypted local vault (Argon2id and
+      AES-256-GCM over SQLite) and injects them into a child process as
+      environment variables instead of writing a .env file. Secrets are scoped
+      per project through a .rapg.toml namespace, isolated from other projects
+      by default. It can also mask vault values in text before it is shared.
+    '';
+    homepage = "https://github.com/kanywst/rapg";
+    changelog = "https://github.com/kanywst/rapg/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kanywst ];
+    mainProgram = "rapg";
+  };
+})


### PR DESCRIPTION
Local-first secret manager that injects secrets into child processes

<https://github.com/kanywst/rapg>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
