### PR TITLE
chromium,chromedriver: 152.0.7977.82 -> 153.0.8010.36

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -450,7 +450,10 @@ let
 
     patches = [
       ./patches/cross-compile.patch
+    ]
+    ++ lib.optionals (!chromiumVersionAtLeast "153") [
       # Optional patch to use SOURCE_DATE_EPOCH in compute_build_timestamp.py (should be upstreamed):
+      # Stopped applying with M153 due to formatting.
       ./patches/no-build-timestamps.patch
     ]
     ++ lib.optionals (packageName == "chromium") [
@@ -589,7 +592,7 @@ let
         hash = "sha256-jR0G9z2R8VGl2tkB3u0368RyWM1J6qYXqNWwKkYd5zU=";
       })
     ]
-    ++ lib.optionals (chromiumVersionAtLeast "151" && lib.versionOlder llvmVersion "23") [
+    ++ lib.optionals (versionRange "151" "153" && lib.versionOlder llvmVersion "23") [
       # Revert CL 7911761 to help the patch below to apply cleanly.
       (fetchpatch {
         name = "chromium-151-revert-Fix-is_wasm-compile-for-supersize.patch";
@@ -600,11 +603,15 @@ let
         hash = "sha256-musbcTi2XMnJXW79gG+kr9qcYJZ25fv6MeIeId/nAwI=";
       })
     ]
-    ++ lib.optionals (chromiumVersionAtLeast "149" && lib.versionOlder llvmVersion "23") [
+    ++ lib.optionals (versionRange "149" "153" && lib.versionOlder llvmVersion "23") [
       # clang++: error: unknown argument: '-fdiagnostics-show-inlining-chain'
       # clang++: error: unknown argument: '-fsanitize-ignore-for-ubsan-feature=array-bounds'
       # clang++: error: unknown argument: '-fsanitize-ignore-for-ubsan-feature=return'
       ./patches/chromium-149-llvm-22.patch
+    ]
+    ++ lib.optionals (chromiumVersionAtLeast "153" && lib.versionOlder llvmVersion "23") [
+      # Rebased variant of the patch above
+      ./patches/chromium-153-llvm-22.patch
     ]
     ++ lib.optionals (chromiumVersionAtLeast "149" && stdenv.hostPlatform.isAarch64) [
       # [43731/56364] CXX obj/media/gpu/sandbox/sandbox/hardware_video_decoding_sandbox_hook_linux.o
@@ -688,10 +695,44 @@ let
       # by https://github.com/Ahrotahn (ungoogled-chromium, BSD-3-Clause)
       ./patches/ungoogled-chromium-152-crubit.patch
     ]
-    ++ lib.optionals (chromiumVersionAtLeast "152" && lib.versionOlder llvmVersion "23") [
+    ++ lib.optionals (versionRange "152" "153" && lib.versionOlder llvmVersion "23") [
       # error: unknown argument: '-fno-lifetime-safety-inference'
       # error: unknown argument: '-fno-experimental-lifetime-safety-tu-analysis'
       ./patches/chromium-152-dawn-llvm-22.patch
+    ]
+    ++ lib.optionals (chromiumVersionAtLeast "153") [
+      (fetchpatch {
+        name = "chromium-153-revert-DEPS-use-DEPS-provided-python-instead-of-a-system-one.patch";
+        # https://chromium-review.googlesource.com/c/chromium/src/+/8160801
+        url = "https://chromium.googlesource.com/chromium/src/+/ce8851b40f37e74adcb7813256930792f35b8039^!?format=TEXT";
+        decode = "base64 -d";
+        revert = true;
+        includes = [ ".gn" ];
+        hash = "sha256-xrtu5YhxJtBFlKpQCqRR1BBkJyiN/DW+aUCVB1zZVHI=";
+      })
+    ]
+    ++ lib.optionals (chromiumVersionAtLeast "153") [
+      (fetchpatch {
+        name = "chromium-153-revert-Migrate-OpenType-format-check-bindings-to-Crubit.patch";
+        # https://chromium-review.googlesource.com/c/chromium/src/+/8244248
+        url = "https://chromium.googlesource.com/chromium/src/+/493e6c3911e33cc356856bafbffc6cf95521266b^!?format=TEXT";
+        decode = "base64 -d";
+        revert = true;
+        hash = "sha256-+5lddQSOJz7XTZanDl3/lqQ7CQhnCVzvUMpxvE3Sz2c=";
+      })
+    ]
+    ++ lib.optionals (chromiumVersionAtLeast "153") [
+      (fetchpatch {
+        name = "chromium-153-revert-devtools-frontend-Remove-TSGO-flag.patch";
+        # https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/8193297
+        url = "https://chromium.googlesource.com/devtools/devtools-frontend/+/2691b4ae139d2e7b6244f05139a0b85082c7473c^!?format=TEXT";
+        decode = "base64 -d";
+        stripLen = 1;
+        extraPrefix = "third_party/devtools-frontend/src/";
+        revert = true;
+        hash = "sha256-Dip5axpXSJbdGmtS7t81nLCvjRPBSkAuJA4Lo6MFKLw=";
+      })
+
     ];
 
     postPatch =
@@ -967,6 +1008,10 @@ let
       // {
         use_pulseaudio = true;
         link_pulseaudio = true;
+      }
+      // lib.optionalAttrs (chromiumVersionAtLeast "153") {
+        use_typescript_go = false;
+        devtools_use_typescript_go = false;
       }
       // lib.optionalAttrs ungoogled (lib.importTOML ./ungoogled-flags.toml)
       // (extraAttrs.gnFlags or { })

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,59 +1,59 @@
 {
   "chromium": {
-    "version": "152.0.7977.82",
+    "version": "153.0.8010.36",
     "chromedriver": {
-      "version": "152.0.7977.83",
-      "hash_darwin": "sha256-cx8v6bu6MuSU+LHOGmxcOWNhH7tZFaegHfcMv+RSZGg=",
-      "hash_darwin_aarch64": "sha256-OM3ogo/Z76H8E8F9RhbcLwjSEgWNxdBJxngDI/nHhkI="
+      "version": "153.0.8010.37",
+      "hash_darwin": "sha256-IMyEnUmK3slNB/QDZ+vtUyzHyU0AB+L6+BMbpCRluYA=",
+      "hash_darwin_aarch64": "sha256-cd1ZWatLQFIkPtCdVacrxFaFfj3rjG9qJ7kGlL3C6OA="
     },
     "deps": {
       "depot_tools": {
-        "rev": "38c391feba5fb96812f9028da12413ffc39df394",
-        "hash": "sha256-yOd+k4GJ/unOVCm2Fj1oDHOMKV87CuBO/z0li3owNQk="
+        "rev": "6411ed52842756261c66b6b8ece6b53ade2570f1",
+        "hash": "sha256-x08CgrvsdaP0+MY8ea0H8jWjgc7/B+ipRhpCLm41lBQ="
       },
       "gn": {
-        "version": "0-unstable-2026-07-23",
-        "rev": "641ace93dd9560e75e7add0d08f77b446fbb3b78",
-        "hash": "sha256-ovLx6KaORdXqnWgbsGEty10k2CHuCmTk3yEqy5//ovk="
+        "version": "0-unstable-2026-08-14",
+        "rev": "e8a8e0932a5e42a99e5896aa58e3b8290f4e5b8c",
+        "hash": "sha256-qvQ13Ws2tb4i2Hdu34kBHivYPAn8w06zjLdQgK4BIJg="
       },
       "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "d04cdb24d67b081f6cf80200ffc5233f44b61109",
-        "hash": "sha256-JiYTfMJBtUWMUSicQdSCXNUtgjLGeaMj4vCNpMvYACk=",
+        "rev": "507c6ee3e2f3b2ca0e660547e5b9ea4820c67f4c",
+        "hash": "sha256-q29a3PWQ7wMG4/JL9EyCK7EaDCeG+4Q/ruemOvvgeZM=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git",
-        "rev": "6eddfb5ec5f92127a531eda66c568d3a11e7ec11",
-        "hash": "sha256-Cm6BOOlEyD0kdYxMSmk6Fj1Dnfs3zCzXsm+BOXgBme0="
+        "rev": "70510081984cfcdb14a15b3e08dfe9776dc7ed37",
+        "hash": "sha256-IC5Dy3elgEezXmRyDbafx5i+V9wiDLMmnpi7O7BucdE="
       },
       "src/third_party/compiler-rt/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git",
-        "rev": "e1c9323385b40780f574f440a8a9ad83855712b0",
-        "hash": "sha256-oxGL+ct1z5S9wduYINjiZrjJx1HlAJjyMPEoDyhIfvo="
+        "rev": "0ccff08262472b88b5d5d193342d84ba4f6fa3fa",
+        "hash": "sha256-+HdvQVqX5F0ylUccsk3H4nx6TEwMr53HCyAlKC4IQPk="
       },
       "src/third_party/libc++/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git",
-        "rev": "b16984ce99c702355a5b2b4c52574e82cec41fb9",
-        "hash": "sha256-ZVgUAi5rYj17N3nAEvLQXZLCxnmvxIo2RpJ3geTSyWQ="
+        "rev": "97b436da4c33663581d394f4ee0a5977fc38c2f4",
+        "hash": "sha256-HMvG9asIDID5KHhQdScfVYx/7iU9+5o1BjOXf0Ev7JY="
       },
       "src/third_party/libc++abi/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git",
-        "rev": "8f11bb1d4438d0239d0dfc1bd9456a9f31629dda",
-        "hash": "sha256-L5CUvhpOLS+NBNGssCv0pY9rsDFuAI0LlPjXQRfy62A="
+        "rev": "fc1897a2c12aa27e703c3ed48b62eba8abf4ce19",
+        "hash": "sha256-oH39u1eOso+gV3hHMJ9DFM8FzSbYMFJmWKVbOyX0VoU="
       },
       "src/third_party/libunwind/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git",
