### PR TITLE
`mkLibretroCore`: split output

### DIFF
--- a/pkgs/applications/video/kodi/addons/libretro-2048/default.nix
+++ b/pkgs/applications/video/kodi/addons/libretro-2048/default.nix
@@ -19,10 +19,10 @@ buildKodiBinaryAddon rec {
   };
 
   extraCMakeFlags = [
-    "-D2048_LIB=${twenty-fortyeight}/lib/retroarch/cores/2048_libretro.so"
+    "-D2048_LIB=${lib.getLib twenty-fortyeight}/lib/retroarch/cores/2048_libretro.so"
   ];
 
-  extraBuildInputs = [ twenty-fortyeight ];
+  extraBuildInputs = [ (lib.getLib twenty-fortyeight) ];
   propagatedBuildInputs = [
     libretro
   ];

--- a/pkgs/applications/video/kodi/addons/libretro-fuse/default.nix
+++ b/pkgs/applications/video/kodi/addons/libretro-fuse/default.nix
@@ -19,10 +19,10 @@ buildKodiBinaryAddon rec {
   };
 
   extraCMakeFlags = [
-    "-DFUSE_LIB=${fuse}/lib/retroarch/cores/fuse_libretro.so"
+    "-DFUSE_LIB=${lib.getLib fuse}/lib/retroarch/cores/fuse_libretro.so"
   ];
 
-  extraBuildInputs = [ fuse ];
+  extraBuildInputs = [ (lib.getLib fuse) ];
   propagatedBuildInputs = [
     libretro
   ];

--- a/pkgs/applications/video/kodi/addons/libretro-genplus/default.nix
+++ b/pkgs/applications/video/kodi/addons/libretro-genplus/default.nix
@@ -19,10 +19,10 @@ buildKodiBinaryAddon rec {
   };
 
   extraCMakeFlags = [
-    "-DGENPLUS_LIB=${genesis-plus-gx}/lib/retroarch/cores/genesis_plus_gx_libretro.so"
+    "-DGENPLUS_LIB=${lib.getLib genesis-plus-gx}/lib/retroarch/cores/genesis_plus_gx_libretro.so"
   ];
 
-  extraBuildInputs = [ genesis-plus-gx ];
+  extraBuildInputs = [ (lib.getLib genesis-plus-gx) ];
   propagatedBuildInputs = [
     libretro
   ];

--- a/pkgs/applications/video/kodi/addons/libretro-gw/default.nix
+++ b/pkgs/applications/video/kodi/addons/libretro-gw/default.nix
@@ -20,10 +20,10 @@ buildKodiBinaryAddon rec {
   };
 
   extraCMakeFlags = [
-    "-DGW_LIB=${gw}/lib/retroarch/cores/gw_libretro.so"
+    "-DGW_LIB=${lib.getLib gw}/lib/retroarch/cores/gw_libretro.so"
   ];
 
-  extraBuildInputs = [ gw ];
+  extraBuildInputs = [ (lib.getLib gw) ];
   propagatedBuildInputs = [
     libretro
   ];

--- a/pkgs/applications/video/kodi/addons/libretro-mgba/default.nix
+++ b/pkgs/applications/video/kodi/addons/libretro-mgba/default.nix
@@ -19,10 +19,10 @@ buildKodiBinaryAddon rec {
   };
 
   extraCMakeFlags = [
-    "-DMGBA_LIB=${mgba}/lib/retroarch/cores/mgba_libretro.so"
+    "-DMGBA_LIB=${lib.getLib mgba}/lib/retroarch/cores/mgba_libretro.so"
   ];
 
-  extraBuildInputs = [ mgba ];
+  extraBuildInputs = [ (lib.getLib mgba) ];
   propagatedBuildInputs = [
     libretro
   ];

--- a/pkgs/applications/video/kodi/addons/libretro-nestopia/default.nix
+++ b/pkgs/applications/video/kodi/addons/libretro-nestopia/default.nix
@@ -20,10 +20,10 @@ buildKodiBinaryAddon rec {
   };
 
   extraCMakeFlags = [
-    "-DNESTOPIA_LIB=${nestopia}/lib/retroarch/cores/nestopia_libretro.so"
+    "-DNESTOPIA_LIB=${lib.getLib nestopia}/lib/retroarch/cores/nestopia_libretro.so"
   ];
 
-  extraBuildInputs = [ nestopia ];
+  extraBuildInputs = [ (lib.getLib nestopia) ];
   propagatedBuildInputs = [
     libretro
   ];

--- a/pkgs/applications/video/kodi/addons/libretro-snes9x/default.nix
+++ b/pkgs/applications/video/kodi/addons/libretro-snes9x/default.nix
@@ -19,10 +19,10 @@ buildKodiBinaryAddon rec {
   };
 
   extraCMakeFlags = [
-    "-DSNES9X_LIB=${snes9x}/lib/retroarch/cores/snes9x_libretro.so"
+    "-DSNES9X_LIB=${lib.getLib snes9x}/lib/retroarch/cores/snes9x_libretro.so"
   ];
 
-  extraBuildInputs = [ snes9x ];
+  extraBuildInputs = [ (lib.getLib snes9x) ];
   propagatedBuildInputs = [
     libretro
   ];

--- a/pkgs/by-name/li/libretroPackages/mkLibretroCore.nix
+++ b/pkgs/by-name/li/libretroPackages/mkLibretroCore.nix
@@ -43,7 +43,7 @@ lib.extendMkDerivation {
     }:
     let
       d2u = if normalizeCore then (lib.replaceStrings [ "-" ] [ "_" ]) else (x: x);
-      coreDir = placeholder "out" + libretroCore;
+      coreDir = placeholder (if finalAttrs.includeRetroArch then "lib" else "out") + libretroCore;
       coreFilename = "${d2u core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary}";
       mainProgram = "retroarch-${core}";
     in
@@ -52,6 +52,8 @@ lib.extendMkDerivation {
 
       buildInputs = [ zlib ] ++ extraBuildInputs;
       nativeBuildInputs = lib.optional finalAttrs.includeRetroArch makeWrapper ++ extraNativeBuildInputs;
+
+      outputs = [ "out" ] ++ lib.optional finalAttrs.includeRetroArch "lib";
 
       inherit
         enableParallelBuilding


### PR DESCRIPTION
Follow-up to #527255: Splits `/lib/retroarch/cores` to `!lib`, leaving `/bin` in `!out`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
