### PR TITLE
voxtype,voxtype-{vulkan,onnx}: 0.7.5 -> 1.0.1

### DIFF
--- a/pkgs/by-name/vo/voxtype/package.nix
+++ b/pkgs/by-name/vo/voxtype/package.nix
@@ -52,16 +52,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "voxtype";
-  version = "0.7.5";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "peteonrails";
     repo = "voxtype";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zsOG1mBTXN4gdsTb1pUPKXATfhV5ZjgEsIUk07asaGo=";
+    hash = "sha256-OT0tVSi9x3U7NwgZU00mojXk3RRWxuFoezpdSknLmmU=";
   };
 
-  cargoHash = "sha256-YK5xZWPo7KAeWZeuMxNxHA3k6RR/MT2MIfEPcgMND00=";
+  cargoHash = "sha256-kJFI9sSMzaaYHuc7ze5Lkwt3ZVskM9rB9bvTon0XguU=";
 
   buildFeatures =
     [ ]


### PR DESCRIPTION
Changelog: https://github.com/peteonrails/voxtype/releases/tag/v1.0.1