-        "rev": "b2ff0e6b9ac002918d7a9ce982eee88dcc27a450",
-        "hash": "sha256-VK9w68Im896xi4cymhtfvh7xdRJZB78YEvUYyxqBu48="
+        "rev": "0790de42df7835816d95ce62c598f9fef5ef4e6c",
+        "hash": "sha256-XbJ5wvqLsRqkZzcvtE0XZjs0XLREaed1N8/nQF4esyw="
       },
       "src/third_party/llvm-libc/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git",
-        "rev": "3ea89f4304312567e31a8eb45e0737577e65b676",
-        "hash": "sha256-g8ZtRI0yazHgli0/TMz/SeAJ5SoMZdir+/29GFQAczM="
+        "rev": "20fd93c3ba54634c545ae2045fb207e7e58bb648",
+        "hash": "sha256-KlYMGfOIIIFwsZPxXKPCA06PJW2+hO84ql5uow2ONRY="
       },
       "src/chrome/test/data/perf/canvas_bench": {
         "url": "https://chromium.googlesource.com/chromium/canvas_bench.git",
@@ -72,8 +72,8 @@
       },
       "src/docs/website": {
         "url": "https://chromium.googlesource.com/website.git",
-        "rev": "e9dfa88cee41c025709e79164ceb0758cfe76a67",
-        "hash": "sha256-mWAwegdaC7LEOYN5Y/xcJBv4R9dInK4VW35/U8rn7Wg="
+        "rev": "ebebad7d52ad3d28f5a21a75561e9bc2b496e472",
+        "hash": "sha256-QZ+SA3FYN0bbfmmLOKLqbxWW1oGN+IigsJrz8ZtTXRI="
       },
       "src/media/cdm/api": {
         "url": "https://chromium.googlesource.com/chromium/cdm.git",
@@ -82,8 +82,8 @@
       },
       "src/net/third_party/quiche/src": {
         "url": "https://quiche.googlesource.com/quiche.git",
-        "rev": "1ba0d99a5c2fec4f4dbb7f98f251b05dcf4e2968",
-        "hash": "sha256-odzVQD9WyldgAv8QRvXABKaSLy1DL6DRhdVQSer4HVM="
+        "rev": "2c4a124642f095f995cd2e9e2fe10decc08df662",
+        "hash": "sha256-5lcY8lJ+nwRrNe9oycRE4C9FzmkqlWyBL4J/YYSiWiQ="
       },
       "src/testing/libfuzzer/fuzzers/wasm_corpus": {
         "url": "https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git",
@@ -92,8 +92,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "7df613367a1d4ca9aea9ece344d4580d32d132a9",
-        "hash": "sha256-bYGok5QvWJoCfliRPQqrDz0ttKf1r9HoFxoC4qwdI3o="
+        "rev": "fca5efdfeff5daf430bc4458375c8d6b7e457400",
+        "hash": "sha256-IoHQfdjZ6TV03VVzHZcxhPqGmNYNhKZrPG4BvQQfC7c="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -107,18 +107,13 @@
       },
       "src/third_party/angle/third_party/VK-GL-CTS/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS",
-        "rev": "3b7cbad78e93bcda20ccf68efae2d71695dd0f65",
-        "hash": "sha256-bPgrkZ3my/tl+H2/YuAxmn83svPSw4l6lnz8zGHQtuk="
+        "rev": "0b04c470ed78569b0b778ece1262d88455ab2b00",
+        "hash": "sha256-PuB0CciB7Gp5f68f5lGxg7f3avOYIFTOJQ1ZKRkuUHc="
       },
       "src/third_party/anonymous_tokens/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git",
