### PR TITLE
python3Packages.bscpylgtv: init at 0.5.2

### DIFF
--- a/pkgs/development/python-modules/bscpylgtv/default.nix
+++ b/pkgs/development/python-modules/bscpylgtv/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  sqlitedict,
+  websockets,
+
+  # optional-dependencies
+  numpy,
+
+  # tests
+  pytest,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bscpylgtv";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "chros73";
+    repo = "bscpylgtv";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8h7H5MA07i5A4JmKVToL6YNi2YeQaj9Gh+0mudA0e8o=";
+  };
+
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    sqlitedict
+    websockets
+  ];
+
+  optional-dependencies = {
+    with_calibration = [ numpy ];
+  };
+
+  nativeCheckInputs = [
+    pytest
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  pythonImportsCheck = [ "bscpylgtv" ];
+
+  meta = {
+    description = "Library to control webOS based LG TV units";
+    mainProgram = "bscpylgtvcommand";
+    homepage = "https://github.com/chros73/bscpylgtv";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mrbjarksen ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2698,6 +2698,8 @@ self: super: with self; {
 
   brunt = callPackage ../development/python-modules/brunt { };
 
+  bscpylgtv = callPackage ../development/python-modules/bscpylgtv { };
+
   bsdiff4 = callPackage ../development/python-modules/bsdiff4 { };
 
   bson = callPackage ../development/python-modules/bson { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [bscpylgtv](https://github.com/chros73/bscpylgtv) to python3Packages, which is a library to control webOS based LG TV devices.

This is an enhanced and faster version of [aiopylgtv](https://github.com/bendavid/aiopylgtv) (which is already packaged), it can be installed without calibration functionality, and is optimized for command line usage.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
