### PR TITLE
release: drop darwin.linux-builder

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -138,7 +138,6 @@ let
             jobs.stdenv.aarch64-darwin
             jobs.vim.aarch64-darwin
             jobs.cachix.aarch64-darwin
-            jobs.darwin.linux-builder.aarch64-darwin
 
             # UI apps
             # jobs.firefox-unwrapped.aarch64-darwin
@@ -221,7 +220,6 @@ let
         jobs.vim.aarch64-darwin
         jobs.inkscape.aarch64-darwin
         jobs.qt5.qtmultimedia.aarch64-darwin
-        jobs.darwin.linux-builder.aarch64-darwin
         /*
           jobs.tests.cc-wrapper.default.aarch64-darwin
           jobs.tests.cc-wrapper.llvmPackages.clang.aarch64-darwin


### PR DESCRIPTION
It wouldn't eval anymore.  See the discussion on:
https://github.com/NixOS/nixpkgs/pull/552774

I've checked that this fixes eval of
https://hydra.nixos.org/job/nixpkgs/staging-next/unstable

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