-        "rev": "e07c92bc81cfd4203e6158cac115fc44c27b31b8",
-        "hash": "sha256-NY/RkTCl/7KBJuIS6pa3sjdgyccWDrSfrUwBqWgL/4I="
-      },
-      "src/third_party/aria-practices/src": {
-        "url": "https://chromium.googlesource.com/external/github.com/w3c/aria-practices.git",
-        "rev": "7b134ce6d19497cce8a67db4a9f59980baf853dc",
-        "hash": "sha256-POnvoO1KfzJj4CbcMPI0pUTRk5EtHLTOyKKmJCZdXOc="
+        "rev": "de00da44e56cf44f15d7aefe69e122e743e5a019",
+        "hash": "sha256-pV0ltk+MOZSgg92w2VYy2PCK8RLwkoG4hLWpeMxdMvk="
       },
       "src/third_party/readability/src": {
         "url": "https://chromium.googlesource.com/external/github.com/mozilla/readability.git",
@@ -127,28 +122,28 @@
       },
       "src/third_party/content_analysis_sdk/src": {
         "url": "https://chromium.googlesource.com/external/github.com/chromium/content_analysis_sdk.git",
-        "rev": "2a8191af30a4d1f591e2f758e595bdeea139e93a",
-        "hash": "sha256-EoEyau3eFcfnftdUSQuLiikIEwVZR7E4Th+qkCdk7kU="
+        "rev": "0a0e7ea516249e786d5a8884552bbd6e163d89cb",
+        "hash": "sha256-dRK4RDkoYcpmRKap6W6lUlP9yyzXj7c/DJlug1mjazc="
       },
       "src/third_party/dav1d/libdav1d": {
         "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git",
-        "rev": "54706fc6bc0cdecab7e9593974a4039cc038fca7",
-        "hash": "sha256-L3a9MmPWJlxmRa19glWDLvkXHev5oiM5/fxtKOBPMxI="
+        "rev": "52b9d3d3ec525f5a20849145fa0e879d585f4911",
+        "hash": "sha256-WVsYrZcVQMCmfjFPFKzh5JZJY46+DnUquin9lsQclWI="
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "ab8827bc57b176eeaa89f71324130c02d4d41145",
-        "hash": "sha256-Xd1FsdIBO6hzNECnNnXR0306woHl5/L+5WZ/pxTlYfA="
+        "rev": "225a7ba1bcb997d26de3e894e04fb341638e8c5a",
+        "hash": "sha256-/ic1j1gu2wl5wCLCESfEcsLAPU5Dmsx8oKFb6RhYzg4="
       },
       "src/third_party/dawn/third_party/glfw3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
-        "rev": "463cf73610d911e8eff95ae345143137cf610be4",
-        "hash": "sha256-+WG+0KALV10B+1hOJzyiU4azlJIej/F5DtqtSkEN040="
+        "rev": "92dcf4ce74f2e2554a98fea09be7c705c17daa5a",
+        "hash": "sha256-8Hu8KQIw9SVRuQPzUbl907Xw+ImdX0bkBnqkA4DDmo4="
       },
       "src/third_party/dawn/third_party/directx-shader-compiler/src": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler",
-        "rev": "1f8a14aecd4f2f25991fa9f7aad6c320fea91409",
-        "hash": "sha256-nesLgajCiFHwb2TKwzlCERFb6wOkwqpMT5z6nzj2Q9Y="
+        "rev": "4b537fd7a7f83373000dea9a3d1d308bf47c3d45",
+        "hash": "sha256-bRctHtMo0S4PoSoXJ8XV5D61+trCVBQ+L5kD3huj+ik="
       },
       "src/third_party/dawn/third_party/directx-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers",
@@ -157,8 +152,8 @@
       },
       "src/third_party/dawn/third_party/OpenGL-Registry/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry",
-        "rev": "9d527dbc81bb76e35ba284fe385ed8a5ddb90cbc",
-        "hash": "sha256-vNXA115a0tDvs7cyLobu/9cgCAPFrEYHUFVM8A/AX88="
+        "rev": "e8f7cd0e35ac8d6f5667a021ff83d04b1fec41ef",
+        "hash": "sha256-5muDTFLFRdz24czuBM9x7QIjJdRj3gzJEItP5A8Xypw="
       },
       "src/third_party/dawn/third_party/EGL-Registry/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/EGL-Registry",
@@ -167,13 +162,13 @@
       },
       "src/third_party/dawn/third_party/webgpu-cts": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts",
-        "rev": "499044af47ec2717e06e644d0943e6fcdb3f3538",
-        "hash": "sha256-M8TWqKdqoiZ01vbDpcRyPWIOaBPCPdSSflxcIpbYjFA="
+        "rev": "2959e1c3959aa55cd3f02726995ae68159d0e064",
+        "hash": "sha256-Z8hszmUjsRupyLk6LTit1R2rZyYfOakTJ75niMwl/Xs="
       },
       "src/third_party/dawn/third_party/webgpu-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers",
-        "rev": "b3f67b89929c133403fd95638be4ef96b56ddca0",
-        "hash": "sha256-pLsvlbh1BCEtfQNejm2XilpelZmNg1/NuLq0agIGqQI="
+        "rev": "01addc4ba8a2915a061b7095a6768b512071ab96",
+        "hash": "sha256-E8SldE2oDNgkWX1CL1NoNSuZQvN6ffKDesWLovI+EGs="
       },
       "src/third_party/disarm/src": {
         "url": "https://chromium.googlesource.com/external/github.com/aengelke/disarm.git",
@@ -202,13 +197,13 @@
       },
       "src/third_party/boringssl/src": {
         "url": "https://boringssl.googlesource.com/boringssl.git",
-        "rev": "572a4c68475d284b34675f45ddbb9c158ef3c2ae",
-        "hash": "sha256-gW+Ksd/boITK5ZTDIwhIgPAdPQNi8MvP7ru6qMdtorI="
+        "rev": "defe5810ee8be430bcdeccf46a199bec0e93abdb",
+        "hash": "sha256-u+rYY4gO9oKrkKxSMl/2AnxtdfP2ca+yb+08rvL4qIY="
       },
       "src/third_party/breakpad/breakpad": {
         "url": "https://chromium.googlesource.com/breakpad/breakpad.git",
-        "rev": "69e9aada412e81575a95d0d94f4592fe1b8dfc15",
-        "hash": "sha256-v0Qw8nlXR6Dnkbt7I0Fe7HKv9mtf/9h0xl4HaCHPJjA="
+        "rev": "418aacd617897c19d960ec3e649f42ea95a6363a",
+        "hash": "sha256-/lUMLXbjhSzQYQuSBFKdrit2jiAv1oM4bhTyvpN5+bI="
       },
       "src/third_party/cast_core/public/src": {
         "url": "https://chromium.googlesource.com/cast_core/public",
@@ -217,8 +212,8 @@
       },
       "src/third_party/catapult": {
         "url": "https://chromium.googlesource.com/catapult.git",
-        "rev": "d810008022eeaefcbea50393ea5baa0930b27047",
-        "hash": "sha256-H2CpevfSmr6suNHkkO97u0Nmu1n3g9v36ea+M8JPpZo="
+        "rev": "1d18f6e11082de030c45fd55b556d15e3aa628a8",
+        "hash": "sha256-q2LYVudrEEudWHdoN6UagcoR3l9cx682IvfdB4GZMB8="
       },
       "src/third_party/ced/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git",
@@ -242,8 +237,8 @@
       },
       "src/third_party/cpuinfo/src": {
         "url": "https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git",
-        "rev": "ea6b9f1bb6e1001d8b21574d5bc78ddef62e499d",
-        "hash": "sha256-/QsOjDik0TnH3FnK7LOwsJkvX+O+2DRFX4eF3MxD3fc="
+        "rev": "66ee79c038d70dad9f08705b2c9b3e58f6d8f512",
+        "hash": "sha256-A+kTj3GthwmO2kKeG3gG/zjvvt45OmuEvAtRLzwfEyM="
       },
       "src/third_party/crc32c/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/crc32c.git",
