### PR TITLE
nixos/collabora-online: use structuredAttrs instead of passAsFile

### DIFF
--- a/nixos/modules/services/web-apps/collabora-online.nix
+++ b/nixos/modules/services/web-apps/collabora-online.nix
@@ -42,7 +42,7 @@ let
           pkgs.yq-go
         ];
         userConfig = builtins.toJSON { config = cfg.settings; };
-        passAsFile = [ "userConfig" ];
+        __structuredAttrs = true;
       }
       # Merge the cfg.settings into the default coolwsd.xml.
       # See https://github.com/CollaboraOnline/online/issues/10049.
@@ -53,10 +53,9 @@ let
            ${cfg.package}/etc/coolwsd/coolwsd.xml \
            > ./default_coolwsd.json
 
-        jq '.[0] * .[1] | del(..|nulls)' \
+        printf "%s" "$userConfig" | jq '.[0] * .[1] | del(..|nulls)' \
            --slurp \
            ./default_coolwsd.json \
-           $userConfigPath \
            > ./merged.json
 
         yq --output-format=xml \


### PR DESCRIPTION
Moving towards `structuredAttrsByDefault` one step at a time...

The change seems straightforward but I don't know how to test this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
