### PR TITLE
anyzig: init at 2026_03_26

### DIFF
--- a/pkgs/by-name/an/anyzig/package.nix
+++ b/pkgs/by-name/an/anyzig/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  zig_0_14,
+  nix-update-script,
+}:
+
+let
+  zig = zig_0_14;
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "anyzig";
+  version = "2026_03_26";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "marler8997";
+    repo = "anyzig";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MQWFKVXsJdv/kV9Kn0GexiSLNDJdd9IGN9rQa2lhF6k=";
+  };
+
+  postPatch = ''
+    substituteInPlace build.zig.zon --replace-fail \
+      '12201a08d7eff7619c8eb8284691a3ff959861b4bdd87216f180ed136672fb4ea26f' \
+      'zipcmdline-0.0.0-AAAAAKBaAAAaCNfv92GcjrgoRpGj_5WYYbS92HIW8YDt'
+  '';
+
+  nativeBuildInputs = [ zig ];
+
+  zigDeps = zig.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-BeCa4IrFbb/bsz+ZuhKRUb9wV8a+JV/11FOBt8JJOKA=";
+  };
+
+  postConfigure = ''
+    ln -s ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Universal zig executable that lets you run any version of zig";
+    homepage = "https://github.com/marler8997/anyzig";
+    changelog = "https://github.com/marler8997/anyzig/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ defelo ];
+    mainProgram = "zig";
+  };
+})


### PR DESCRIPTION
https://github.com/marler8997/anyzig

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