@@ -252,33 +247,38 @@
       },
       "src/third_party/cros_system_api": {
         "url": "https://chromium.googlesource.com/chromiumos/platform2/system_api.git",
-        "rev": "54e5484f94e59fdc31e7821293692a8bb47f88a3",
-        "hash": "sha256-TUW8y9as37owHYgg4mTs9ZUmZ4G+N1Njtrs6eyY5MDU="
+        "rev": "faf06f1112b67fead7dbd81cd9f769f1c9c22726",
+        "hash": "sha256-wdZzNbmtuUu/NhQz2eaNiSeUYiO6jtZ5RYUDQavrhdw="
       },
       "src/third_party/crossbench": {
         "url": "https://chromium.googlesource.com/crossbench.git",
-        "rev": "eb6e4790f4fc6f2f66a20aba07de9a58985db46b",
-        "hash": "sha256-kEMKNDP57Q3m2eBjb0McScZTxrFpLTIE/9dSAupTOJ4="
+        "rev": "98b5ff69cfec93bbdb98695850e7a15cc82101de",
+        "hash": "sha256-SwjdB0nvdbfnKhCNPhjRpK70P3B5RfDx6KHb6Zjn0YM="
       },
       "src/third_party/crossbench-web-tests": {
         "url": "https://chromium.googlesource.com/chromium/web-tests.git",
-        "rev": "92d748acb154cb58c76ad1d509378d5aa8669755",
-        "hash": "sha256-vh6uX1jXhxDgqfXnme/nh8W+O4Qq+Fx33lSQ08LNunM="
+        "rev": "b9000ed38c9a012d961d72918b4b33000309bb06",
+        "hash": "sha256-3OZeEcJaxMFHUK5JzbhkHdFn1kBWDYsc9GgHCDHUKgg="
       },
       "src/third_party/depot_tools": {
         "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-        "rev": "38c391feba5fb96812f9028da12413ffc39df394",
-        "hash": "sha256-yOd+k4GJ/unOVCm2Fj1oDHOMKV87CuBO/z0li3owNQk="
+        "rev": "6411ed52842756261c66b6b8ece6b53ade2570f1",
+        "hash": "sha256-x08CgrvsdaP0+MY8ea0H8jWjgc7/B+ipRhpCLm41lBQ="
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "04db1f5240b636511ec4e9058a78f8274a7f65ee",
-        "hash": "sha256-vZxKC/QD2dHNnVm9OZI1Bo0Jdnn+AJhFpXYSXXF7JsA="
+        "rev": "511172b786248e29d7493bf954faa57f834dc5b3",
+        "hash": "sha256-jKXBklk5bjhwmJ9DlKmuI33y17JglrZuHejufeTm4t4="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
         "rev": "199de96b345ada7c6e7e6ba3d2fa7a6911b8767d",
         "hash": "sha256-yuEBD2XQlV3FGI/i7lTmJbCqzeBiuG1Qow8wvsppGJw="
+      },
+      "src/third_party/ds_store/src": {
+        "url": "https://chromium.googlesource.com/external/github.com/dmgbuild/ds_store.git",
+        "rev": "5cf0b73afdaf6592666364c354501b51c5ce606e",
+        "hash": "sha256-o9oI002FqQHe15yZbv4I7bHMr1NkFghKnLaZKNHZswQ="
       },
       "src/third_party/dragonbox/src": {
         "url": "https://chromium.googlesource.com/external/github.com/jk-jeon/dragonbox.git",
@@ -287,8 +287,8 @@
       },
       "src/third_party/eigen3/src": {
         "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git",
-        "rev": "d53ac33805ba0a23fa139adaf24227fb6707e6fa",
-        "hash": "sha256-+s/4HVUzKJR5OVcoxwiEzB8F89lov24g0HBPg3tp9Xs="
+        "rev": "76a7c53018c33cd39e0effeb697fa3295bbd3179",
+        "hash": "sha256-R5VxpUMkWwr41wYDA+8Z72aSg0q7+8PX9R7PFRanllg="
       },
       "src/third_party/farmhash/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/farmhash.git",
@@ -307,8 +307,8 @@
       },
       "src/third_party/ffmpeg": {
         "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git",
-        "rev": "2b68d2babae73714846961fb0ee47e3b3d2e39a9",
-        "hash": "sha256-Bl8lAM5sHLZ9BHSIaWr5+P/8s014SXsgSmdLya5gd64="
+        "rev": "53fa34a23be9054d25ac2500dbdae9a0e570bb5c",
+        "hash": "sha256-yQE2hS6iClqZQqXXRkzjrYZQh9PIkHhLOeQ8V/j7eKU="
       },
       "src/third_party/flac": {
         "url": "https://chromium.googlesource.com/chromium/deps/flac.git",
@@ -337,8 +337,8 @@
       },
       "src/third_party/freetype/src": {
         "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git",
-        "rev": "656cb777798fa420a13faba3758779e9ed6c4798",
-        "hash": "sha256-i1X/ETNJTAL3A5pOiUcZRYpqjhPvZIm8FG1HMQreW6g="
+        "rev": "9e9d3b73f31367dbb4261f93c727a277f6632c77",
+        "hash": "sha256-NoXERTcn2SIddhYFtAdRlnikNtVR9GB48aMJqCRwP3E="
       },
       "src/third_party/fxdiv/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git",
@@ -347,18 +347,13 @@
       },
       "src/third_party/harfbuzz/src": {
         "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git",
-        "rev": "28f4dc622fef010dab12f4275ac195b5d4a4a704",
-        "hash": "sha256-wqycfs0TITlLu0iJICjAqSX82u8LGrr/NaZ+pgPvycs="
+        "rev": "dfdc088c4d7c5d31dd5b13070b919b51f6c21ea8",
+        "hash": "sha256-DNWpvXkuTMc89lZTTrVWPMj9YQCw80gxOCh2Gmnlw70="
       },
       "src/third_party/ink/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ink.git",
-        "rev": "e781093cb91ad22a666f1880f5122fe2ed30ecfd",
-        "hash": "sha256-j9FIfGrrNEQB3wI2zMvjUksLBEdx8yrVf1NAbJSyjAI="
-      },
-      "src/third_party/instrumented_libs": {
-        "url": "https://chromium.googlesource.com/chromium/third_party/instrumented_libraries.git",
-        "rev": "e8cb570a9a2ee9128e2214c73417ad2a3c47780b",
-        "hash": "sha256-5cb9qhSEzb941pF5HH0Br+x9wEH7MiGwQttvErb2mZo="
+        "rev": "a4349e28c716c7baf0aba80d7602476ff9e65662",
+        "hash": "sha256-hgYJYb/6zwnW6vnuOmfzsFZD2x1a07jn9PO9OXY3hGI="
       },
       "src/third_party/emoji-segmenter/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/emoji-segmenter.git",
@@ -392,18 +387,18 @@
       },
       "src/third_party/icu": {
         "url": "https://chromium.googlesource.com/chromium/deps/icu.git",
-        "rev": "d578f2e8b7bd5938e21cfb6bf15c079e0aa5b738",
-        "hash": "sha256-DsktUjKFFbeSqlFZTBqbZgvuJLOKvssCym2M3tcOJtw="
+        "rev": "8cc91d9b6ab9991802fd208ee03a69714fd0251c",
+        "hash": "sha256-vIkKJ5YaSLJZCZ821hCDgceZQC/9JKPZbIHBEZpOUes="
       },
       "src/third_party/nlohmann_json/src": {
         "url": "https://chromium.googlesource.com/external/github.com/nlohmann/json.git",
-        "rev": "3565f40229515411177c196ec912a06307802ed6",
-        "hash": "sha256-kngBPCN5i+5kzJ95pJ5vY2RLa9P4JYs4e+7Qn3QWsc4="
+        "rev": "55f93686c01528224f448c19128836e7df245f72",
+        "hash": "sha256-cECvDOLxgX7Q9R3IE86Hj9JJUxraDQvhoyPDF03B2CY="
       },
       "src/third_party/jsoncpp/source": {
         "url": "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git",
-        "rev": "edc01ab10f52135ec80e3589b6b4e0a9c65b27fd",
-        "hash": "sha256-mdQo7AiS3DzTF8CqCRT9oL60AzGLQCFng7KUFaFEBIM="
+        "rev": "60de77f915ab08499032d6e5a63e05e974f85d01",
+        "hash": "sha256-mAIscGzXFVQxP8C2znDR6y/IXkGxq+p0gxdanJeyFME="
       },
       "src/third_party/leveldatabase/src": {
         "url": "https://chromium.googlesource.com/external/leveldb.git",
@@ -412,13 +407,13 @@
       },
       "src/third_party/libFuzzer/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer.git",
