### PR TITLE
 python3Packages.foundrytools-cli: init at 2.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22506,6 +22506,12 @@
     githubId = 121009904;
     name = "penalty1083";
   };
+  pengo = {
+    email = "pengo+nixpkgs@pengo.uk";
+    github = "pengolord";
+    githubId = 152470365;
+    name = "pengo";
+  };
   pentane = {
     email = "cyclopentane@aidoskyneen.eu";
     github = "cyclic-pentane";

--- a/pkgs/development/python-modules/foundrytools-cli/default.nix
+++ b/pkgs/development/python-modules/foundrytools-cli/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  uv-build,
+
+  # dependencies
+  afdko,
+  click,
+  foundrytools,
+  loguru,
+  pathvalidate,
+  rich,
+  ufolib2,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "foundrytools-cli";
+  version = "2.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ftCLI";
+    repo = "FoundryTools-CLI";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KYCiFs5IJwE+OGxQ+UcOSzjd3noeO21OVXtPpsyLfFU=";
+  };
+
+  build-system = [
+    uv-build
+  ];
+
+  dependencies = [
+    afdko
+    click
+    foundrytools
+    loguru
+    pathvalidate
+    rich
+    ufolib2
+  ];
+
+  meta = {
+    description = "Command line interface for the FoundryTools library";
+    homepage = "https://github.com/ftCLI/FoundryTools-CLI";
+    changelog = "https://github.com/ftCLI/FoundryTools-CLI/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pengo ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6452,6 +6452,8 @@ self: super: with self; {
 
   foundrytools = callPackage ../development/python-modules/foundrytools { };
 
+  foundrytools-cli = callPackage ../development/python-modules/foundrytools-cli { };
+
   fountains = callPackage ../development/python-modules/fountains { };
 
   foxdot = callPackage ../development/python-modules/foxdot { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
