### PR TITLE
art-standalone: fix aarch64 cross-compilation

### DIFF
--- a/pkgs/by-name/an/android-translation-layer/package.nix
+++ b/pkgs/by-name/an/android-translation-layer/package.nix
@@ -24,6 +24,7 @@
   makeWrapper,
   nixosTests,
   bintools,
+  buildPackages,
 }:
 
 stdenv.mkDerivation {
@@ -50,6 +51,15 @@ stdenv.mkDerivation {
     substituteInPlace src/main-executable/main.c \
       --replace-fail '@out@' "$out"
   '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  depsBuildBuild = [
+    buildPackages.glib
+    buildPackages.wayland-scanner
+    buildPackages.art-standalone
+  ];
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/by-name/ar/art-standalone/package.nix
+++ b/pkgs/by-name/ar/art-standalone/package.nix
@@ -19,6 +19,7 @@
   libpng,
   makeWrapper,
   binutils,
+  vixl,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "art-standalone";
@@ -47,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     jdk17
@@ -67,12 +69,20 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     xz
     zlib
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isAarch64 [ vixl ];
 
   makeFlags = [
     "____LIBDIR=lib"
     "____PREFIX=${placeholder "out"}"
     "____INSTALL_ETC=${placeholder "out"}/etc"
+    "ARCH=${stdenv.hostPlatform.uname.processor}"
+    "HOST_CC=${stdenv.cc.targetPrefix}cc"
+    "HOST_CXX=${stdenv.cc.targetPrefix}c++"
+    "HOST_AR=${stdenv.cc.targetPrefix}ar"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+    "C_INCLUDE_PATH=${vixl}/include"
   ];
 
   postFixup = ''
@@ -86,7 +96,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.com/android_translation_layer/art_standalone";
     # No license specified yet
     license = lib.licenses.unfree;
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
     maintainers = with lib.maintainers; [ onny ];
   };
 })


### PR DESCRIPTION
Superseeds: https://github.com/NixOS/nixpkgs/pull/453809

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