-        "rev": "3f386be62e362fa50284ebd24262966f1a93798e",
-        "hash": "sha256-vQBWi+4ynPBhZma/2+ApbhT9tbOCd8U+QrabC8GnqKQ="
+        "rev": "5811dc57603eac1fa0e76addedb77f72f62bfa2d",
+        "hash": "sha256-NfhWg32W2GB3zlDYX+4nrYFeka92tfg3XiGQO5vLDPo="
       },
       "src/third_party/fuzztest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git",
-        "rev": "239bf6cc1ffcbad7d5c96e3b836b474654cbf96c",
-        "hash": "sha256-h268YPbMTgr5zd0bhTh1Xj/BcCxBhDD60o6+oelW/BQ="
+        "rev": "8bc765afc32fa8210cfe827ff4c94ab7db1c518b",
+        "hash": "sha256-J0HpOSEizCK23tr0D6+n3tFiKds2kEhfVIYhRNawiLw="
       },
       "src/third_party/domato/src": {
         "url": "https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git",
@@ -432,13 +427,13 @@
       },
       "src/third_party/libaom/source/libaom": {
         "url": "https://aomedia.googlesource.com/aom.git",
-        "rev": "d08a82575de50dc99f3b3d324e7b8304836fe0ef",
-        "hash": "sha256-32WklYoVgBiMxnY+2nOckwmKjZBKZtgwKBmStoO8y/Q="
+        "rev": "7a210280be0986d63abae0661b71d0c342560b9d",
+        "hash": "sha256-fQ/zyAYCwZDAJfU6+7KmGcBe5iiBy1N9iZPPeHNhkcY="
       },
       "src/third_party/crabbyavif/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git",
-        "rev": "61f5abadda7b179f90e557fed6ae7a3d78bd8231",
-        "hash": "sha256-N9YwO68d3CXPje43fWs9CoO5Sc3wIULta7n8cp+2Efs="
+        "rev": "a843d6269faf338da244b981cfeb7601007b4e6c",
+        "hash": "sha256-k8cFaQ5Y+Cglhk07IdQrhw+PZ5Ilu/nhnbYU9WnOX8k="
       },
       "src/third_party/nearby/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/nearby-connections.git",
@@ -452,8 +447,8 @@
       },
       "src/third_party/jetstream/main": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git",
-        "rev": "b7babdf323e64e69bd2f6c376189c15825f5c73a",
-        "hash": "sha256-s6UMdUYWZqk/MbhyCi2zdQNgni98gGsYxcuUh/5AUy0="
+        "rev": "7769b693502fa80f28a97bbfacd3296e0513acc5",
+        "hash": "sha256-jh1FTtuS2NVPCmHrSG72lMITbsZlQj7VH2fh0l3NjLM="
       },
       "src/third_party/jetstream/v2.2": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git",
@@ -522,8 +517,8 @@
       },
       "src/third_party/libphonenumber/src": {
         "url": "https://chromium.googlesource.com/external/libphonenumber.git",
-        "rev": "eee81630a337b9045c6db4577cf60bb1a2c6cbd1",
-        "hash": "sha256-voK+aAFzFGTXg6UVprNiD5Mbh6hW75EKbtzqIjPsxI0="
+        "rev": "17c9061a3af14f2e10907d73df92601b27785713",
+        "hash": "sha256-3p1NYvD5k5jOhxAJiOdijlsO3ca7YaQMQ5iCurbNp24="
       },
       "src/third_party/libprotobuf-mutator/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/libprotobuf-mutator.git",
@@ -547,8 +542,8 @@
       },
       "src/third_party/libvpx/source/libvpx": {
         "url": "https://chromium.googlesource.com/webm/libvpx.git",
-        "rev": "ade52487a37ef76a0f209bd39bea9fe67d6db4c4",
-        "hash": "sha256-Ke28x3c0Ssg2GFfHmFlfW8fex3jSuBcN0e6PXzH0b5g="
+        "rev": "8729fc25eaaace0736e6a2e1da3cd307f75446fc",
+        "hash": "sha256-sBTu4Rx1xkJIYoAc7jcrXcZbeDyfTrglyzag80lo0o4="
       },
       "src/third_party/libwebm/source": {
         "url": "https://chromium.googlesource.com/webm/libwebm.git",
@@ -562,18 +557,23 @@
       },
       "src/third_party/libyuv": {
         "url": "https://chromium.googlesource.com/libyuv/libyuv.git",
-        "rev": "26e56be0f984af3dae4d0c0ab7a0bac8ac20e1b0",
-        "hash": "sha256-Ievf2MXM7VX9+R85N3i2W+1jZSbt5mvy1SCNc0iqJYw="
+        "rev": "a0fa6329391922faca64955c1a7bf635ab87d833",
+        "hash": "sha256-8h+PCcocc4fZZWUZ4h1vCtTX4m91FCar6yJ2addm43g="
       },
       "src/third_party/lss": {
         "url": "https://chromium.googlesource.com/linux-syscall-support.git",
         "rev": "29164a80da4d41134950d76d55199ea33fbb9613",
         "hash": "sha256-89CdA7vBYudbko0nAIyHcpHMXqFZHC05kwRIUmeEWGo="
       },
