### PR TITLE
freebsd: correctly don't assume packages will build for platforms other than freebsd

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/pkgs/bintrans.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/bintrans.nix
@@ -1,5 +1,10 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 mkDerivation {
   path = "usr.bin/bintrans";
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/config.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/config.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   freebsdSetupHook,
@@ -32,4 +33,6 @@ mkDerivation {
     libnv
     libsbuf
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/ctfconvert.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/ctfconvert.nix
@@ -34,4 +34,5 @@ mkDerivation {
   ];
 
   meta.license = lib.licenses.cddl;
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/ctfmerge.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/ctfmerge.nix
@@ -32,4 +32,5 @@ mkDerivation {
   ];
 
   meta.license = lib.licenses.cddl;
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/elfcopy.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/elfcopy.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   compatIfNeeded,
   libelf,
@@ -24,4 +25,6 @@ mkDerivation {
 
   # since we built libpe and co separate they are not internal and thus not pie...?
   MK_PIE = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/file2c.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/file2c.nix
@@ -1,6 +1,11 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 
 mkDerivation {
   path = "usr.bin/file2c";
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/gencat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/gencat.nix
@@ -1,5 +1,6 @@
 {
-  lib, mkDerivation,
+  lib,
+  mkDerivation,
 }:
 
 mkDerivation {

--- a/pkgs/os-specific/bsd/freebsd/pkgs/gencat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/gencat.nix
@@ -1,3 +1,9 @@
-{ mkDerivation }:
+{
+  lib, mkDerivation,
+}:
 
-mkDerivation { path = "usr.bin/gencat"; }
+mkDerivation {
+  path = "usr.bin/gencat";
+
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/install.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/install.nix
@@ -70,4 +70,6 @@ mkDerivation {
     "man"
     "test"
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kldxref.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kldxref.nix
@@ -26,4 +26,6 @@ mkDerivation {
   postPatch = ''
     sed -i 's/FTS_PHYSICAL/FTS_LOGICAL/' $BSDSRCDIR/usr.sbin/kldxref/kldxref.c
   '';
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libdwarf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libdwarf.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   m4,
   compatIfNeeded,
@@ -21,4 +22,6 @@ mkDerivation {
     libelf
   ];
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libelf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libelf.nix
@@ -41,4 +41,6 @@ mkDerivation {
   preBuild = lib.optionalString stdenv.hostPlatform.isFreeBSD ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -B${csu}/lib"
   '';
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libelftc.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libelftc.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   libelf,
   compatIfNeeded,
@@ -19,4 +20,6 @@ mkDerivation {
   '';
 
   alwaysKeepStatic = true;
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libmd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libmd.nix
@@ -70,6 +70,8 @@ mkDerivation (
             cp "$f" "$man/share/man/$f"
           done
         '';
+
+    meta.platforms = lib.platforms.unix;
   }
   // lib.optionalAttrs bootstrapInstallation {
     nativeBuildInputs = [

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libnetbsd/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libnetbsd/package.nix
@@ -28,4 +28,6 @@ mkDerivation {
   ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "INSTALL=boot-install";
 
   alwaysKeepStatic = true;
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libnv.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libnv.nix
@@ -1,4 +1,7 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 
 mkDerivation {
   path = "lib/libnv";
@@ -7,4 +10,6 @@ mkDerivation {
     "sys/sys"
   ];
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libpe.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libpe.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
 }:
 mkDerivation {
@@ -13,4 +14,6 @@ mkDerivation {
   '';
 
   alwaysKeepStatic = true;
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libsbuf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libsbuf.nix
@@ -1,7 +1,12 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 
 mkDerivation {
   path = "lib/libsbuf";
   extraPaths = [ "sys/kern" ];
   env.MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libspl.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libspl.nix
@@ -19,5 +19,6 @@ mkDerivation {
 
   meta = {
     license = lib.licenses.cddl;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/lorder.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/lorder.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   freebsdSetupHook,
@@ -22,4 +23,6 @@ mkDerivation {
     "out"
     "man"
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/makeMinimal.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/makeMinimal.nix
@@ -65,4 +65,6 @@ mkDerivation {
   '';
 
   extraPaths = make.extraPaths;
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -114,6 +114,7 @@ lib.makeOverridable (
           artemist
         ];
         license = lib.licenses.bsd2;
+        platforms = lib.platforms.freebsd;
       }
       // attrs.meta or { };
     }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkcsmapper.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkcsmapper.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   mkDerivation,
   byacc,
@@ -17,4 +18,6 @@ mkDerivation {
     byacc
     flex
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkesdb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkesdb.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   byacc,
   flex,
@@ -13,4 +14,6 @@ mkDerivation {
     byacc
     flex
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mtree.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mtree.nix
@@ -42,4 +42,6 @@ mkDerivation {
       )
     }"
   '';
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/rpcgen/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/rpcgen/package.nix
@@ -23,4 +23,6 @@ mkDerivation {
     # the problem is fixed properly in glibc.
     ./rpcgen-glibc-hack.patch
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/tsort.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/tsort.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   freebsdSetupHook,
@@ -24,4 +25,6 @@ mkDerivation {
     mandoc
     groff
   ];
+
+  meta.platforms = lib.platforms.unix;
 }


### PR DESCRIPTION
facf54a5e759f3b77024c1d5904a576244694546 was not tested correctly, and in fact had the opposite effect of its intent.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
