### PR TITLE
ki: fix build with gitpython 3.1.57+

### DIFF
--- a/pkgs/by-name/ki/ki/fix-gitpython-remote-url-type.patch
+++ b/pkgs/by-name/ki/ki/fix-gitpython-remote-url-type.patch
@@ -1,0 +1,13 @@
+diff --git a/ki/__init__.py b/ki/__init__.py
+index a9e4877..09ea9c1 100644
+--- a/ki/__init__.py
++++ b/ki/__init__.py
+@@ -1460,7 +1460,7 @@ def _pull2(kirepo: KiRepo, col: Collection) -> Collection:
+ 
+     # Create git remote pointing to `remote_repo`, which represents the current
+     # state of the Anki SQLite3 database, and pull it into `lca_repo`.
+-    anki_remote = lca_repo.create_remote(REMOTE_NAME, F.gitd(remote_repo))
++    anki_remote = lca_repo.create_remote(REMOTE_NAME, str(F.gitd(remote_repo)))
+     anki_remote.fetch()
+ 
+     # Handle deleted files, preferring `theirs`.

--- a/pkgs/by-name/ki/ki/package.nix
+++ b/pkgs/by-name/ki/ki/package.nix
@@ -22,6 +22,7 @@ python3Packages.buildPythonApplication {
     ./fix-beartype-error.patch
     ./replace-deprecated-distutils-with-setuptools.patch
     ./update-to-newer-anki-versions.patch
+    ./fix-gitpython-remote-url-type.patch
   ];
 
   build-system = with python3Packages; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