+      "src/third_party/mac_alias/src": {
+        "url": "https://chromium.googlesource.com/external/github.com/dmgbuild/mac_alias.git",
+        "rev": "caa30be84fa49efd0675c3864a18ae6ffac9f6db",
+        "hash": "sha256-phO7L5/cHoQTHxCq4465UZ0v43AV6U7enVIX3qOOM/I="
+      },
       "src/third_party/material_color_utilities/src": {
         "url": "https://chromium.googlesource.com/external/github.com/material-foundation/material-color-utilities.git",
-        "rev": "6fd88eb3e95ba1d457842e2a2bf847d06b3a018a",
-        "hash": "sha256-il8qvhd9JDhu3Z03bTcYD30e7Lw9+WKzWZ71ncKPTSk="
+        "rev": "f05459ea2170f3be610f89a4ddeee8843c2deb61",
+        "hash": "sha256-EQozefgSHR9SM7So2oRgsu1tSPeeZkwjS7HxJYKgWjo="
       },
       "src/third_party/minigbm/src": {
         "url": "https://chromium.googlesource.com/chromiumos/platform/minigbm.git",
@@ -592,8 +592,8 @@
       },
       "src/third_party/neon_2_sse/src": {
         "url": "https://chromium.googlesource.com/external/github.com/intel/ARM_NEON_2_x86_SSE.git",
-        "rev": "ed59be8546632d5126ff69c87122ae5de20ffe4f",
-        "hash": "sha256-ydHSMPJS+axvW7KIR/9SLWNFq/lP67dpg9Yt7shLCng="
+        "rev": "183fc88bcb90dbfaefba33a292eae8a5ce94bd67",
+        "hash": "sha256-B81CNMxUdb4q2aHTmM7qBALIOawXS6SYBOIxtskKVuM="
       },
       "src/third_party/openh264/src": {
         "url": "https://chromium.googlesource.com/external/github.com/cisco/openh264",
@@ -602,8 +602,8 @@
       },
       "src/third_party/openscreen/src": {
         "url": "https://chromium.googlesource.com/openscreen",
-        "rev": "9732a5d77a01f05e7c4e8c79104d27f4f2358f9f",
-        "hash": "sha256-j3veVCbmV94YKBpVrtf4DGETWYXieW9lLNJZqLAs1MY="
+        "rev": "11e4e00008df90ce2914335869fbfbd572d24c77",
+        "hash": "sha256-FLyNF/F8d+kbqhrl+O6RAiRBwX8ok+4uxB7P0U/zT40="
       },
       "src/third_party/openscreen/src/buildtools": {
         "url": "https://chromium.googlesource.com/chromium/src/buildtools",
@@ -612,18 +612,18 @@
       },
       "src/third_party/openscreen/src/third_party/tinycbor/src": {
         "url": "https://chromium.googlesource.com/external/github.com/intel/tinycbor.git",
-        "rev": "d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7",
-        "hash": "sha256-fMKBFUSKmODQyg4hKIa1hwnEKIV6WBbY1Gb8DOSnaHA="
+        "rev": "9441b2ca882f95849c93de03f2c754196db13154",
+        "hash": "sha256-MzMEB46pNRmIEbc/Vn1/bLyIlvPfxP+y76r+pk570j8="
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "8f3e90282ef137adf7d380079c3178b24407104a",
-        "hash": "sha256-4OhJcWZJ3UC/Mf4DJNzLLYQtrw0y0suO/wy0d1GYP4w="
+        "rev": "ae277bf214480d77ac74852969146655bf728a11",
+        "hash": "sha256-23Bl4gnmj7AJ539nFehZuknvlD+CQFUFavQmzNUuRFk="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
-        "rev": "9c7ce42050379be8c24a270f395e00c7347965cb",
-        "hash": "sha256-wbHdFhzbOP98IOQnXyUWDQtjt/nOD4VABSyvErhLBI4="
+        "rev": "da65f7e907e0caf473ddec16e15427465f503d05",
+        "hash": "sha256-DWbdXAaIPKxvpr5D+shklo192TG/YxOQMCZ7KE8wJHI="
       },
       "src/third_party/protobuf-javascript/src": {
         "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript",
@@ -662,8 +662,8 @@
       },
       "src/third_party/search_engines_data/resources": {
         "url": "https://chromium.googlesource.com/external/search_engines_data.git",
-        "rev": "cf814b5cc732a437b4ee636f1c7907f8f1ced51a",
-        "hash": "sha256-koTwcthcJn3a4XH+rY+E3z4uvWbv+1yuX9qkcqu5t5A="
+        "rev": "b9f48dc46a8172cbdd9c3923bd5a85c04458e49f",
+        "hash": "sha256-hLY4ge+lfx6ftlr+lbH+PLF5q0bx2z99hpe9IfGr/S0="
       },
       "src/third_party/sframe/src": {
         "url": "https://chromium.googlesource.com/external/github.com/cisco/sframe",
@@ -672,8 +672,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "0873ec164a06966b90ae0d43ef783cfb180084ae",
-        "hash": "sha256-LbSs+UNakFipC2t9TSbZVreylVXHf1PsbK6z2qJh6QI="
+        "rev": "4f574af2444846ceca4d277a8095c5d4229d175f",
+        "hash": "sha256-HrpA4labNWXPWj/yiS9O8KjdQPwJOllmR5r66TwCjB0="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -687,8 +687,8 @@
       },
       "src/third_party/sqlite/src": {
         "url": "https://chromium.googlesource.com/chromium/deps/sqlite.git",
-        "rev": "0a5fe1b18a5b651b6c4c90d397e3d0b8061f73fb",
-        "hash": "sha256-y+lJK8Qi22KUcYyY62x9xCXej85on9e0FxySaMNSYPY="
+        "rev": "ba8c54c83337618a9f15dd368a267e46b672fc84",
+        "hash": "sha256-0I1kNRIMsBLH7u+l005YAfdOlPsiK+2/PFlHi6Kaj5w="
       },
       "src/third_party/swiftshader": {
         "url": "https://swiftshader.googlesource.com/SwiftShader.git",
@@ -702,23 +702,23 @@
       },
       "src/third_party/tflite/src": {
         "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git",
-        "rev": "7bedf2e94aff6ca62150d74fd40aa63cb73c6583",
-        "hash": "sha256-Uv1SbtjalHt7XLAcvOfiycgepDrEK8/JdpD3GPK1MNo="
+        "rev": "a387c0a471a69c0c9068334e73d184e1e0ce579f",
+        "hash": "sha256-REahts/Z20Yy000uyrtpvCs6cshboy8PY3mW4xz9xm0="
       },
       "src/third_party/litert/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google-ai-edge/LiteRT.git",
-        "rev": "1ae23176dd5d3a43e35961d8236d5adda7f8c0a1",
-        "hash": "sha256-xcCqZA8BKZG/TV/fAUAWPOoZwSQkRDATlhE6A05PyX0="
+        "rev": "2add6f4eda319e204c7c021ec871503a0fa766fc",
+        "hash": "sha256-zV+1VfylQfn3yUs99JYsPXFW1OSnQohR8O9Oy4dURJg="
       },
       "src/third_party/vulkan-deps": {
         "url": "https://chromium.googlesource.com/vulkan-deps",
-        "rev": "9bf18397113dbdc7adf4f76408df7f79d4ad141a",
-        "hash": "sha256-ol8SSAFHrEfsKWUmg64klpFFXIlZU4gyibENmzZD454="
+        "rev": "89c8e85edb61327644aca41e27641b43711bc783",
+        "hash": "sha256-r6ttlYFgrJcsHXb9Rdro4/KIQyPfv8ViueSaPRux7YM="
       },
       "src/third_party/glslang/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang",
-        "rev": "8292684e941bf22583b257bd9dfe47daccacb665",
-        "hash": "sha256-1D971MPCHr8vnj31IFUwe1s+X3UAabxYUQ1Cd/VyqDA="
+        "rev": "5d69854866df654a898a32d93cff20a181ac82ed",
+        "hash": "sha256-DWvwxPD2T9Ojwg3sRKWuTlt36kqBk0wn5ii7PoXvd5E="
       },
       "src/third_party/spirv-cross/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross",
@@ -727,38 +727,38 @@
       },
       "src/third_party/spirv-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers",
-        "rev": "29981f65241605e08b0ede4cfeb999fe3b723c6a",
-        "hash": "sha256-tGY4H3+5p9M5LBK/xxRdMT9CX+qq3e7fPkaftnpjU9I="
+        "rev": "0d25db97cb9b8f725e4c95e4553001710e7fc39d",
+        "hash": "sha256-HvdKHnraSSWBriVgiNfhnC60moYRseDb3aRxxoANX1I="
       },
       "src/third_party/spirv-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools",
