### PR TITLE
caelestia-shell: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/by-name/ca/caelestia-shell/package.nix
+++ b/pkgs/by-name/ca/caelestia-shell/package.nix
@@ -33,14 +33,14 @@
   withCli ? true,
 }:
 let
-  version = "2.3.0";
-  rev = "94d5eb9e6fe9c6b1f69e663d9ed410a441e2d67f";
+  version = "2.4.0";
+  rev = "24aa15eefdb146350d2548c0a015b04eddbd1008";
 
   m3shapes_src = fetchFromGitHub {
     owner = "soramanew";
     repo = "m3shapes";
-    rev = "bdc327b29f95394a732baf3c9b19658ba23755b6";
-    hash = "sha256-kfHyzZaPHgqZML48OA+5JwBOsLdQJ2ci/aGPShvUB4Y=";
+    rev = "32ad9ce328bb77ed349b40a3be10ee9ea610b8ab";
+    hash = "sha256-YZelgEZflFNwGutX4/tIzBdbOeghJgE2oDw0uWYGxns=";
   };
 
   runtimeDeps = [
@@ -73,11 +73,9 @@ let
     (lib.cmakeFeature "DISTRIBUTOR" "nixpkgs")
   ];
 
-  m3shapesFlag = lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_M3SHAPES_EXTERNAL" "${m3shapes_src}";
-
   shellSrc = fetchurl {
     url = "https://github.com/caelestia-dots/shell/releases/download/v${version}/caelestia-shell-v${version}.tar.gz";
-    hash = "sha256-EjPnMXxonYAewJW1/XKQUC5fbqIU7xSwI3XTW1VC544=";
+    hash = "sha256-r3SRcn/zBplpgVD598GGCJzNFxpQne8zK8uh3hyzF3E=";
   };
 
   extras = stdenv.mkDerivation {
@@ -130,7 +128,7 @@ let
   m3shapesModule = stdenv.mkDerivation {
     inherit cmakeBuildType;
     name = "caelestia-m3shapes";
-    src = shellSrc;
+    src = m3shapes_src;
 
     nativeBuildInputs = [
       cmake
@@ -139,15 +137,13 @@ let
     buildInputs = [
       qt6.qtbase
       qt6.qtdeclarative
+      qt6.qtshadertools
     ];
 
     dontWrapQtApps = true;
     cmakeFlags = [
-      (lib.cmakeFeature "ENABLE_MODULES" "m3shapes")
       (lib.cmakeFeature "INSTALL_QMLDIR" qt6.qtbase.qtQmlPrefix)
-      m3shapesFlag
-    ]
-    ++ cmakeVersionFlags;
+    ];
   };
 
 in

--- a/pkgs/by-name/ca/caelestia-shell/update.sh
+++ b/pkgs/by-name/ca/caelestia-shell/update.sh
@@ -15,8 +15,12 @@ TAR_URL="https://github.com/caelestia-dots/shell/releases/download/v${VERSION}/c
 SHELL_RAW="$(nix-prefetch-url "$TAR_URL" 2>/dev/null | tail -n 1)"
 SHELL_SRI="$(nix hash convert --to sri --hash-algo sha256 "$SHELL_RAW")"
 
-CMAKE_TXT="$(curl -sL ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://raw.githubusercontent.com/caelestia-dots/shell/$REV/CMakeLists.txt")"
-M3_REV="$(echo "$CMAKE_TXT" | grep "set(M3SHAPES_REV" | awk '{print $2}' | tr -d ')')"
+M3_REV="$(curl -sL ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://raw.githubusercontent.com/caelestia-dots/shell/$REV/flake.lock" | jq -r '.nodes.m3shapes.locked.rev // empty')"
+if [[ -z "$M3_REV" ]]; then
+  CMAKE_TXT="$(curl -sL ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://raw.githubusercontent.com/caelestia-dots/shell/$REV/CMakeLists.txt")"
+  M3_REV="$(echo "$CMAKE_TXT" | grep "set(M3SHAPES_REV" | awk '{print $2}' | tr -d ')' || true)"
+fi
+
 M3_RAW="$(nix-prefetch-url --unpack "https://github.com/soramanew/m3shapes/archive/$M3_REV.tar.gz" 2>/dev/null | tail -n 1)"
 M3_SRI="$(nix hash convert --to sri --hash-algo sha256 "$M3_RAW")"
 
@@ -29,10 +33,10 @@ with open("$PKG_NIX", "r") as f:
 content = re.sub(r'version\s*=\s*"[^"]+";', f'version = "$VERSION";', content, count=1)
 content = re.sub(r'rev\s*=\s*"[^"]+";', f'rev = "$REV";', content, count=1)
 
-m3_pattern = r'(m3shapes_src\s*=\s*fetchFromGitHub\s*\{[^}]*?rev\s*=\s*")[^"]+(";\s*hash\s*=\s*")[^"]+(";\s*\};)'
+m3_pattern = r'(m3shapes_src\s*=\s*fetchFromGitHub\s*\{.*?rev\s*=\s*")[^"]+(";\s*hash\s*=\s*")[^"]+(";\s*\};)'
 content = re.sub(m3_pattern, rf'\g<1>$M3_REV\g<2>$M3_SRI\g<3>', content, flags=re.DOTALL)
 
-shell_pattern = r'(shellSrc\s*=\s*fetchurl\s*\{[^}]*?hash\s*=\s*")[^"]+(";\s*\};)'
+shell_pattern = r'(shellSrc\s*=\s*fetchurl\s*\{.*?hash\s*=\s*")[^"]+(";\s*\};)'
 content = re.sub(shell_pattern, rf'\g<1>$SHELL_SRI\g<2>', content, flags=re.DOTALL)
 
 with open("$PKG_NIX", "w") as f:


### PR DESCRIPTION
Upstream release [v2.4.0](https://github.com/caelestia-dots/shell/releases/tag/v2.4.0).
- Upstream decoupled `m3shapes` from the main cmake build ([#1909](https://github.com/caelestia-dots/shell/pull/1909)), so `m3shapesModule` now builds directly from `m3shapes_src`.
- Updated `update.sh` to extract the pinned `m3shapes` revision from `flake.lock`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
