### PR TITLE
jellyfin-ffmpeg: disable more big and unused dependencies

### DIFF
--- a/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
+++ b/pkgs/by-name/je/jellyfin-ffmpeg/package.nix
@@ -18,8 +18,14 @@ in
   };
   buildFfplay = false; # requires SDL2 which gets disabled
   buildFfprobe = true; # required by various programs like Immich
-  withSamba = false; # samba is rather big and unused
+
+  # dependencies with big closure sizes that are not enabled by upstream in
+  # https://github.com/jellyfin/jellyfin-ffmpeg/tree/jellyfin/builder/scripts.d
+  withFrei0r = false;
+  withRav1e = false;
+  withSamba = false;
   withSdl2 = false;
+  withWhisper = false;
 }).overrideAttrs
   (old: {
     pname = "jellyfin-ffmpeg";


### PR DESCRIPTION
Relevant diff on my system:
```
frei0r-plugins: 3.5.0 → ∅, -7.2 MiB
rav1e: 0.8.1 → ∅, -19.8 MiB
whisper-cpp: 1.9.2 → ∅, -82.1 MiB
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