-        "rev": "a665e21f3061f34064b39937cf00fe8d8769f4ef",
-        "hash": "sha256-4m/xdMk/r4C5zdU/CZzdoXtRN0MWs8pN5QUPI5Ej3+w="
+        "rev": "e39e5c5838bc4b4162c349f2a2e5f163efe5432f",
+        "hash": "sha256-lNBakr+4dRpdjbw204vjarZyz9PLCsFSW/4iFboknCI="
       },
       "src/third_party/vulkan-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers",
-        "rev": "d314eae73fdc90847bb8304a86ee7c6a8ee023b6",
-        "hash": "sha256-YU51vfV/8vQqVTngS2SRHKXpgxU/5IJ+jAT5pcYUcpw="
+        "rev": "0b7f383797fa7be53ae28213e001ae60668ee511",
+        "hash": "sha256-hRAu7Gj7t38huQSKceL6eq5LSjto8pByxmZgkiQIX3o="
       },
       "src/third_party/vulkan-loader/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader",
-        "rev": "59a70594de4559fd3aed73fe8ac2d6c48ca002d4",
-        "hash": "sha256-M/gm3fkCcFZJyslWCO/v2DzuavTOfvvKvx+0bNihEqs="
+        "rev": "83ddfc5ec5ca64ddd1055cefa1559c568101075a",
+        "hash": "sha256-LqklBLCWg04Qet0CtffTQwqBvkeu2Py8DM8eNuideNo="
       },
       "src/third_party/vulkan-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools",
-        "rev": "286299bb6b732e4b22771cfb9d7d421542d40501",
-        "hash": "sha256-kbySCu2c5nh6icnPQV6qplfg1gHFnGPEYOG6G6TG8EU="
+        "rev": "99140cef98b4ea135141e0040d84c17a1543e5e3",
+        "hash": "sha256-lETdemR3/hkPULaDpnrH8mEnL+CBKiXb9YQE1cdG260="
       },
       "src/third_party/vulkan-utility-libraries/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries",
-        "rev": "e9585c3e3d41ab608ee3b098ce4721d357308fc8",
-        "hash": "sha256-WcSiUe3vB7zUO0vpqcVJkKqhnZXz76ApWaoMO49efXg="
+        "rev": "245b48c522b5375c0acd5377d52bef5e4917f31e",
+        "hash": "sha256-1h5iWfG+6dOhS6JX4mCyAHbbBe6Nnge775614Atwi1c="
       },
       "src/third_party/vulkan-validation-layers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers",
-        "rev": "11079f041fa85ec27c40c4ef2d63531138a2ab98",
-        "hash": "sha256-1lG6shUQRKXtojLHwfZD6gDz5yVnNoVp6BHMyUz70Co="
+        "rev": "6d4c4f8b14241307a822f21bb9453b2380b66117",
+        "hash": "sha256-fk0IXwY5LJk0WNQHERtq3Yt7KpwBLppkHFgoH47RHpo="
       },
       "src/third_party/vulkan_memory_allocator": {
         "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git",
@@ -767,8 +767,8 @@
       },
       "src/third_party/wayland/src": {
         "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland.git",
-        "rev": "736d12ac67c20c60dc406dc49bb06be878501f86",
-        "hash": "sha256-5iG0HaPXJCEo027TuyXlJQNGluTaAPlvwQDFbiYOEJQ="
+        "rev": "87cc8a8728a923fc57938faa81ba0e74f34ecdc7",
+        "hash": "sha256-dnaXYcVfc4DfNRsAEL316eSTen9tpf+nuQbActege4E="
       },
       "src/third_party/wayland-protocols/src": {
         "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland-protocols.git",
@@ -797,8 +797,8 @@
       },
       "src/third_party/webgpu-cts/src": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts.git",
-        "rev": "499044af47ec2717e06e644d0943e6fcdb3f3538",
-        "hash": "sha256-M8TWqKdqoiZ01vbDpcRyPWIOaBPCPdSSflxcIpbYjFA="
+        "rev": "2959e1c3959aa55cd3f02726995ae68159d0e064",
+        "hash": "sha256-Z8hszmUjsRupyLk6LTit1R2rZyYfOakTJ75niMwl/Xs="
       },
       "src/third_party/webpagereplay": {
         "url": "https://chromium.googlesource.com/webpagereplay.git",
@@ -807,13 +807,13 @@
       },
       "src/third_party/webpagereplay/third_party/clang-format/script": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git",
-        "rev": "6eddfb5ec5f92127a531eda66c568d3a11e7ec11",
-        "hash": "sha256-Cm6BOOlEyD0kdYxMSmk6Fj1Dnfs3zCzXsm+BOXgBme0="
+        "rev": "70510081984cfcdb14a15b3e08dfe9776dc7ed37",
+        "hash": "sha256-IC5Dy3elgEezXmRyDbafx5i+V9wiDLMmnpi7O7BucdE="
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "6f37672d358475cd17544121a12494da454d85fb",
-        "hash": "sha256-c0h6bD8zNZbacnOgRei+yVB+5+AvfglW+eQDNZU945M="
+        "rev": "9ea5afcad008b940468c2a15aec339592cf5a935",
+        "hash": "sha256-y0W8g4STp/9vJJQ6ZBt4Pssl9kFLEF1WChxDD+sm68E="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -827,8 +827,8 @@
       },
       "src/third_party/xnnpack/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git",
