### PR TITLE
docker-dash: init at 0.1.3

### DIFF
--- a/pkgs/by-name/do/docker-dash/package.nix
+++ b/pkgs/by-name/do/docker-dash/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "docker-dash";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "GustavoCaso";
+    repo = "docker-dash";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MM4cuF99j0l8c2bwnXwnzKFykYijTbitN17Wz72H2yw=";
+  };
+
+  vendorHash = "sha256-yY/oKPvxUMHmowfqRHDlDNO4cDqCQndE/MRlH0UbVo8=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Keyboard-first Docker dashboard for the terminal";
+    mainProgram = "docker-dash";
+    homepage = "https://github.com/GustavoCaso/docker-dash";
+    changelog = "https://github.com/GustavoCaso/docker-dash/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kangazero
+    ];
+  };
+})


### PR DESCRIPTION
`docker-dash` init at 0.1.3

A keyboard-driven docker dashboard TUI tool.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
