### PR TITLE
seedfiles: init at 1.7.2

### DIFF
--- a/pkgs/by-name/se/seedfiles/package.nix
+++ b/pkgs/by-name/se/seedfiles/package.nix
@@ -1,0 +1,49 @@
+{
+  acl,
+  fetchFromCodeberg,
+  lib,
+  libcap,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "seedfiles";
+  version = "1.7.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "Gardenhouse";
+    repo = "seedfiles";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bnawN7sbRrQ7Tb4QbPd7DgKEvgGefy8jyg3fsH4X914=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [ acl ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libcap ];
+
+  mesonFlags = [
+    "-Ddefault_configs=disabled"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Portable drop-in reimplementation of systemd-tmpfiles";
+    homepage = "https://codeberg.org/Gardenhouse/seedfiles";
+    mainProgram = "seedfiles";
+    maintainers = with lib.maintainers; [ es-sai-fi ];
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://codeberg.org/Gardenhouse/seedfiles
A portable drop-in reimplementation of systemd-tmpfiles.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
