### PR TITLE
bash: fix here-document hang on Darwin

### DIFF
--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -91,14 +91,30 @@ lib.warnIf (withDocs != null)
 
     patchFlags = [ "-p0" ];
 
-    patches = upstreamPatches ++ [
-      # Enable PGRP_PIPE independently of the kernel of the build machine.
-      # This doesn't seem to be upstreamed despite such a mention of in https://github.com/NixOS/nixpkgs/pull/77196,
-      # which originally introduced the patch
-      # Some related discussion can be found in
-      # https://lists.gnu.org/archive/html/bug-bash/2015-05/msg00071.html
-      ./pgrp-pipe-5.patch
-    ];
+    patches =
+      upstreamPatches
+      ++ [
+        # Enable PGRP_PIPE independently of the kernel of the build machine.
+        # This doesn't seem to be upstreamed despite such a mention of in https://github.com/NixOS/nixpkgs/pull/77196,
+        # which originally introduced the patch
+        # Some related discussion can be found in
+        # https://lists.gnu.org/archive/html/bug-bash/2015-05/msg00071.html
+        ./pgrp-pipe-5.patch
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        # Backport of upstream devel commit 03e7298d1eb7f7163cda94ee23dcfa983152a540:
+        # macOS can throttle the capacity of new pipes to 512 bytes, which makes
+        # pipe-backed here-documents block. Remove once the fix ships in an
+        # official bash 5.3 patch.
+        # https://lists.gnu.org/archive/html/bug-bash/2026-06/msg00126.html
+        ./darwin-heredoc-pipesize-dynamic.patch
+      ];
+
+    # The patch touches configure.ac as well, so refresh the generated configure
+    # to keep make from trying to regenerate it with autoconf.
+    postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+      touch configure
+    '';
 
     configureFlags = [
       # At least on Linux bash memory allocator has pathological performance

--- a/pkgs/shells/bash/darwin-heredoc-pipesize-dynamic.patch
+++ b/pkgs/shells/bash/darwin-heredoc-pipesize-dynamic.patch
@@ -1,0 +1,95 @@
+--- configure
++++ configure
+@@ -23260,7 +23260,7 @@ hpux*)		LOCAL_CFLAGS="-DHPUX -DTGETENT_BROKEN -DTGETFLAG_BROKEN" ;;
+ dgux*)		LOCAL_CFLAGS=-D_DGUX_SOURCE; LOCAL_LIBS=-ldgc ;;
+ isc*)		LOCAL_CFLAGS=-Disc386 ;;
+ rhapsody*)	LOCAL_CFLAGS=-DRHAPSODY ;;
+-darwin*)	LOCAL_CFLAGS=-DMACOSX ;;
++darwin*)	LOCAL_CFLAGS="-DMACOSX -DPIPESIZE_DYNAMIC" ;;
+ sco3.2v5*)	LOCAL_CFLAGS="-b elf -DWAITPID_BROKEN -DPATH_MAX=1024" ;;
+ sco3.2v4*)	LOCAL_CFLAGS="-DMUST_UNBLOCK_CHLD -DPATH_MAX=1024" ;;
+ sco3.2*)	LOCAL_CFLAGS=-DMUST_UNBLOCK_CHLD ;;
+--- configure.ac
++++ configure.ac
+@@ -1211,7 +1211,7 @@ hpux*)		LOCAL_CFLAGS="-DHPUX -DTGETENT_BROKEN -DTGETFLAG_BROKEN" ;;
+ dgux*)		LOCAL_CFLAGS=-D_DGUX_SOURCE; LOCAL_LIBS=-ldgc ;;
+ isc*)		LOCAL_CFLAGS=-Disc386 ;;
+ rhapsody*)	LOCAL_CFLAGS=-DRHAPSODY ;;
+-darwin*)	LOCAL_CFLAGS=-DMACOSX ;;
++darwin*)	LOCAL_CFLAGS="-DMACOSX -DPIPESIZE_DYNAMIC" ;;
+ sco3.2v5*)	LOCAL_CFLAGS="-b elf -DWAITPID_BROKEN -DPATH_MAX=1024" ;;
+ sco3.2v4*)	LOCAL_CFLAGS="-DMUST_UNBLOCK_CHLD -DPATH_MAX=1024" ;;
+ sco3.2*)	LOCAL_CFLAGS=-DMUST_UNBLOCK_CHLD ;;
+--- general.c
++++ general.c
+@@ -615,6 +615,27 @@ sh_unset_nodelay_mode (int fd)
+   return 0;
+ }
+ 
++int
++sh_setnodelay (int fd)
++{
++  int flags;
++
++  if ((flags = fcntl (fd, F_GETFL, 0)) < 0)
++    return -1;
++
++  /* This is defined to O_NDELAY in filecntl.h if O_NONBLOCK is not present
++     and O_NDELAY is defined. */
++#ifdef O_NONBLOCK
++  flags |= O_NONBLOCK;
++#endif
++
++#ifdef O_NDELAY
++  flags |= O_NDELAY;
++#endif
++
++  return (fcntl (fd, F_SETFL, flags));
++}
++
+ /* Just a wrapper for the define in include/filecntl.h */
+ int
+ sh_setclexec (int fd)
+--- general.h
++++ general.h
+@@ -320,6 +320,7 @@ extern int line_isblank (const char *);
+ extern int assignment (const char *, int);
+ 
+ extern int sh_unset_nodelay_mode (int);
++extern int sh_setnodelay (int);
+ extern int sh_setclexec (int);
+ extern int sh_validfd (int);
+ extern int fd_ispipe (int);
+--- redir.c
++++ redir.c
+@@ -478,7 +478,30 @@ here_document_to_fd (WORD_DESC *redirectee, enum r_instruction ri)
+ 	}
+ #endif
+ 
++#if defined (PIPESIZE_DYNAMIC)
++      /* If we can't count on the pipe size determined at compile time to be
++	 constant across systems, define PIPESIZE_DYNAMIC in configure.ac.
++	 We set the pipe's write end to be non-blocking, try to write, and
++	 fall back to a temp file on error. */
++      if (sh_setnodelay (herepipe[1]) < 0)
++	{
++	  close (herepipe[0]);
++	  close (herepipe[1]);
++	  goto use_tempfile;
++	}
++#endif
++      
+       r = heredoc_write (herepipe[1], document, document_len);
++
++#if defined (PIPESIZE_DYNAMIC)
++      if (r == ENOSPC || r == EAGAIN)
++	{
++	  close (herepipe[0]);
++	  close (herepipe[1]);
++	  goto use_tempfile;
++	}
++#endif
++	  
+       if (document != redirectee->word)
+ 	free (document);
+       close (herepipe[1]);


