### PR TITLE
tailscale-gui: 1.98.5 -> 1.102.3

### DIFF
--- a/pkgs/by-name/ta/tailscale-gui/package.nix
+++ b/pkgs/by-name/ta/tailscale-gui/package.nix
@@ -14,11 +14,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tailscale-gui";
-  version = "1.98.5";
+  version = "1.102.3";
 
   src = fetchurl {
     url = "https://pkgs.tailscale.com/stable/Tailscale-${finalAttrs.version}-macos.pkg";
-    hash = "sha256-r7e8aKNWaX1psI0a3sohTUv8xmUv8oebH/ndjeHLoVA=";
+    hash = "sha256-oRYbUUbWXslFGZ9rt0HIa3BXxPGurkHhDXwIIIBktks=";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
Bumps the macOS GUI client to the current stable release, matching what pkgs.tailscale.com serves today.

Changelog: https://tailscale.com/changelog#client

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested, as applicable: the derivation builds on aarch64-darwin, and the extracted bundle is `diff -r`-identical to the vendor's own 1.102.3 install running on my machine (menu-bar app, system extension, and bundled CLI all working)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
