### PR TITLE
modules/image: make inclusion without enable a noop

### DIFF
--- a/nixos/doc/manual/installation/building-images-via-systemd-repart.chapter.md
+++ b/nixos/doc/manual/installation/building-images-via-systemd-repart.chapter.md
@@ -15,6 +15,7 @@ An example of how to build an image:
   imports = [ "${modulesPath}/image/repart.nix" ];
 
   image.repart = {
+    enable = true;
     name = "image";
     partitions = {
       "esp" = {
@@ -148,6 +149,7 @@ in
       fileSystems."/".device = "/dev/disk/by-label/nixos";
 
       image.repart = {
+        enable = true;
         name = "image";
         partitions = {
           "esp" = {

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -242,6 +242,8 @@
 
 - The papra NixOS module is now hardening the systemd unit by default. If this breaks any of the configured directories, please reconfigure them through `services.papra.environment` to enable sandbox passthrough.
 
+- The `image/repart.nix` module now requires users to explicitly enable its use via `image.repart.enable`.
+
 - `services.selfoss.extraConfig` and `services.selfoss.database` have been removed in favor of the structured [](#opt-services.selfoss.settings) option. When moving the `database` options to `settings`, you should also switch to the upstream naming:
 
   - `type` → [`db_type`](#opt-services.selfoss.settings.db_type)

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -131,6 +131,7 @@ in
   ];
 
   options.image.repart = {
+    enable = lib.mkEnableOption "systemd-repart boot image";
 
     name = lib.mkOption {
       type = lib.types.str;
@@ -313,7 +314,7 @@ in
 
   };
 
-  config = {
+  config = lib.mkIf cfg.enable {
     image.baseName =
       let
         version = config.image.repart.version;

--- a/nixos/tests/appliance-repart-image-verity-store.nix
+++ b/nixos/tests/appliance-repart-image-verity-store.nix
@@ -27,6 +27,8 @@
       };
 
       image.repart = {
+        enable = true;
+
         verityStore = {
           enable = true;
           # by default the module works with systemd-boot, for simplicity this test directly boots the UKI

--- a/nixos/tests/appliance-repart-image.nix
+++ b/nixos/tests/appliance-repart-image.nix
@@ -46,6 +46,8 @@ in
       };
 
       image.repart = {
+        enable = true;
+
         name = "appliance-gpt-image";
         # OVMF does not work with the default repart sector size of 4096
         sectorSize = 512;


### PR DESCRIPTION
For our internal modules, we impose the rule that inclusion of the module must not change anything on its own in the config without actually enabling/configuring the module. This property is not given for the repart module and this propagates into our CI requiring ugly exceptions.

Add an enable option to guard the config changes of the repart module instead (just like other modules).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
