### PR TITLE
rocqPackages: add withPackages to coq, refer to fixpoint in withPackages

### DIFF
--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -19,6 +19,21 @@ let
     self: rocq-core:
     let
       callPackage = self.callPackage;
+
+      # The 'finalDrv' argument refers to the package in the scope.
+      # When drv is overridden, the withPackages won't follow the modification otherwise.
+      mkWithPackages =
+        drv: finalDrv:
+        drv.overrideAttrs (oldAttrs: {
+          passthru = (oldAttrs.passthru or { }) // {
+            withPackages =
+              f:
+              (callPackage ../applications/science/logic/coq/with-packages.nix {
+                coq = finalDrv;
+              })
+                (f self);
+          };
+        });
     in
     {
       inherit lib;
@@ -37,13 +52,17 @@ let
       };
       mkRocqDerivation = lib.makeOverridable (callPackage ../build-support/rocq { });
 
-      coq = callPackage ../applications/science/logic/coq {
-        ocamlPackages_4_09 = null;
-        ocamlPackages_4_10 = null;
-        ocamlPackages_4_12 = null;
-        inherit ocamlPackages_4_14 ocamlPackages_5_5;
-        inherit (rocq-core) version;
-      };
+      coq =
+        let
+          thisCoq = callPackage ../applications/science/logic/coq {
+            ocamlPackages_4_09 = null;
+            ocamlPackages_4_10 = null;
+            ocamlPackages_4_12 = null;
+            inherit ocamlPackages_4_14 ocamlPackages_5_5;
+            inherit (self.rocq-core) version;
+          };
+        in
+        mkWithPackages thisCoq self.coq;
 
       mkCoqDerivation =
         args:
@@ -55,16 +74,7 @@ let
           // args
         );
 
-      rocq-core = rocq-core.overrideAttrs (oldAttrs: {
-        passthru = (oldAttrs.passthru or { }) // {
-          withPackages =
-            f:
-            (callPackage ../applications/science/logic/coq/with-packages.nix {
-              coq = rocq-core;
-            })
-              (f self);
-        };
-      });
+      rocq-core = mkWithPackages rocq-core self.rocq-core;
 
       contribs = lib.recurseIntoAttrs (callPackage ../development/rocq-modules/contribs { });
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

coq in rocqPackages on master doesn't have the `withPackages` attribute anymore. I added it back while ensuring the references points to the fixpoint ones, so override will function correctly.

I have tested with coqtop `Print LoadPath.` and it can see the packages from the packages added with `withPackages`.

### Update
I was told on zulip that coq doesn't need `withPackages` because it is merely a compatibility package. However, without `withPackages` I do not know an alternative way to meet the following requirements:
- build a derivation with rocqide (afaik requires the `coq` compatibility package)
- make libraries available to the rocqide (afaik requires `withPackage`)

This PR achieves the requirement. Suggestions are very welcome.


---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
