### PR TITLE
weylus: unstable-2025-10-08 -> unstable-2026-2-16

### DIFF
--- a/pkgs/by-name/we/weylus/package.nix
+++ b/pkgs/by-name/we/weylus/package.nix
@@ -37,13 +37,13 @@
 
 rustPlatform.buildRustPackage {
   pname = "weylus";
-  version = "0.11.4-unstable-2025-10-08";
+  version = "0.11.4-unstable-2026-2-16";
 
   src = fetchFromGitHub {
     owner = "H-M-H";
     repo = "weylus";
-    rev = "56e29ecbde3a4aba994a9df047b5398feb447c1b";
-    hash = "sha256-dHdgWrygSXqKf9fpYRVDj+Ql97Or/kjBfN/mECy2ipc=";
+    rev = "38a01a8f8e429500c7e9f67fc1c88ca37a4d1e93";
+    hash = "sha256-kcFXwrxg9PQxR4/71s10TMtaFvksuQaNReSoGBbrdM0=";
   };
 
   postPatch = ''
@@ -88,7 +88,7 @@ rustPlatform.buildRustPackage {
     libtool
   ];
 
-  cargoHash = "sha256-Mx8/zMG36qztbFYgqC7SB75bf8T0NkYQA+2Hs9/pnjk=";
+  cargoHash = "sha256-2K+zLgZ3ApTCpj/OYy0f80pkvXPaB6TJe4fcrqsxPPw=";
 
   cargoBuildFlags = [ "--features=ffmpeg-system" ];
   cargoTestFlags = [ "--features=ffmpeg-system" ];

--- a/pkgs/by-name/we/weylus/package.nix
+++ b/pkgs/by-name/we/weylus/package.nix
@@ -123,6 +123,6 @@ rustPlatform.buildRustPackage {
     mainProgram = "weylus";
     homepage = "https://github.com/H-M-H/Weylus";
     license = lib.licenses.agpl3Only;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.zainkergaye ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Bumping small bugfixes, most notably the [Fix ios video rendering](https://github.com/H-M-H/Weylus/commit/22c1c65b231c69581850f264009ed7267beebaf1). Other commits are [here](https://github.com/H-M-H/Weylus/commits/master/)

No AI was used. (It's a simple hash bump anyway)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
