### PR TITLE
cuda-oxide: init at 0.2.1

### DIFF
--- a/pkgs/by-name/cu/cuda-oxide/package.nix
+++ b/pkgs/by-name/cu/cuda-oxide/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  autoAddDriverRunpath,
+  cudaPackages,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cuda-oxide";
+  version = "0.2.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NVlabs";
+    repo = "cuda-oxide";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dOa/ScWgEQre0f9MgxFVLRtuNcqr2JC61XP7FsHAP2A=";
+  };
+
+  cargoHash = "sha256-3JmDEO4DC9Xhgdoa0xnpUE9nJailezqoTUk6FA7BKeI=";
+
+  nativeBuildInputs = [
+    autoAddDriverRunpath
+    cudaPackages.cuda_nvcc
+    rustPlatform.bindgenHook
+  ];
+
+  env = {
+    # requires nightly features
+    RUSTC_BOOTSTRAP = true;
+
+    # Adding `cudaPackages.cuda_cudart` allows compilation to succeed, but cargo-oxide errors at runtime:
+    #   cargo-oxide: error while loading shared libraries: libcuda.so.1: cannot open shared object file: No such file or directory
+    CUDA_HOME = (lib.getLib cudaPackages.cuda_cudart).outPath;
+
+    NIX_LDFLAGS = "-L${lib.getOutput "stubs" cudaPackages.cuda_cudart}/lib/stubs"; # fixes -lcuda not found
+  };
+
+  cargoBuildFlags = [
+    "--package=cargo-oxide"
+  ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Experimental Rust-to-CUDA compiler that lets you write (SIMT) GPU kernels in safe(ish), idiomatic Rust";
+    homepage = "https://github.com/NVlabs/cuda-oxide";
+    changelog = "https://github.com/NVlabs/cuda-oxide/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      ethancedwards8
+    ];
+    teams = with lib.teams; [ cuda ];
+    mainProgram = "cargo-oxide";
+  };
+})


### PR DESCRIPTION
Homepage: https://github.com/NVlabs/cuda-oxide


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
