### PR TITLE
marabou: init at 2.0.0

### DIFF
--- a/pkgs/by-name/ma/marabou/cmake.patch
+++ b/pkgs/by-name/ma/marabou/cmake.patch
@@ -1,0 +1,61 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 32ce965f..2c196b3f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -108,13 +108,13 @@ list(APPEND LIBS ${Boost_LIBRARIES})
+ ##############
+ # Protobuf is needed to compile ONNX
+ 
+-set(PROTOBUF_VERSION 3.19.2)
++set(PROTOBUF_VERSION 21.12.0)
+ set(PROTOBUF_DEFAULT_DIR "${TOOLS_DIR}/protobuf-${PROTOBUF_VERSION}")
+ if (NOT PROTOBUF_DIR)
+     set(PROTOBUF_DIR ${PROTOBUF_DEFAULT_DIR})
+ endif()
+ 
+-if(NOT EXISTS "${PROTOBUF_DIR}/installed/lib/libprotobuf.a")
++if(NOT EXISTS "${PROTOBUF_DIR}/lib/libprotobuf.so")
+     message("Can't find protobuf, installing. If protobuf is installed please use the PROTOBUF_DIR parameter to pass the path")
+     if (${PROTOBUF_DIR} STREQUAL ${PROTOBUF_DEFAULT_DIR})
+         message("installing protobuf")
+@@ -127,8 +127,8 @@ endif()
+ set(PROTOBUF_LIB protobuf)
+ add_library(${PROTOBUF_LIB} SHARED IMPORTED)
+ set_property(TARGET ${PROTOBUF_LIB} PROPERTY POSITION_INDEPENDENT_CODE ON)
+-set_target_properties(${PROTOBUF_LIB} PROPERTIES IMPORTED_LOCATION ${PROTOBUF_DIR}/installed/lib/libprotobuf.a)
+-target_include_directories(${PROTOBUF_LIB} INTERFACE ${PROTOBUF_DIR}/installed/include)
++set_target_properties(${PROTOBUF_LIB} PROPERTIES IMPORTED_LOCATION ${PROTOBUF_DIR}/lib/libprotobuf.so)
++target_include_directories(${PROTOBUF_LIB} INTERFACE ${PROTOBUF_DIR}/include)
+ list(APPEND LIBS ${PROTOBUF_LIB})
+ 
+ ##########
+@@ -183,7 +183,7 @@ endif()
+ ##############
+ 
+ if (NOT MSVC AND ${ENABLE_OPENBLAS})
+-  set(OPENBLAS_VERSION 0.3.19)
++  set(OPENBLAS_VERSION 0.3.28)
+ 
+   set(OPENBLAS_LIB openblas)
+   set(OPENBLAS_DEFAULT_DIR "${TOOLS_DIR}/OpenBLAS-${OPENBLAS_VERSION}")
+@@ -193,7 +193,7 @@ if (NOT MSVC AND ${ENABLE_OPENBLAS})
+ 
+   message(STATUS "Using OpenBLAS for matrix multiplication")
+   add_compile_definitions(ENABLE_OPENBLAS)
+-  if(NOT EXISTS "${OPENBLAS_DIR}/installed/lib/libopenblas.a")
++  if(NOT EXISTS "${OPENBLAS_DIR}/lib/libopenblas.so")
+     message("Can't find OpenBLAS, installing. If OpenBLAS is installed please use the OPENBLAS_DIR parameter to pass the path")
+       if (${OPENBLAS_DIR} STREQUAL ${OPENBLAS_DEFAULT_DIR})
+         message("Installing OpenBLAS")
+@@ -204,9 +204,9 @@ if (NOT MSVC AND ${ENABLE_OPENBLAS})
+   endif()
+ 
+   add_library(${OPENBLAS_LIB} SHARED IMPORTED)
+-  set_target_properties(${OPENBLAS_LIB} PROPERTIES IMPORTED_LOCATION ${OPENBLAS_DIR}/installed/lib/libopenblas.a)
++  set_target_properties(${OPENBLAS_LIB} PROPERTIES IMPORTED_LOCATION ${OPENBLAS_DIR}/lib/libopenblas.so)
+   list(APPEND LIBS ${OPENBLAS_LIB})
+-  target_include_directories(${OPENBLAS_LIB} INTERFACE ${OPENBLAS_DIR}/installed/include)
++  target_include_directories(${OPENBLAS_LIB} INTERFACE ${OPENBLAS_DIR}/)
+ endif()
+ 
+ ###########

