### PR TITLE
nixos/syncoid: Fix overlapping syncoid commands

### DIFF
--- a/nixos/modules/services/backup/syncoid.nix
+++ b/nixos/modules/services/backup/syncoid.nix
@@ -17,6 +17,96 @@ let
       lib.optionals (m != null) m
     );
 
+  dedupeNames =
+    l:
+    lib.pipe l [
+      (lib.groupBy (e: e.name))
+      (lib.mapAttrs (
+        name: elements:
+        if (builtins.length elements) == 1 then
+          elements
+        else
+          lib.imap1 (
+            i: e:
+            e
+            // {
+              name = "${e.name}-${toString i}";
+            }
+          ) elements
+      ))
+      lib.attrValues
+      lib.concatLists
+    ];
+
+  allowCommands = lib.pipe cfg.commands [
+    # One element per (command, dataset, permission)
+    (lib.mapAttrsToList (
+      command: c:
+      (lib.concatMap (
+        dataset:
+        lib.map (permission: {
+          inherit command dataset permission;
+        }) c.localSourceAllow
+      ) (localDatasetName c.source))
+      ++ (lib.concatMap (
+        dataset:
+        lib.map (permission: {
+          inherit command dataset permission;
+        }) c.localTargetAllow
+      ) (localDatasetName c.target))
+    ))
+    lib.concatLists
+    # Group commands by (dataset, permission)
+    (lib.groupBy (p: "${p.dataset}@${p.permission}"))
+    (lib.mapAttrsToList (
+      _: ps: {
+        inherit (lib.head ps) dataset permission;
+        commands = map (p: p.command) ps;
+      }
+    ))
+    # Group permissions by (dataset, commands)
+    (lib.groupBy (p: lib.concatStringsSep "@" (p.commands ++ [ p.dataset ])))
+    (lib.mapAttrsToList (
+      _: ps: {
+        inherit (lib.head ps) dataset commands;
+        permissions = map (p: p.permission) ps;
+      }
+    ))
+    # Turn each (dataset, commands) group into a service definition
+    (map (p: {
+      inherit (p) commands;
+      name = "syncoidallow-${escapeUnitName p.dataset}";
+      value = {
+        description = "Syncoid ZFS allow for ${p.dataset}";
+        after = [ "zfs.target" ];
+        unitConfig = {
+          StopWhenUnneeded = true;
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = buildAllowCommand p.permissions p.dataset;
+          ExecStop = buildUnallowCommand p.permissions p.dataset;
+        };
+      };
+    }))
+    dedupeNames
+  ];
+
+  allowUnits = lib.listToAttrs allowCommands;
+
+  allowUnitsByCommand = lib.pipe allowCommands [
+    (lib.concatMap (
+      u:
+      map (command: {
+        unit = "${u.name}.service";
+        inherit command;
+      }) u.commands
+    ))
+    (lib.groupBy (u: u.command))
+    (lib.mapAttrs (_: us: map (u: u.unit) us))
+  ];
+
   # Escape as required by: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
   escapeUnitName =
     name:
@@ -355,123 +445,123 @@ in
       };
     };
 
