### PR TITLE
pesde: 0.7.3 -> 0.7.4, adopt

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6234,6 +6234,12 @@
     github = "dadada";
     githubId = 7216772;
   };
+  daimond113 = {
+    name = "daimond113";
+    github = "daimond113";
+    githubId = 72147841;
+    email = "contact@daimond113.com";
+  };
   dalance = {
     email = "dalance@gmail.com";
     github = "dalance";

--- a/pkgs/by-name/pe/pesde/package.nix
+++ b/pkgs/by-name/pe/pesde/package.nix
@@ -9,17 +9,17 @@
 
 rustPlatform.buildRustPackage {
   pname = "pesde";
-  version = "0.7.3";
+  version = "0.7.4";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pesde-pkg";
     repo = "pesde";
-    rev = "e57b4c2db9eaf295c8af998212f427ea039ed46e";
-    hash = "sha256-+8SneWw3UQwXg1IV1zn0OM1ySAJpcvMqyoQd7eYAarE=";
+    rev = "611c484ed26aa6a7151d5f2c85e5048012eefdac";
+    hash = "sha256-4SF+k14QQGrkrJ0qYGY1khjQmm9gA6aLQjv5bAIe9gY=";
   };
 
-  cargoHash = "sha256-1k7bmH4ocF9JK15C7YonCmwDKVh639Nropuzm62roDA=";
+  cargoHash = "sha256-/jQmlkgWY6tqenwi/ceavGkz8BPwvx+DCzBjKA0w5ZU=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
@@ -32,7 +32,10 @@ rustPlatform.buildRustPackage {
     description = "Package manager for the Luau programming language, supporting multiple runtimes including Roblox and Lune.";
     homepage = "https://github.com/pesde-pkg/pesde";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ vokinn ];
+    maintainers = with lib.maintainers; [
+      daimond113
+      vokinn
+    ];
     mainProgram = "pesde";
   };
 }


### PR DESCRIPTION
https://github.com/pesde-pkg/pesde/compare/v0.7.3+registry.0.2.3...v0.7.4+registry.0.2.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
