### PR TITLE
python3Packages.pgmpy: cleanup, fix on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/pgmpy/default.nix
+++ b/pkgs/development/python-modules/pgmpy/default.nix
@@ -36,6 +36,7 @@ buildPythonPackage (finalAttrs: {
   pname = "pgmpy";
   version = "1.1.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pgmpy";

--- a/pkgs/development/python-modules/pgmpy/default.nix
+++ b/pkgs/development/python-modules/pgmpy/default.nix
@@ -4,6 +4,9 @@
   buildPythonPackage,
   fetchFromGitHub,
 
+  # build-system
+  setuptools,
+
   # dependencies
   google-generativeai,
   huggingface-hub,
@@ -40,6 +43,10 @@ buildPythonPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-qZoyeUaRsatWUiFoL1VaRqApjM/AFS8xqTjVBcUpYas=";
   };
+
+  build-system = [
+    setuptools
+  ];
 
   dependencies = [
     google-generativeai

--- a/pkgs/development/python-modules/pgmpy/default.nix
+++ b/pkgs/development/python-modules/pgmpy/default.nix
@@ -148,6 +148,18 @@ buildPythonPackage (finalAttrs: {
     "test_forward_sample"
     "test_rejection_sample_basic"
   ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # Failures due to numeric precision differences on aarch64-linux
+    "test_fisher_z_residual"
+    "test_generalized_cov_approx"
+    "test_hotelling_approx"
+    "test_hotelling_no_cond"
+    "test_pearsonr_residual"
+    "test_roys_approx"
+    "test_roys_no_cond"
+    "test_wilks_approx"
+    "test_wilks_no_cond"
+  ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Failures due to numeric precision differences on Darwin
     "test_generalized_cov_approx"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.pgmpy: explicitly add setuptools to build-system**
- **python3Packages.pgmpy: enable __structuredAttrs**
- **python3Packages.pgmpy: skip failing test on aarch64-linux**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