-        "rev": "09c4a9137f3a19b053dc45724a62f4f73ec7746a",
-        "hash": "sha256-eoS9qQ1hOJJBw6RQ2mTyRQb/AaAj8XnFbtqPpAb99y4="
+        "rev": "eccfcfe85b347d8f48015ecdf9fa7db1a9ef61cb",
+        "hash": "sha256-BqbqC2PUcvTdz3IxxkySHxzpfNp1uI7dFLMx50JbXMc="
       },
       "src/third_party/libei/src": {
         "url": "https://chromium.googlesource.com/external/gitlab.freedesktop.org/libinput/libei.git",
@@ -837,18 +837,18 @@
       },
       "src/third_party/zstd/src": {
         "url": "https://chromium.googlesource.com/external/github.com/facebook/zstd.git",
-        "rev": "5233c58e6ca0b1c4c6b353ad79649191ed195bdc",
-        "hash": "sha256-vEl0s7Mjh+5rciOMxm99PNWiamtCk+sTN4lRYKCIZ+8="
+        "rev": "5c7b7bad26808e6b40ac3b3d0075466e27738a9d",
+        "hash": "sha256-dncfOdwIDcMGT5VvzpzMBAbLkE4e6vAPeZBlEmoWcCc="
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "4323497a6a73839e6d5260f6acd7ec0212cb3321",
-        "hash": "sha256-HUg4GGtYL4xGk/xw0QXxNZAnsFVcznklWGQaqhZj9QM="
+        "rev": "f343157cebb388bfa416baccb5d35507e6fe8cc7",
+        "hash": "sha256-zSCyFQpDMNygmV6N4TajL8VB5+VRynrMPV/wAiWsJO4="
       },
       "src/agents/shared": {
         "url": "https://chromium.googlesource.com/chromium/agents.git",
-        "rev": "559f135fc214d637f85174c6be7010804e31f1e5",
-        "hash": "sha256-/PhF9Pc8wPx+TLABd3yD218TfEatBySazVci1Wc+9e4="
+        "rev": "e64987d3ea47f5f5d00c66de617aec591d1c0bcf",
+        "hash": "sha256-LEVJVFhLptUEXDqGt6n9GybLOTfl3uAc2+ifvoD5kiU="
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/patches/chromium-153-llvm-22.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/chromium-153-llvm-22.patch
@@ -1,0 +1,30 @@
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index 8153e68ce90a14613f268f5c950c7e020e29aa2f..5d27ffb088590944302577a3f154ecf4d15606bf 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -590,7 +590,7 @@ config("compiler") {
+     cflags += [ "-fcolor-diagnostics" ]
+     if (!is_wasm) {
+       if (!is_win) {
+-        cflags += [ "-fdiagnostics-show-inlining-chain" ]
++        cflags += [ ]
+       } else {
+         # Combine after https://github.com/llvm/llvm-project/pull/192241
+         cflags += [ "/clang:-fdiagnostics-show-inlining-chain" ]
+@@ -1590,7 +1590,7 @@ config("clang_warning_suppression") {
+ # See also: https://crbug.com/40891132#comment10
+ ubsan_hardening("c_array_bounds") {
+   sanitizer = "array-bounds"
+-  condition = !(is_asan && target_cpu == "x86")
++  condition = false
+ 
+   # Because we've enabled array-bounds sanitizing we also want to suppress
+   # the related warning about "unsafe-buffer-usage-in-static-sized-array",
+@@ -1604,6 +1604,7 @@ ubsan_hardening("c_array_bounds") {
+ # `NOTREACHED()` at the end of such functions.
+ ubsan_hardening("return") {
+   sanitizer = "return"
++  condition = false
+ }
+ 
+ config("rustc_revision") {


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/09/stable-channel-update-for-desktop_0808145027.html

This update includes 230 security fixes. Google is aware that an exploit for CVE-2026-87491 exists in the wild.

CVEs:
CVE-2026-87464 CVE-2026-87488 CVE-2026-87438 CVE-2026-87527 CVE-2026-87628 CVE-2026-87512 CVE-2026-87585 CVE-2026-87444 CVE-2026-87447 CVE-2026-87440 CVE-2026-87633 CVE-2026-87525 CVE-2026-87578 CVE-2026-87517 CVE-2026-87524 CVE-2026-87569 CVE-2026-87554 CVE-2026-87467 CVE-2026-87492 CVE-2026-87520 CVE-2026-87514 CVE-2026-87650 CVE-2026-87596 CVE-2026-87654 CVE-2026-87604 CVE-2026-87621 CVE-2026-87647 CVE-2026-87646 CVE-2026-87500 CVE-2026-87572 CVE-2026-87460 CVE-2026-87542 CVE-2026-87639 CVE-2026-87552 CVE-2026-87651 CVE-2026-87587 CVE-2026-87564 CVE-2026-87498 CVE-2026-87499 CVE-2026-87607 CVE-2026-87558 CVE-2026-87581 CVE-2026-87480 CVE-2026-87612 CVE-2026-87536 CVE-2026-87474 CVE-2026-87504 CVE-2026-87640 CVE-2026-87491 CVE-2026-87478 CVE-2026-87446 CVE-2026-87657 CVE-2026-87434 CVE-2026-87487 CVE-2026-87453 CVE-2026-87588 CVE-2026-87636 CVE-2026-87611 CVE-2026-87606 CVE-2026-87456 CVE-2026-87553 CVE-2026-87658 CVE-2026-87465 CVE-2026-87515 CVE-2026-87547 CVE-2026-87442 CVE-2026-87506 CVE-2026-87433 CVE-2026-87557 CVE-2026-87457 CVE-2026-87503 CVE-2026-87481 CVE-2026-87537 CVE-2026-87471 CVE-2026-87485 CVE-2026-87652 CVE-2026-87582 CVE-2026-87466 CVE-2026-87603 CVE-2026-87615 CVE-2026-87642 CVE-2026-87577 CVE-2026-87449 CVE-2026-87613 CVE-2026-87645 CVE-2026-87443 CVE-2026-87630 CVE-2026-87590 CVE-2026-87580 CVE-2026-87482 CVE-2026-87497 CVE-2026-87579 CVE-2026-87576 CVE-2026-87476 CVE-2026-87475 CVE-2026-87436 CVE-2026-87479 CVE-2026-87513 CVE-2026-87432 CVE-2026-87560 CVE-2026-87521 CVE-2026-87539 CVE-2026-87648 CVE-2026-87534 CVE-2026-87562 CVE-2026-87556 CVE-2026-87508 CVE-2026-87643 CVE-2026-87573 CVE-2026-87548 CVE-2026-87501 CVE-2026-87452 CVE-2026-87516 CVE-2026-87599 CVE-2026-87507 CVE-2026-87559 CVE-2026-87472 CVE-2026-87486 CVE-2026-87655 CVE-2026-87462 CVE-2026-87649 CVE-2026-87445 CVE-2026-87567 CVE-2026-87496 CVE-2026-87441 CVE-2026-87549 CVE-2026-87458 CVE-2026-87574 CVE-2026-87495 CVE-2026-87541 CVE-2026-87451 CVE-2026-87570 CVE-2026-87555 CVE-2026-87600 CVE-2026-87532 CVE-2026-87439 CVE-2026-87450 CVE-2026-87505 CVE-2026-87622 CVE-2026-87540 CVE-2026-87594 CVE-2026-87518 CVE-2026-87589 CVE-2026-87484 CVE-2026-87530 CVE-2026-87550 CVE-2026-87494 CVE-2026-87483 CVE-2026-87454 CVE-2026-87616 CVE-2026-87535 CVE-2026-87644 CVE-2026-87533 CVE-2026-87635 CVE-2026-87641 CVE-2026-87431 CVE-2026-87493 CVE-2026-87625 CVE-2026-87468 CVE-2026-87563 CVE-2026-87510 CVE-2026-87435 CVE-2026-87531 CVE-2026-87637 CVE-2026-87529 CVE-2026-87470 CVE-2026-87586 CVE-2026-87584 CVE-2026-87632 CVE-2026-87528 CVE-2026-87623 CVE-2026-87566 CVE-2026-87638 CVE-2026-87455 CVE-2026-87591 CVE-2026-87526 CVE-2026-87609 CVE-2026-87610 CVE-2026-87626 CVE-2026-87629 CVE-2026-87653 CVE-2026-87634 CVE-2026-87429 CVE-2026-87618 CVE-2026-87614 CVE-2026-87619 CVE-2026-87561 CVE-2026-87598 CVE-2026-87519 CVE-2026-87543 CVE-2026-87522 CVE-2026-87568 CVE-2026-87656 CVE-2026-87511 CVE-2026-87627 CVE-2026-87595 CVE-2026-87592 CVE-2026-87620 CVE-2026-87502 CVE-2026-87448 CVE-2026-87459 CVE-2026-87463 CVE-2026-87546 CVE-2026-87538 CVE-2026-87545 CVE-2026-87617 CVE-2026-87523 CVE-2026-87565 CVE-2026-87597 CVE-2026-87624 CVE-2026-87605 CVE-2026-87490 CVE-2026-87583 CVE-2026-87509 CVE-2026-87473 CVE-2026-87461 CVE-2026-87631 CVE-2026-87469 CVE-2026-87489 CVE-2026-87575 CVE-2026-87571 CVE-2026-87477 CVE-2026-87551 CVE-2026-87608 CVE-2026-87437 CVE-2026-87602 CVE-2026-87601 CVE-2026-87544 CVE-2026-87430 CVE-2026-87593

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nixosTests.chromium`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
