### PR TITLE
expressvpn: 3.52.0.2 -> 14.2.1.13658

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -27,6 +27,10 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `expressvpn` has been updated from 3.52.0 to 14.2.1. The new client includes
+  a graphical interface and requires the `services.expressvpn` NixOS module to
+  provide its runtime filesystem layout.
+
 - `moon` has been updated to `2.x` and needs manual migration. See the [migration guide](https://moonrepo.dev/docs/migrate/2.0) for instructions.
 
 - `perlPackages.NetOAuth` has been updated from 0.28 to 0.33.

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -130,6 +130,10 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `services.expressvpn` now supports the ExpressVPN 14 graphical and command-line
+  clients. Users who should be allowed to control the VPN must be listed in
+  `services.expressvpn.users`.
+
 - Artalk has been updated to 2.10.0. Its default configuration and data
   directory discovery changed; see the [upstream migration
   guide](https://artalk.js.org/en/guide/releases/v2.10.0.html) when invoking

--- a/nixos/modules/services/networking/expressvpn.nix
+++ b/nixos/modules/services/networking/expressvpn.nix
@@ -4,25 +4,95 @@
   pkgs,
   ...
 }:
+let
+  cfg = config.services.expressvpn;
+
+  # ExpressVPN invokes helpers with a conventional, sanitized PATH.
+  fhsTools = pkgs.buildEnv {
+    name = "expressvpn-fhs-tools";
+    paths = with pkgs; [
+      cfg.package
+      coreutils
+      e2fsprogs
+      findutils
+      gawk
+      gnugrep
+      iproute2
+      iptables
+      procps
+      psmisc
+      systemd
+      util-linux
+      zip
+    ];
+    pathsToLink = [ "/bin" ];
+  };
+in
 {
-  options.services.expressvpn.enable = lib.mkOption {
-    type = lib.types.bool;
-    default = false;
-    description = ''
-      Enable the ExpressVPN daemon.
-    '';
+  options.services.expressvpn = {
+    enable = lib.mkEnableOption "ExpressVPN daemon and client";
+
+    package = lib.mkPackageOption pkgs "expressvpn" { };
+
+    users = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "alice" ];
+      description = ''
+        Users allowed to control the ExpressVPN daemon.
+      '';
+    };
   };
 
-  config = lib.mkIf config.services.expressvpn.enable {
+  config = lib.mkIf cfg.enable {
     boot.kernelModules = [ "tun" ];
+
+    environment.systemPackages = [ cfg.package ];
+
+    users.groups.expressvpn.members = cfg.users;
+    users.groups.expressvpnhnsd = { };
+
+    # The daemon authorizes clients by checking that /proc/<pid>/exe is below
+    # /opt/expressvpn/bin, so this must be a bind mount rather than a symlink.
+    systemd.tmpfiles.rules = [
+      "d  /opt/expressvpn         0755 root root - -"
+      "d  /opt/expressvpn/bin     0755 root root - -"
+      "L+ /opt/expressvpn/lib     - - - - ${cfg.package}/lib"
+      "L+ /opt/expressvpn/plugins - - - - ${cfg.package}/plugins"
+      "L+ /opt/expressvpn/qml     - - - - ${cfg.package}/qml"
+      "L+ /opt/expressvpn/share   - - - - ${cfg.package}/share"
+      "d  /opt/expressvpn/etc     0750 root expressvpn - -"
+      "d  /opt/expressvpn/var     0750 root expressvpn - -"
+      "d  /var/lib/expressvpn     0750 root expressvpn - -"
+    ];
+
+    systemd.mounts = [
+      {
+        description = "ExpressVPN binaries";
+        what = "${cfg.package}/libexec/expressvpn";
+        where = "/opt/expressvpn/bin";
+        type = "none";
+        options = "bind,ro";
+        wantedBy = [ "local-fs.target" ];
+      }
+    ];
 
     systemd.services.expressvpn = {
       description = "ExpressVPN Daemon";
+      path = [ fhsTools ];
+      unitConfig.RequiresMountsFor = "/opt/expressvpn/bin";
       serviceConfig = {
-        ExecStart = "${pkgs.expressvpn}/bin/expressvpnd";
-        Restart = "on-failure";
+        ExecStart = "/opt/expressvpn/bin/expressvpn-daemon";
+        Restart = "always";
         RestartSec = 5;
+        BindReadOnlyPaths = [
+          "${pkgs.bash}/bin/bash:/bin/bash"
+          "${cfg.package}/bin/expressvpn-support-tool:/bin/expressvpn-support-tool"
+          "${fhsTools}/bin:/usr/bin"
+          "${pkgs.iproute2}/bin/ip:/sbin/ip"
+        ];
       };
+      environment.LD_LIBRARY_PATH = "${cfg.package}/lib";
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
       after = [

--- a/pkgs/by-name/ex/expressvpn/package.nix
+++ b/pkgs/by-name/ex/expressvpn/package.nix
@@ -1,115 +1,135 @@
 {
   autoPatchelfHook,
-  buildFHSEnv,
-  dpkg,
+  brotli,
+  dbus,
   fetchurl,
-  inotify-tools,
+  fontconfig,
+  freetype,
+  glib,
   lib,
-  stdenvNoCC,
-  sysctl,
-  writeScript,
+  libcap_ng,
+  libdrm,
+  libglvnd,
+  libice,
+  libnl,
+  libsm,
+  libxkbcommon,
+  stdenv,
+  wayland,
+  zlib,
 }:
 
 let
+  version = "14.2.1.13658";
+in
+stdenv.mkDerivation {
   pname = "expressvpn";
-  clientVersion = "3.52.0";
-  clientBuild = "2";
-  version = lib.strings.concatStringsSep "." [
-    clientVersion
-    clientBuild
+  inherit version;
+
+  src = fetchurl {
+    url = "https://www.expressvpn.works/clients/linux/expressvpn-linux-universal-${version}_release.run";
+    hash = "sha256-o9y+sIwcZO7bkhsYwNkdZM3oS5eEQ336dMdmLzDsTDk=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    glib
+    libxkbcommon
+    fontconfig
+    freetype
+    libcap_ng
+    dbus
+    zlib
+    brotli
+    libglvnd
+    libdrm
+    wayland
+    libsm
+    libice
   ];
 
-  expressvpnBase = stdenvNoCC.mkDerivation {
-    inherit pname version;
+  # The daemon loads libnl dynamically for network-change monitoring.
+  runtimeDependencies = [ (lib.getLib libnl) ];
 
-    src = fetchurl {
-      url = "https://www.expressvpn.works/clients/linux/expressvpn_${version}-1_amd64.deb";
-      hash = "sha256-cDZ9R+MA3FXEto518bH4/c1X4W9XxgTvXns7zisylew=";
-    };
+  # The archive ships optional QML plugins whose backing Qt libraries are not
+  # bundled. The client does not import these modules.
+  autoPatchelfIgnoreMissingDeps = [
+    "libQt6StateMachineQml.so.6"
+    "libQt6StateMachine.so.6"
+    "libQt6QmlXmlListModel.so.6"
+    "libQt6LabsAnimation.so.6"
+    "libQt6LabsFolderListModel.so.6"
+    "libQt6LabsWavefrontMesh.so.6"
+    "libQt6LabsSharedImage.so.6"
+    "libQt6LabsSettings.so.6"
+    "libQt6LabsQmlModels.so.6"
+    "libQt6Bodymovin.so.6"
+    "libQt6QuickTest.so.6"
+    "libQt6Test.so.6"
+    "libQt6QuickTimeline.so.6"
+    "libQt6QuickParticles.so.6"
+    "libQt6VirtualKeyboard.so.6"
+    "libQt6QmlLocalStorage.so.6"
+    "libQt6Sql.so.6"
+    "libQt6WlShellIntegration.so.6"
+    "libQt6EglFsKmsSupport.so.6"
+    "libQt6EglFSDeviceIntegration.so.6"
+  ];
 
-    nativeBuildInputs = [
-      dpkg
-      autoPatchelfHook
-    ];
-
-    dontConfigure = true;
-    dontBuild = true;
-
-    unpackPhase = ''
-      runHook preUnpack
-      dpkg --fsys-tarfile $src | tar --extract
-      runHook postUnpack
-    '';
-
-    installPhase = ''
-      runHook preInstall
-      mv usr/ $out/
-      runHook postInstall
-    '';
-  };
-
-  expressvpndFHS = buildFHSEnv {
-    inherit version;
-    pname = "expressvpnd";
-
-    # When connected, it directly creates/deletes resolv.conf to change the DNS entries.
-    # Since it's running in an FHS environment, it has no effect on actual resolv.conf.
-    # Hence, place a watcher that updates host resolv.conf when FHS resolv.conf changes.
-
-    # Mount the host's resolv.conf to the container's /etc/resolv.conf
-    runScript = writeScript "${pname}-wrapper" ''
-      mkdir -p /host/etc
-      [ -e /host/etc/resolv.conf ] || touch /host/etc/resolv.conf
-      mount --bind /etc/resolv.conf /host/etc/resolv.conf
-      mount -o remount,rw /host/etc/resolv.conf
-      trap "umount /host/etc/resolv.conf" EXIT
-
-      while inotifywait /etc 2>/dev/null;
-      do
-        cp /etc/resolv.conf /host/etc/resolv.conf;
-      done &
-      expressvpnd --client-version ${clientVersion} --client-build ${clientBuild}
-    '';
-
-    # expressvpnd binary has hard-coded the path /sbin/sysctl hence below workaround.
-    extraBuildCommands = ''
-      mkdir -p sbin
-      chmod +w sbin
-      ln -s ${sysctl}/bin/sysctl sbin/sysctl
-    '';
-
-    # The expressvpnd binary also uses hard-coded paths to the other binaries and files
-    # it ships with, hence the FHS environment.
-
-    targetPkgs =
-      pkgs: with pkgs; [
-        expressvpnBase
-        inotify-tools
-        iproute2
-      ];
-  };
-in
-stdenvNoCC.mkDerivation {
-  inherit pname version;
-
-  dontUnpack = true;
-  dontConfigure = true;
-  dontBuild = true;
+  unpackPhase = ''
+    runHook preUnpack
+    bash "$src" --noexec --accept --target ./extract
+    cd "./extract/${if stdenv.hostPlatform.isAarch64 then "arm64" else "x64"}"
+    runHook postUnpack
+  '';
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin $out/share
-    ln -s ${expressvpnBase}/bin/expressvpn $out/bin
-    ln -s ${expressvpndFHS}/bin/expressvpnd $out/bin
-    ln -s ${expressvpnBase}/share/{bash-completion,doc,man} $out/share/
+    mkdir -p "$out"/{bin,libexec/expressvpn,lib,plugins,qml,share}
+    cp -r expressvpnfiles/bin/* "$out/libexec/expressvpn/"
+    cp -r expressvpnfiles/lib/* "$out/lib/"
+    cp -r expressvpnfiles/plugins/* "$out/plugins/"
+    cp -r expressvpnfiles/qml/* "$out/qml/"
+    cp -r expressvpnfiles/share/* "$out/share/"
+
+    install -Dm644 installfiles/app-icon.png "$out/share/pixmaps/expressvpn.png"
+    install -Dm644 installfiles/expressvpn.desktop "$out/share/applications/expressvpn.desktop"
+
+    substituteInPlace "$out/libexec/expressvpn/qt.conf" \
+      --replace-fail /opt/expressvpn "$out"
+    substituteInPlace "$out/libexec/expressvpn/openvpn-updown.sh" \
+      --replace-fail /opt/expressvpn/var /var/lib/expressvpn
+
+    ln -s expressvpn-daemon "$out/libexec/expressvpn/expressvpnd"
+    ln -s expressvpnctl "$out/libexec/expressvpn/expressvpn"
     runHook postInstall
   '';
 
+  postFixup = ''
+    for name in expressvpn-daemon expressvpn-client expressvpnctl \
+                expressvpn-support-tool support-tool-launcher browser_helper; do
+      cat > "$out/bin/$name" <<EOF
+    #!${stdenv.shell}
+    exec /opt/expressvpn/bin/$name "\$@"
+    EOF
+      chmod +x "$out/bin/$name"
+    done
+    ln -s expressvpn-daemon "$out/bin/expressvpnd"
+    ln -s expressvpnctl "$out/bin/expressvpn"
+  '';
+
   meta = {
-    description = "CLI client for ExpressVPN";
+    description = "CLI and GUI clients for ExpressVPN";
     homepage = "https://www.expressvpn.com";
     license = lib.licenses.unfree;
-    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     maintainers = with lib.maintainers; [ yureien ];
+    mainProgram = "expressvpn";
   };
 }


### PR DESCRIPTION
Replace the retired CLI-only Debian package with the universal GUI and CLI bundle.

The vendor validates clients through /proc/<pid>/exe and invokes helpers through hard-coded FHS paths. Provide the required bind-mounted installation layout and a private helper environment in the NixOS module.

Assisted-by: Cursor (GPT-5.6 Sol)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