### PR DESCRIPTION
Once system-wide pipe buffer usage reaches the `maxpipekva` limit of 16 MiB,
macOS caps the capacity of newly created pipes at 512 bytes, so the capacity
bash probes at build time (65536 here) no longer holds. Bash 5.1 and later
write a here-document into a pipe before forking the reader, so on such a
machine a document between 513 and 65536 bytes blocks forever, with no error
message.

Upstream fixed this in the devel branch (commit 03e7298d) after reports in
bug-bash. It is not in an official bash 5.3 patch yet, so this backports the
five hunks that make up the fix, guarded by
`lib.optionals stdenv.hostPlatform.isDarwin` so the `patches` attribute is
unchanged for a Linux host.

Reports upstream:
- https://lists.gnu.org/archive/html/bug-bash/2026-06/msg00126.html
- https://lists.gnu.org/archive/html/bug-bash/2026-07/msg00017.html

Verification on aarch64-darwin, with the machine held at the `maxpipekva`
limit (measured by writing to a fresh non-blocking pipe and seeing it accept
only 512 bytes):

    # bash 5.3.15 as currently packaged
    $ timeout 5 bash -c 'cat <<<"$1" | wc -c' _ "$(head -c 2500 /dev/zero | tr '\0' a)"
    (no output, exit 124)

    # bashNonInteractive built with this patch and postPatch applied
    $ timeout 5 /nix/store/...-bash-5.3p15/bin/bash -c 'cat <<<"$1" | wc -c' _ "$(head -c 2500 /dev/zero | tr '\0' a)"
    2501

`patch -p0` applies to the 5.3 tarball with official patches 001 through 015
without offsets or rejects, and `bash --version` still reports 5.3.15 since
`patchlevel.h` is untouched.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
