### PR TITLE
coverage-reporter: add chrjabs as maintainer, 0.6.17 -> 0.6.22

### DIFF
--- a/pkgs/by-name/co/coverage-reporter/package.nix
+++ b/pkgs/by-name/co/coverage-reporter/package.nix
@@ -1,19 +1,19 @@
 {
   lib,
-  crystal_1_17,
+  crystal_1_19,
   fetchFromGitHub,
   versionCheckHook,
   ...
 }:
-crystal_1_17.buildCrystalPackage rec {
+crystal_1_19.buildCrystalPackage rec {
   pname = "coverage-reporter";
-  version = "0.6.17";
+  version = "0.6.22";
 
   src = fetchFromGitHub {
     owner = "coverallsapp";
     repo = "coverage-reporter";
     tag = "v${version}";
-    hash = "sha256-wbxPjNAUubbL9TJnyqR7aYkMmADkIuD2PF00xI2wa84=";
+    hash = "sha256-9h7nshdO7qc5XdAMoELwKkFtIwTa5IMi0AvC6lL5fyk=";
   };
 
   shardsFile = ./shards.nix;

--- a/pkgs/by-name/co/coverage-reporter/package.nix
+++ b/pkgs/by-name/co/coverage-reporter/package.nix
@@ -33,7 +33,10 @@ crystal_1_17.buildCrystalPackage rec {
     description = "Self-contained, universal coverage uploader binary";
     homepage = "https://github.com/coverallsapp/coverage-reporter";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ quadradical ];
+    maintainers = with lib.maintainers; [
+      quadradical
+      chrjabs
+    ];
     mainProgram = "coveralls";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Homepage: https://github.com/coverallsapp/coverage-reporter
Changelog: https://github.com/coverallsapp/coverage-reporter/releases/tag/v0.6.22

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
