### PR TITLE
davinci-resolve: 21.0.4 -> 21.1

### DIFF
--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -56,7 +56,7 @@ let
   davinci = (
     stdenv.mkDerivation rec {
       pname = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
-      version = "21.0.4";
+      version = "21.1";
 
       nativeBuildInputs = [
         appimageTools.appimage-exec
@@ -78,9 +78,9 @@ let
             outputHashAlgo = "sha256";
             outputHash =
               if studioVariant then
-                "sha256-FwaSnK3DAIRGCz6kiWxE4o0Cd0en2qoyuWCDHat1xHQ="
+                "sha256-D5RjUukwKMpULrDfMJOPsPWW9FxhQ/IUMh76u5JLytA="
               else
-                "sha256-oX/abUHhnl1AW3xb53x8l7WIdSKc9e2Ocp0qtGAOv/A=";
+                "sha256-bQ4Yag4xfIF9Fs0UVKaYFhObMsAof5n+Sy4osw35a9g=";
 
             impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 
@@ -171,7 +171,7 @@ let
           test -e ${lib.escapeShellArg appimageName}
           appimage-exec.sh -x $out ${lib.escapeShellArg appimageName}
 
-          mkdir -p $out/{"Apple Immersive/Calibration",configs,DolbyVision,easyDCP,Extras,Fairlight,GPUCache,logs,Media,"Resolve Disk Database",.crashreport,.license,.LUT}
+          mkdir -p $out/{"Apple Immersive/Calibration",configs,DolbyVision,easyDCP,Extras,Fairlight,GPUCache,Immersive/Canon/STMap,logs,Media,"Resolve Disk Database",.crashreport,.license,.LUT}
 
           # Install udev rules for Blackmagic hardware (color panels, Speed Editor, Editor Keyboard)
           mkdir -p $out/lib/udev/rules.d

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -39,7 +39,7 @@
   xkeyboard_config,
   glib,
   libarchive,
-  libxcrypt,
+  libxcrypt-legacy,
   python3,
   aprutil,
   makeDesktopItem,
@@ -207,7 +207,6 @@ let
             addDriverRunpath "$program"
           fi
         done
-        ln -s $out/libs/libcrypto.so.1.1 $out/libs/libcrypt.so.1
       '';
 
       desktopItems = [
@@ -303,7 +302,7 @@ buildFHSEnv {
       librsvg
       libtool
       libuuid
-      libxcrypt # provides libcrypt.so.1
+      libxcrypt-legacy # provides libcrypt.so.1
       libxkbcommon
       nspr
       ocl-icd


### PR DESCRIPTION
Changelog: https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=239823

See individual commits for details

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