--- a/pkgs/by-name/ma/marabou/package.nix
+++ b/pkgs/by-name/ma/marabou/package.nix
@@ -1,0 +1,89 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchgit,
+  cmake,
+  openblas,
+  boost186,
+  python3,
+  python3Packages,
+  protobuf_21,
+}:
+
+let
+  onnx-protofile = (
+    stdenv.mkDerivation {
+      name = "onnx-protofile";
+      src = fetchFromGitHub {
+        owner = "onnx";
+        repo = "onnx";
+        rev = "v1.15.0";
+        sparseCheckout = [
+          "onnx/"
+        ];
+        hash = "sha256-sRHeYo/3GWkzeHxq31Lshk5EpFl/HZOnLmtl/PXONtU=";
+      };
+      installPhase = ''
+        mkdir $out
+        mv onnx/onnx.proto3 $out/onnx.proto3
+      '';
+    }
+  );
+in
+stdenv.mkDerivation {
+  __structuredAttrs = true;
+  strictDeps = true;
+  pname = "Marabou";
+  version = "2.0";
+  src = fetchgit {
+    url = "https://github.com/NeuralNetworkVerification/Marabou.git";
+    rev = "v2.0.0";
+    sha256 = "sha256-Bplaq1T+3KPA9Cykzk9Zxje4KQscYDTrDY2rdYlO2E0=";
+    fetchSubmodules = true;
+  };
+  buildInputs = [
+    boost186
+    openblas
+  ];
+  nativeBuildInputs = [
+    cmake
+    python3
+    python3Packages.pybind11
+    python3Packages.pythonImportsCheckHook
+    protobuf_21
+    onnx-protofile
+  ];
+  # Regression tests are disabled because of python imports errors
+  cmakeFlags = [
+    "-DBUILD_PYTHON=OFF"
+    "-DPROTOBUF_DIR=${protobuf_21}"
+    "-DOPENBLAS_DIR=${openblas}"
+  ];
+  # Generating ourselves the onnx proto header, preempting CMake
+  # Assuming onnx revision is vX.YY.Z
+  prePatch = ''
+    export ONNX_VERSION=$(echo "${onnx-protofile.src.rev}" | tr -d v)
+    mkdir -p tools/onnx-$ONNX_VERSION
+    ${protobuf_21}/bin/protoc --proto_path=${onnx-protofile} --cpp_out=tools/onnx-$ONNX_VERSION ${onnx-protofile}/onnx.proto3
+  '';
+  # Patches:
+  # - cxx tests to use python3 constructs
+  # - cmake paths to comply with nix conventions
+  patches = [
+    ./cmake.patch
+    ./python3-cxx-tests.patch
+  ];
+  installPhase = ''
+    mkdir -p $out/bin
+    mv Marabou $out/bin/
+  '';
+
+  meta = {
+    homepage = "https://github.com/NeuralNetworkVerification/Marabou";
+    description = "Marabou is an SMT-based tool for formal verification of
+    neural networks.";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GirardR1006 ];
+  };
+}

--- a/pkgs/by-name/ma/marabou/python3-cxx-tests.patch
+++ b/pkgs/by-name/ma/marabou/python3-cxx-tests.patch
@@ -1,0 +1,59 @@
+diff --git a/tools/cxxtest/cxxtestgen.py b/tools/cxxtest/cxxtestgen.py
+index 831d23ab..d12eff7d 100755
+--- a/tools/cxxtest/cxxtestgen.py
++++ b/tools/cxxtest/cxxtestgen.py
+@@ -57,7 +57,7 @@ def main():
+ def usage( problem = None ):
+     '''Print usage info and exit'''
+     if problem is None:
+-        print usageString()
++        print(usageString())
+         sys.exit(0)
+     else:
+         sys.stderr.write( usageString() )
+@@ -82,7 +82,7 @@ def parseCommandline():
+                                             'error-printer', 'abort-on-fail', 'have-std', 'no-std',
+                                             'have-eh', 'no-eh', 'template=', 'include=',
+                                             'root', 'part', 'no-static-init', 'factor', 'longlong='] )
+-    except getopt.error, problem:
++    except (getopt.error, problem):
+         usage( problem )
+     setOptions( options )
+     return setFiles( patterns )
+@@ -315,12 +315,12 @@ def scanLineForDestroy( suite, lineNo, line ):
+ 
+ def cstr( str ):
+     '''Convert a string to its C representation'''
+-    return '"' + string.replace( str, '\\', '\\\\' ) + '"'
++    return '"' + str.replace( '\\', '\\\\' ) + '"'
+ 
+ 
+ def addSuiteCreateDestroy( suite, which, line ):
+     '''Add createSuite()/destroySuite() to current suite'''
+-    if suite.has_key(which):
++    if which in suite:
+         abort( '%s:%s: %sSuite() already declared' % ( suite['file'], str(line), which ) )
+     suite[which] = line
+ 
+@@ -335,10 +335,10 @@ def closeSuite():
+ 
+ def verifySuite(suite):
+     '''Verify current suite is legal'''
+-    if suite.has_key('create') and not suite.has_key('destroy'):
++    if 'create' in suite and not 'destroy' in suite:
+         abort( '%s:%s: Suite %s has createSuite() but no destroySuite()' %
+                (suite['file'], suite['create'], suite['name']) )
+-    if suite.has_key('destroy') and not suite.has_key('create'):
++    if 'destroy' in suite and not 'create' in suite:
+         abort( '%s:%s: Suite %s has destroySuite() but no createSuite()' %
+                (suite['file'], suite['destroy'], suite['name']) )
+ 
+@@ -474,7 +474,7 @@ def isGenerated(suite):
+ 
+ def isDynamic(suite):
+     '''Checks whether a suite is dynamic'''
+-    return suite.has_key('create')
++    return 'create' in suite
+ 
+ lastIncluded = ''
+ def writeInclude(output, file):


### PR DESCRIPTION
## Contribution

Add Marabou, a solver for the verification of Neural Networks.

Motivation: actively developed since 2019, used in numerous academic publications and industrial contexts.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
