### PR TITLE
gh-teacher, gh-student: init at 1.47.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12908,6 +12908,17 @@
       }
     ];
   };
+  jaspermayone = {
+    email = "nix@jaspermayone.com";
+    github = "jaspermayone";
+    githubId = 65788728;
+    name = "Jasper Mayone";
+    keys = [
+      {
+        fingerprint = "00E6 43C2 1FAC 965F FB28  D3B7 14D0 D45A 1DAD AAFA";
+      }
+    ];
+  };
   jaspersurmont = {
     email = "jasper@surmont.dev";
     github = "jaspersurmont";

--- a/pkgs/by-name/gh/gh-student/package.nix
+++ b/pkgs/by-name/gh/gh-student/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  git,
+  gh,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "gh-student";
+  version = "1.47.0";
+
+  __structuredAttrs = true;
+
+  # The foundation50/gh-student repo only carries the release artifacts; the
+  # source lives in the classroom50 monorepo under cli/gh-student.
+  src = fetchFromGitHub {
+    owner = "foundation50";
+    repo = "classroom50";
+    tag = "cli-v${finalAttrs.version}";
+    hash = "sha256-tHv8jgzp6oFbUMpiFQR6iKnuN0/Vq+CGdTLrvGx5xkU=";
+  };
+
+  modRoot = "cli/gh-student";
+  vendorHash = "sha256-VzmXSUqRTsq/cMFumTVg0NmzYyMX8KWM5U4flmW98wI=";
+
+  # The repo root carries a go.work covering both extensions and their shared
+  # module. It is dev-only, and workspace mode makes `go mod vendor` fail. Each
+  # module also carries a relative `replace` for the shared module, so building
+  # one module on its own works with the workspace off.
+  env.GOWORK = "off";
+
+  # The accept tests shell out to git.
+  nativeCheckInputs = [ git ];
+
+  # Upstream also bakes in the commit and the build date, which would make the
+  # build unreproducible.
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=cli-v(.*)" ];
+  };
+
+  meta = {
+    description = "GitHub CLI extension for students using classroom50, a free alternative to GitHub Classroom";
+    homepage = "https://github.com/foundation50/gh-student";
+    changelog = "https://github.com/foundation50/classroom50/blob/cli-v${finalAttrs.version}/cli/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ jaspermayone ];
+    mainProgram = "gh-student";
+    inherit (gh.meta) platforms;
+  };
+})

--- a/pkgs/by-name/gh/gh-teacher/package.nix
+++ b/pkgs/by-name/gh/gh-teacher/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gh,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "gh-teacher";
+  version = "1.47.0";
+
+  __structuredAttrs = true;
+
+  # The foundation50/gh-teacher repo only carries the release artifacts; the
+  # source lives in the classroom50 monorepo under cli/gh-teacher.
+  src = fetchFromGitHub {
+    owner = "foundation50";
+    repo = "classroom50";
+    tag = "cli-v${finalAttrs.version}";
+    hash = "sha256-tHv8jgzp6oFbUMpiFQR6iKnuN0/Vq+CGdTLrvGx5xkU=";
+  };
+
+  modRoot = "cli/gh-teacher";
+  vendorHash = "sha256-Nu7qfJ12FMN3Y7lfD0zbvU0EwSswV8PykWStP4WxUYc=";
+
+  # The repo root carries a go.work covering both extensions and their shared
+  # module. It is dev-only, and workspace mode makes `go mod vendor` fail. Each
+  # module also carries a relative `replace` for the shared module, so building
+  # one module on its own works with the workspace off.
+  env.GOWORK = "off";
+
+  # Upstream also bakes in the commit and the build date, which would make the
+  # build unreproducible.
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=cli-v(.*)" ];
+  };
+
+  meta = {
+    description = "GitHub CLI extension for teachers using classroom50, a free alternative to GitHub Classroom";
+    homepage = "https://github.com/foundation50/gh-teacher";
+    changelog = "https://github.com/foundation50/classroom50/blob/cli-v${finalAttrs.version}/cli/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ jaspermayone ];
+    mainProgram = "gh-teacher";
+    inherit (gh.meta) platforms;
+  };
+})


### PR DESCRIPTION
Adds the `gh teacher` and `gh student` CLI extensions from [classroom50](https://github.com/foundation50/classroom50), a free and open-source alternative to GitHub Classroom. `gh teacher` is the instructor side, `gh student` the student side.

Not the same thing as the existing `gh-classroom`, which is GitHub's own extension for driving GitHub Classroom. Different project.

The source layout is unusual, so a few notes on the packaging:

The `foundation50/gh-teacher` and `foundation50/gh-student` repos only hold a README, a LICENSE and a release workflow. The code itself lives in the `foundation50/classroom50` monorepo, under `cli/gh-teacher`, `cli/gh-student` and a shared `cli/shared` module, released in `cli-v*` tags. Both packages build from the monorepo with `modRoot` instead of fetching the published binaries.

The monorepo root has a `go.work` that covers both extensions and the shared module. It is only there for local dev, and workspace mode makes `go mod vendor` fail. Each module also has a relative `replace` for the shared module, so `env.GOWORK = "off"` is enough to build either one on its own.

`updateScript` passes `--version-regex=cli-v(.*)`, which skips the `web-v*` tags cut for the web app. `ldflags` match the upstream release workflow, minus the commit and build date, which would not be reproducible. `gh-student`'s accept tests shell out to `git`, so it gets `nativeCheckInputs`; `gh-teacher`'s tests do not.

Also adds me to the maintainer list.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

The upstream Go test suites run during both builds and pass, and both binaries report `v1.47.0`. `nixpkgs-review` results are in the comments: `aarch64-darwin` on this machine, `aarch64-linux` in a `nixos/nix` container. I have no x86_64 hardware here, so those two boxes stay unticked, but ofborg built `x86_64-linux` green.

## Disclosure

Per the automation/AI policy: this was written with Claude Code (`claude-opus-5`), and the commits carry `Assisted-by:` trailers. I read through both package definitions and the maintainer entry, and checked the builds and the binaries myself.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