-    systemd.services = lib.mapAttrs' (
-      name: c:
-      lib.nameValuePair "syncoid-${escapeUnitName name}" (
-        lib.mkMerge [
-          {
-            description = "Syncoid ZFS synchronization from ${c.source} to ${c.target}";
-            after = [ "zfs.target" ];
-            # syncoid may need zpool to get feature@extensible_dataset
-            path = [ "/run/booted-system/sw/bin/" ];
-            serviceConfig = {
-              ExecStartPre =
-                (map (buildAllowCommand c.localSourceAllow) (localDatasetName c.source))
-                ++ (map (buildAllowCommand c.localTargetAllow) (localDatasetName c.target));
-              ExecStopPost =
-                (map (buildUnallowCommand c.localSourceAllow) (localDatasetName c.source))
-                ++ (map (buildUnallowCommand c.localTargetAllow) (localDatasetName c.target));
-              ExecStart = lib.escapeShellArgs (
-                [ "${cfg.package}/bin/syncoid" ]
-                ++ lib.optionals c.useCommonArgs cfg.commonArgs
-                ++ lib.optional c.recursive "-r"
-                ++ lib.optionals (c.sshKey != null) [
-                  "--sshkey"
-                  c.sshKey
-                ]
-                ++ c.extraArgs
-                ++ [
-                  "--sendoptions"
-                  c.sendOptions
-                  "--recvoptions"
-                  c.recvOptions
-                  "--no-privilege-elevation"
-                  c.source
-                  c.target
-                ]
-              );
-              User = cfg.user;
-              Group = cfg.group;
-              StateDirectory = [ "syncoid" ];
-              StateDirectoryMode = "700";
-              # Prevent SSH control sockets of different syncoid services from interfering
-              PrivateTmp = true;
-              # Permissive access to /proc because syncoid
-              # calls ps(1) to detect ongoing `zfs receive`.
-              ProcSubset = "all";
-              ProtectProc = "default";
+    systemd.services =
+      allowUnits
+      // lib.mapAttrs' (
+        name: c:
+        let
+          commandAllowUnits = allowUnitsByCommand.${name};
+        in
+        lib.nameValuePair "syncoid-${escapeUnitName name}" (
+          lib.mkMerge [
+            {
+              description = "Syncoid ZFS synchronization from ${c.source} to ${c.target}";
+              requires = commandAllowUnits;
+              after = [ "zfs.target" ] ++ commandAllowUnits;
+              # syncoid may need zpool to get feature@extensible_dataset
+              path = [ "/run/booted-system/sw/bin/" ];
+              serviceConfig = {
+                ExecStart = lib.escapeShellArgs (
+                  [ "${cfg.package}/bin/syncoid" ]
+                  ++ lib.optionals c.useCommonArgs cfg.commonArgs
+                  ++ lib.optional c.recursive "-r"
+                  ++ lib.optionals (c.sshKey != null) [
+                    "--sshkey"
+                    c.sshKey
+                  ]
+                  ++ c.extraArgs
+                  ++ [
+                    "--sendoptions"
+                    c.sendOptions
+                    "--recvoptions"
+                    c.recvOptions
+                    "--no-privilege-elevation"
+                    c.source
+                    c.target
+                  ]
+                );
+                User = cfg.user;
+                Group = cfg.group;
+                StateDirectory = [ "syncoid" ];
+                StateDirectoryMode = "700";
+                # Prevent SSH control sockets of different syncoid services from interfering
+                PrivateTmp = true;
+                # Permissive access to /proc because syncoid
+                # calls ps(1) to detect ongoing `zfs receive`.
+                ProcSubset = "all";
+                ProtectProc = "default";
 
-              # The following options are only for optimizing:
-              # systemd-analyze security | grep syncoid-'*'
-              AmbientCapabilities = "";
-              CapabilityBoundingSet = "";
-              DeviceAllow = [ "/dev/zfs" ];
-              LockPersonality = true;
-              MemoryDenyWriteExecute = true;
-              NoNewPrivileges = true;
-              PrivateDevices = true;
-              PrivateMounts = true;
-              PrivateNetwork = lib.mkDefault false;
-              PrivateUsers = false; # Enabling this breaks on zfs-2.2.0
-              ProtectClock = true;
-              ProtectControlGroups = true;
-              ProtectHome = true;
-              ProtectHostname = true;
-              ProtectKernelLogs = true;
-              ProtectKernelModules = true;
-              ProtectKernelTunables = true;
-              ProtectSystem = "strict";
-              RemoveIPC = true;
-              RestrictAddressFamilies = [
-                "AF_UNIX"
-                "AF_INET"
-                "AF_INET6"
-              ];
-              RestrictNamespaces = true;
-              RestrictRealtime = true;
-              RestrictSUIDSGID = true;
-              RootDirectory = "/run/syncoid/${escapeUnitName name}";
-              RootDirectoryStartOnly = true;
-              BindPaths = [ "/dev/zfs" ];
-              BindReadOnlyPaths = [
-                builtins.storeDir
-                "/etc"
-                "/run"
-                "/bin/sh"
-              ];
-              # Avoid useless mounting of RootDirectory= in the own RootDirectory= of ExecStart='s mount namespace.
-              InaccessiblePaths = [ "-+/run/syncoid/${escapeUnitName name}" ];
-              MountAPIVFS = true;
-              # Create RootDirectory= in the host's mount namespace.
-              RuntimeDirectory = [ "syncoid/${escapeUnitName name}" ];
-              RuntimeDirectoryMode = "700";
-              SystemCallFilter = [
-                "@system-service"
-                # Groups in @system-service which do not contain a syscall listed by:
-                # perf stat -x, 2>perf.log -e 'syscalls:sys_enter_*' syncoid …
-                # awk >perf.syscalls -F "," '$1 > 0 {sub("syscalls:sys_enter_","",$3); print $3}' perf.log
-                # systemd-analyze syscall-filter | grep -v -e '#' | sed -e ':loop; /^[^ ]/N; s/\n //; t loop' | grep $(printf ' -e \\<%s\\>' $(cat perf.syscalls)) | cut -f 1 -d ' '
-                "~@aio"
-                "~@chown"
-                "~@keyring"
-                "~@memlock"
-                "~@privileged"
-                "~@resources"
-                "~@setuid"
-                # NB: pv after 1.11.0 uses timer syscalls (specifically setitimer)
-                # "~@timer"
-              ];
-              SystemCallArchitectures = "native";
-              # This is for BindPaths= and BindReadOnlyPaths=
-              # to allow traversal of directories they create in RootDirectory=.
-              UMask = "0066";
-            };
-          }
-          cfg.service
-          c.service
-        ]
-      )
-    ) cfg.commands;
+                # The following options are only for optimizing:
+                # systemd-analyze security | grep syncoid-'*'
+                AmbientCapabilities = "";
+                CapabilityBoundingSet = "";
+                DeviceAllow = [ "/dev/zfs" ];
+                LockPersonality = true;
+                MemoryDenyWriteExecute = true;
+                NoNewPrivileges = true;
+                PrivateDevices = true;
+                PrivateMounts = true;
+                PrivateNetwork = lib.mkDefault false;
+                PrivateUsers = false; # Enabling this breaks on zfs-2.2.0
+                ProtectClock = true;
+                ProtectControlGroups = true;
+                ProtectHome = true;
+                ProtectHostname = true;
+                ProtectKernelLogs = true;
+                ProtectKernelModules = true;
+                ProtectKernelTunables = true;
+                ProtectSystem = "strict";
+                RemoveIPC = true;
+                RestrictAddressFamilies = [
+                  "AF_UNIX"
+                  "AF_INET"
+                  "AF_INET6"
+                ];
+                RestrictNamespaces = true;
+                RestrictRealtime = true;
+                RestrictSUIDSGID = true;
+                RootDirectory = "/run/syncoid/${escapeUnitName name}";
+                RootDirectoryStartOnly = true;
+                BindPaths = [ "/dev/zfs" ];
+                BindReadOnlyPaths = [
+                  builtins.storeDir
+                  "/etc"
+                  "/run"
+                  "/bin/sh"
+                ];
+                # Avoid useless mounting of RootDirectory= in the own RootDirectory= of ExecStart='s mount namespace.
+                InaccessiblePaths = [ "-+/run/syncoid/${escapeUnitName name}" ];
+                MountAPIVFS = true;
+                # Create RootDirectory= in the host's mount namespace.
+                RuntimeDirectory = [ "syncoid/${escapeUnitName name}" ];
+                RuntimeDirectoryMode = "700";
+                SystemCallFilter = [
+                  "@system-service"
+                  # Groups in @system-service which do not contain a syscall listed by:
+                  # perf stat -x, 2>perf.log -e 'syscalls:sys_enter_*' syncoid …
+                  # awk >perf.syscalls -F "," '$1 > 0 {sub("syscalls:sys_enter_","",$3); print $3}' perf.log
+                  # systemd-analyze syscall-filter | grep -v -e '#' | sed -e ':loop; /^[^ ]/N; s/\n //; t loop' | grep $(printf ' -e \\<%s\\>' $(cat perf.syscalls)) | cut -f 1 -d ' '
+                  "~@aio"
+                  "~@chown"
+                  "~@keyring"
+                  "~@memlock"
+                  "~@privileged"
+                  "~@resources"
+                  "~@setuid"
+                  # NB: pv after 1.11.0 uses timer syscalls (specifically setitimer)
+                  # "~@timer"
+                ];
+                SystemCallArchitectures = "native";
+                # This is for BindPaths= and BindReadOnlyPaths=
+                # to allow traversal of directories they create in RootDirectory=.
+                UMask = "0066";
+              };
+            }
+            cfg.service
+            c.service
+          ]
+        )
+      ) cfg.commands;
 
     systemd.timers = lib.concatMapAttrs (
       name: c:

--- a/nixos/tests/sanoid.nix
+++ b/nixos/tests/sanoid.nix
@@ -60,6 +60,33 @@ in
             };
             # Take snapshot and sync
             "pool/syncoid".target = "root@target:pool/syncoid";
