### PR TITLE
mujoco: 3.12.0 -> 3.13.0

### DIFF
--- a/pkgs/by-name/mu/mujoco/mujoco-system-deps-dont-fetch.patch
+++ b/pkgs/by-name/mu/mujoco/mujoco-system-deps-dont-fetch.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6c1747f3..ab69cf5e 100644
+index 54aadcca..070057a3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -158,7 +158,7 @@ target_link_libraries(
+@@ -210,7 +210,7 @@ target_link_libraries(
            lodepng
            qhullstatic_r
            tinyobjloader
@@ -10,21 +10,12 @@ index 6c1747f3..ab69cf5e 100644
 +          tinyxml2::tinyxml2
  )
  
- set_target_properties(
+ if(NOT EMSCRIPTEN)
 diff --git a/cmake/MujocoDependencies.cmake b/cmake/MujocoDependencies.cmake
-index d2404bc1..5c7ddaf6 100644
+index 6e205a7d..815d1c90 100644
 --- a/cmake/MujocoDependencies.cmake
 +++ b/cmake/MujocoDependencies.cmake
-@@ -87,8 +87,6 @@ set(BUILD_SHARED_LIBS
- if(NOT TARGET lodepng)
-   FetchContent_Declare(
-     lodepng
--    GIT_REPOSITORY https://github.com/lvandeve/lodepng.git
--    GIT_TAG ${MUJOCO_DEP_VERSION_lodepng}
-   )
- 
-   FetchContent_GetProperties(lodepng)
-@@ -111,8 +109,6 @@ endif()
+@@ -88,8 +88,6 @@ include(third_party_deps/lodepng)
  if(NOT TARGET marchingcubecpp)
    FetchContent_Declare(
      marchingcubecpp
@@ -33,12 +24,8 @@ index d2404bc1..5c7ddaf6 100644
    )
  
    FetchContent_GetProperties(marchingcubecpp)
-@@ -132,13 +128,9 @@ findorfetch(
-   USE_SYSTEM_PACKAGE
-   OFF
-   PACKAGE_NAME
--  qhull
-+  Qhull
+@@ -112,10 +110,6 @@ findorfetch(
+   qhull
    LIBRARY_NAME
    qhull
 -  GIT_REPO
@@ -48,7 +35,7 @@ index d2404bc1..5c7ddaf6 100644
    TARGETS
    qhull
    EXCLUDE_FROM_ALL
-@@ -160,12 +152,8 @@ findorfetch(
+@@ -137,10 +131,6 @@ findorfetch(
    tinyxml2
    LIBRARY_NAME
    tinyxml2
@@ -57,12 +44,9 @@ index d2404bc1..5c7ddaf6 100644
 -  GIT_TAG
 -  ${MUJOCO_DEP_VERSION_tinyxml2}
    TARGETS
--  tinyxml2
-+  tinyxml2::tinyxml2
+   tinyxml2
    EXCLUDE_FROM_ALL
- )
- target_compile_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
-@@ -183,10 +171,6 @@ findorfetch(
+@@ -160,10 +150,6 @@ findorfetch(
    tinyobjloader
    LIBRARY_NAME
    tinyobjloader
@@ -73,7 +57,7 @@ index d2404bc1..5c7ddaf6 100644
    TARGETS
    tinyobjloader
    EXCLUDE_FROM_ALL
-@@ -216,10 +200,6 @@ findorfetch(
+@@ -198,10 +184,6 @@ findorfetch(
    ccd
    LIBRARY_NAME
    ccd
@@ -84,7 +68,7 @@ index d2404bc1..5c7ddaf6 100644
    TARGETS
    ccd
    EXCLUDE_FROM_ALL
-@@ -256,8 +256,6 @@ set(BUILD_TESTS OFF)
+@@ -234,8 +216,6 @@ endif()
  set(BUILD_TESTS OFF)
  fetchpackage(
    PACKAGE_NAME  miniz
@@ -93,7 +77,7 @@ index d2404bc1..5c7ddaf6 100644
    TARGETS       miniz
  )
  if(_BUILD_TESTS_WAS_DEFINED)
-@@ -261,10 +241,6 @@ if(MUJOCO_BUILD_TESTS OR MUJOCO_BUILD_STUDIO OR MUJOCO_USE_FILAMENT)
+@@ -267,10 +247,6 @@ if(MUJOCO_BUILD_TESTS OR MUJOCO_BUILD_STUDIO OR MUJOCO_USE_FILAMENT)
      absl
      LIBRARY_NAME
      abseil-cpp
@@ -104,7 +88,7 @@ index d2404bc1..5c7ddaf6 100644
      TARGETS
      absl::core_headers
      EXCLUDE_FROM_ALL
-@@ -291,14 +267,9 @@ if(MUJOCO_BUILD_TESTS)
+@@ -299,10 +275,6 @@ if(MUJOCO_BUILD_TESTS)
      GTest
      LIBRARY_NAME
      googletest
@@ -113,15 +97,9 @@ index d2404bc1..5c7ddaf6 100644
 -    GIT_TAG
 -    ${MUJOCO_DEP_VERSION_gtest}
      TARGETS
--    gtest
--    gmock
--    gtest_main
-+    GTest::gmock
-+    GTest::gtest_main
-     EXCLUDE_FROM_ALL
-   )
- 
-@@ -323,10 +294,6 @@ if(MUJOCO_BUILD_TESTS)
+     gtest
+     gmock
+@@ -331,10 +303,6 @@ if(MUJOCO_BUILD_TESTS)
      benchmark
      LIBRARY_NAME
      benchmark
@@ -132,14 +110,7 @@ index d2404bc1..5c7ddaf6 100644
      TARGETS
      benchmark::benchmark
      benchmark::benchmark_main
-@@ -337,14 +304,12 @@ endif()
- 
- if(MUJOCO_TEST_PYTHON_UTIL)
-   add_compile_definitions(EIGEN_MPL2_ONLY)
--  if(NOT TARGET eigen)
-+  if(NOT TARGET Eigen3::Eigen)
-     # Support new IN_LIST if() operator.
-     set(CMAKE_POLICY_DEFAULT_CMP0057 NEW)
+@@ -351,8 +319,6 @@ if(MUJOCO_TEST_PYTHON_UTIL)
  
      FetchContent_Declare(
        Eigen3
@@ -148,8 +119,20 @@ index d2404bc1..5c7ddaf6 100644
      )
  
      FetchContent_GetProperties(Eigen3)
+diff --git a/cmake/third_party_deps/lodepng.cmake b/cmake/third_party_deps/lodepng.cmake
+index b604f052..9f4d531d 100644
+--- a/cmake/third_party_deps/lodepng.cmake
++++ b/cmake/third_party_deps/lodepng.cmake
+@@ -22,7 +22,5 @@ include(FindOrFetch)
+ 
+ fetchpackage(
+     PACKAGE_NAME  lodepng
+-    GIT_REPO      https://github.com/lvandeve/lodepng.git
+-    GIT_TAG       ${MUJOCO_DEP_VERSION_lodepng}
+     CUSTOM_CMAKE  "${CMAKE_CURRENT_LIST_DIR}/lodepng/CMakeLists.txt"
+ )
 diff --git a/python/mujoco/util/CMakeLists.txt b/python/mujoco/util/CMakeLists.txt
-index 666a3725..8f4ce043 100644
+index 666a3725..d89bb499 100644
 --- a/python/mujoco/util/CMakeLists.txt
 +++ b/python/mujoco/util/CMakeLists.txt
 @@ -63,8 +63,8 @@ if(BUILD_TESTING)
@@ -185,26 +168,22 @@ index 666a3725..8f4ce043 100644
    )
    gtest_add_tests(TARGET func_wrap_test SOURCES func_wrap_test.cc)
  
-diff --git a/simulate/cmake/SimulateDependencies.cmake b/simulate/cmake/SimulateDependencies.cmake
-index 7885f5f9..97b8b783 100644
---- a/simulate/cmake/SimulateDependencies.cmake
-+++ b/simulate/cmake/SimulateDependencies.cmake
-@@ -81,10 +81,6 @@ findorfetch(
-   glfw3
-   LIBRARY_NAME
-   glfw3
--  GIT_REPO
--  https://github.com/glfw/glfw.git
--  GIT_TAG
--  ${MUJOCO_DEP_VERSION_glfw3}
-   TARGETS
-   glfw
-   EXCLUDE_FROM_ALL
+@@ -90,8 +90,8 @@ if(BUILD_TESTING)
+   target_link_libraries(
+     tuple_tools_test
+     func_wrap
+-    gmock
+-    gtest_main
++    GTest::gmock
++    GTest::gtest_main
+   )
+   gtest_add_tests(TARGET tuple_tools_test SOURCES tuple_tools_test.cc)
+ endif()
 diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
-index f459a6ca..6830509d 100644
+index f1bbba61..4c3ee22d 100644
 --- a/test/CMakeLists.txt
 +++ b/test/CMakeLists.txt
-@@ -82,8 +82,8 @@ target_link_libraries(
+@@ -98,8 +98,8 @@ target_link_libraries(
           absl::synchronization
           absl::flat_hash_map
           absl::flat_hash_set

--- a/pkgs/by-name/mu/mujoco/package.nix
+++ b/pkgs/by-name/mu/mujoco/package.nix
@@ -20,8 +20,8 @@ let
     abseil-cpp = fetchFromGitHub {
       owner = "abseil";
       repo = "abseil-cpp";
-      rev = "5650e9cf76d3be4318d5fa3af38ee483ddfd5e4a";
-      hash = "sha256-O9ClnGm4WSTX3g1Q2VYTMhUtGG52XBwxzgHtWW9WSG0=";
+      rev = "2065f4ded0558c6f89fee67c8e5228feb4eb960e";
+      hash = "sha256-CEtLO4il9/jk+bFDDV0rXeX1OkirA0u6nxrSiWq0NPM=";
     };
     benchmark = fetchFromGitHub {
       owner = "google";
@@ -44,14 +44,8 @@ let
     googletest = fetchFromGitHub {
       owner = "google";
       repo = "googletest";
-      rev = "52eb8108c5bdec04579160ae17225d66034bd723";
-      hash = "sha256-HIHMxAUR4bjmFLoltJeIAVSulVQ6kVuIT2Ku+lwAx/4=";
-    };
-    lodepng = fetchFromGitHub {
-      owner = "lvandeve";
-      repo = "lodepng";
-      rev = "17d08dd26cac4d63f43af217ebd70318bfb8189c";
-      hash = "sha256-vnw52G0lY68471dzH7NXc++bTbLRsITSxGYXOTicA5w=";
+      rev = "063de7e9578f82b369302001269680b4b1553359";
+      hash = "sha256-rXsn2L0xeWvfxTjMAoWEu0UFZ7xOSfYmhbKgRF5J9co=";
     };
     miniz = fetchFromGitHub {
       owner = "richgel999";
@@ -68,8 +62,8 @@ let
     tinyobjloader = fetchFromGitHub {
       owner = "tinyobjloader";
       repo = "tinyobjloader";
-      rev = "1421a10d6ed9742f5b2c1766d22faa6cfbc56248";
-      hash = "sha256-9z2Ne/WPCiXkQpT8Cun/pSGUwgClYH+kQ6Dx1JvW6w0=";
+      rev = "2945a967c5303b2c8c14174117c45f3302591150";
+      hash = "sha256-eEgy43IzhovTjEgLz3qNsRnOkp0bcvQdWve7jOidHX4=";
     };
     tinyxml2 = fetchFromGitHub {
       owner = "leethomason";
@@ -83,12 +77,20 @@ let
       rev = "f03a1b3ec29b1d7d865691ca8aea4f1eb2c2873d";
       hash = "sha256-90ei0lpJA8XuVGI0rGb3md0Qtq8/bdkU7dUCHpp88Bw=";
     };
+
+    # cmake/third_party_deps/lodepng.cmake
+    lodepng = fetchFromGitHub {
+      owner = "lvandeve";
+      repo = "lodepng";
+      rev = "17d08dd26cac4d63f43af217ebd70318bfb8189c";
+      hash = "sha256-vnw52G0lY68471dzH7NXc++bTbLRsITSxGYXOTicA5w=";
+    };
   };
 
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mujoco";
-  version = "3.12.0";
+  version = "3.13.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -99,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "google-deepmind";
     repo = "mujoco";
     tag = finalAttrs.version;
-    hash = "sha256-BmppJK19YYgrLWdgv3i/eVXISIMIoJQ2OQVwcEXsMSI=";
+    hash = "sha256-uf1AGy9OBdZUNOKHzBnQOibIR7yPRDOKwnivIqakkOI=";
   };
 
   patches = [
@@ -151,7 +153,6 @@ stdenv.mkDerivation (finalAttrs: {
   + ''
     ln -s ${pin.eigen3} build/_deps/eigen3-src
     ln -s ${pin.googletest} build/_deps/googletest-src
-    ln -s ${pin.lodepng} build/_deps/lodepng-src
     ln -s ${pin.miniz} build/_deps/miniz-src
   ''
   # qhull is patched by mujoco's cmake and thus needs to be writable
@@ -159,6 +160,12 @@ stdenv.mkDerivation (finalAttrs: {
   + ''
     cp -r ${pin.qhull} build/_deps/qhull-src
     chmod -R +w build/_deps/qhull-src
+  ''
+  # lodepng needs a custom CMakeLists.txt copied into its source dir
+  # by FindOrFetch, so it must be writable
+  + ''
+    cp -r ${pin.lodepng} build/_deps/lodepng-src
+    chmod -R +w build/_deps/lodepng-src
   ''
   + ''
     ln -s ${pin.tinyobjloader} build/_deps/tinyobjloader-src

--- a/pkgs/development/python-modules/dm-control/default.nix
+++ b/pkgs/development/python-modules/dm-control/default.nix
@@ -29,15 +29,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "dm-control";
-  version = "1.0.45";
+  version = "1.0.46";
   pyproject = true;
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "google-deepmind";
     repo = "dm_control";
-    tag = finalAttrs.version;
-    hash = "sha256-mau3lWRubRmK5VU3OTYGURCYXqRkOCj/yQxW44AyLnE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z0Li4o6w0PjFgZ2qESxakUE7Ufaijlo084YlP3/m9Yo=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/mujoco/default.nix
+++ b/pkgs/development/python-modules/mujoco/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage (finalAttrs: {
   # in the project's CI.
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-OLs+r0JRk3qF1Ysl9VsWeSlxVbxPTpZEkNH9n0L4v5M=";
+    hash = "sha256-U5F11dsl0Z7BRRcPomR4SmJsXssif3jRh341oKeVX2k=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -86,11 +86,20 @@ buildPythonPackage (finalAttrs: {
       in
       ''
         ${lib.getExe perl} -0777 -i -pe "s/GIT_REPO\n.*\n.*GIT_TAG\n.*\n//gm" mujoco/CMakeLists.txt
-        ${lib.getExe perl} -0777 -i -pe "s/(FetchContent_Declare\(\n.*lodepng\n.*)(GIT_REPO.*\n.*GIT_TAG.*\n)(.*\))/\1\3/gm" mujoco/simulate/CMakeLists.txt
+      ''
+      # In 3.13.0, lodepng moved from simulate/CMakeLists.txt to
+      # cmake/third_party_deps/lodepng.cmake and uses fetchpackage (same-line args)
+      + ''
+        ${lib.getExe perl} -0777 -i -pe "s/GIT_REPO[^\n]*\n[^\n]*GIT_TAG[^\n]*\n//g" mujoco/cmake/third_party_deps/lodepng.cmake
 
         build="build/temp.${platform}-cpython-${pythonVersionMajorMinor}"
         mkdir -p $build/_deps
-        ln -s ${mujoco.pin.lodepng} $build/_deps/lodepng-src
+      ''
+      # lodepng needs a custom CMakeLists.txt copied into its source dir by FindOrFetch, so it must
+      # be writable
+      + ''
+        cp -r ${mujoco.pin.lodepng} $build/_deps/lodepng-src
+        chmod -R +w $build/_deps/lodepng-src
         ln -s ${mujoco.pin.eigen3} $build/_deps/eigen-src
         ln -s ${mujoco.pin.abseil-cpp} $build/_deps/abseil-cpp-src
       ''


### PR DESCRIPTION
## Things done 

- **mujoco: 3.12.0 -> 3.13.0** ([Diff](https://github.com/google-deepmind/mujoco/compare/3.12.0...3.13.0), [Changelog](https://mujoco.readthedocs.io/en/3.13.0/changelog.html))
- **python3Packages.dm-control: 1.0.45 -> 1.0.46** ([Diff](https://github.com/google-deepmind/dm_control/compare/1.0.45...v1.0.46), [Changelog](https://github.com/google-deepmind/dm_control/releases/tag/v1.0.46))

cc @samuela @tmplt

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test