+            # Test to make sure two commands can use the same dataset
+            "pool/syncoid2" = {
+              source = "pool/syncoid";
+              target = "root@target:pool/syncoid2";
+              extraArgs = [
+                "--identifier"
+                "syncoid2"
+              ];
+            };
+            # Test to make sure two commands can use the same dataset with different permissions
+            "pool/syncoid3" = {
+              source = "pool/syncoid";
+              target = "root@target:pool/syncoid3";
+              extraArgs = [
+                "--identifier"
+                "syncoid3"
+              ];
+              localSourceAllow = [
+                "bookmark"
+                "hold"
+                "send"
+                "snapshot"
+                "destroy"
+                "mount"
+                "rollback"
+              ];
+            };
 
             # Test pool without parent (regression test for https://github.com/NixOS/nixpkgs/pull/180111)
             "pool".target = "root@target:pool/full-pool";
@@ -127,11 +154,13 @@ in
     source.succeed("touch /mnt/pool/syncoid/test.txt")
     source.systemctl("start --wait syncoid-pool-sanoid.service")
     target.succeed("cat /mnt/pool/sanoid/test.txt")
-    source.systemctl("start --wait syncoid-pool-syncoid.service")
-    source.systemctl("start --wait syncoid-pool-syncoid.service")
+    source.systemctl("start --wait syncoid-pool-syncoid.service syncoid-pool-syncoid2.service syncoid-pool-syncoid3.service")
+    source.systemctl("start --wait syncoid-pool-syncoid.service syncoid-pool-syncoid2.service syncoid-pool-syncoid3.service")
     target.succeed("cat /mnt/pool/syncoid/test.txt")
+    target.succeed("cat /mnt/pool/syncoid2/test.txt")
+    target.succeed("cat /mnt/pool/syncoid3/test.txt")
 
-    assert(len(source.succeed("zfs list -H -t snapshot pool/syncoid").splitlines()) == 1), "Syncoid should only retain one sync snapshot"
+    assert(len(source.succeed("zfs list -H -t snapshot pool/syncoid").splitlines()) == 3), "Syncoid should only retain one sync snapshot for each command"
 
     source.systemctl("start --wait syncoid-pool.service")
     target.succeed("[[ -d /mnt/pool/full-pool/syncoid ]]")


### PR DESCRIPTION
When multiple syncoid commands target the same source or target dataset, the `zfs allow` and `zfs unallow` commands will overlap, causing permission to be revoked from the still-running send.

Instead of using `ExecStartPre`/`ExecStopPost` to run `zfs allow` and `zfs unallow`, now we generate a separate systemd unit with `StopWhenUnneeded=true` to clean up permissions when there are no remaining running syncoid instances.

Fixes #259390

There have been three previous attempts to fix this: #208121, #147559, and #236729. Unlike those changes, this PR does not introduce new users, `DynamicUser`, or any new configuration surface.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
