### PR TITLE
nixos/{k3s,rke2}: avoid IFD when generating auto-deploy chart manifests

### DIFF
--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -62,17 +62,6 @@ let
         builtins.attrNames cfg.charts
       );
 
-      # Converts YAML -> JSON -> Nix
-      fromYaml =
-        path:
-        builtins.fromJSON (
-          builtins.readFile (
-            pkgs.runCommand "${path}-converted.json" { nativeBuildInputs = [ pkgs.yq-go ]; } ''
-              yq --no-colors --output-format json ${path} > $out
-            ''
-          )
-        );
-
       # Replace prefixes and characters that are problematic in file names
       cleanHelmChartName =
         name:
@@ -136,9 +125,12 @@ let
       mkHelmChartCR =
         name: value:
         let
-          chartValues = if (lib.isPath value.values) then fromYaml value.values else value.values;
-          # use JSON for values as it's a subset of YAML and understood by the rancher Helm controller
-          valuesContent = builtins.toJSON chartValues;
+          # file values are inlined as YAML; attrs are converted to JSON (a YAML subset)
+          valuesContent =
+            if builtins.isAttrs value.values then
+              builtins.toJSON value.values
+            else
+              builtins.readFile (toString value.values);
         in
         # merge with extraFieldDefinitions to allow setting advanced values and overwrite generated
         # values
@@ -162,15 +154,33 @@ let
         } value.extraFieldDefinitions;
 
       # Generate a HelmChart custom resource together with extraDeploy manifests.
+      # Assembled at build time to avoid IFD.
       mkAutoDeployChartManifest = name: value: {
         # target is the final name of the link created for the manifest file
         target = mkManifestTarget name;
         inherit (value) enable package;
         # source is a store path containing the complete manifest file
-        source = mkManifestSource "auto-deploy-chart-${name}" (
-          lib.singleton (mkHelmChartCR name value)
-          ++ map (x: fromYaml (mkExtraDeployManifest x)) value.extraDeploy
-        );
+        source =
+          let
+            crFile = pkgs.writers.writeJSON "auto-deploy-chart-${name}-cr" (mkHelmChartCR name value);
+            extraFiles = map (
+              x:
+              if builtins.isAttrs x then
+                pkgs.writers.writeJSON "auto-deploy-chart-${name}-extra" x
+              else
+                mkExtraDeployManifest x
+            ) value.extraDeploy;
+            allFiles = [ crFile ] ++ extraFiles;
+            docs = lib.concatStringsSep "\necho ---\n" (
+              map (f: "yq -o json '.' ${f}") allFiles
+            );
+          in
+          pkgs.runCommand "auto-deploy-chart-${name}" { nativeBuildInputs = [ pkgs.yq-go ]; } ''
+            {
+              ${docs}
+            } | yq eval-all -o json '[.] | {"apiVersion": "v1", "kind": "List", "items": .}' - \
+              ${lib.optionalString (!jsonManifests) "| yq -o yaml -P '.'"} > $out
+          '';
       };
 
       autoDeployChartsModule = lib.types.submodule (

--- a/nixos/tests/rancher/auto-deploy.nix
+++ b/nixos/tests/rancher/auto-deploy.nix
@@ -199,6 +199,14 @@ in
                 kind = "Namespace";
                 metadata.name = "test";
               }
+              # extraDeploy item from a YAML file
+              (builtins.toFile "${rancherDistro}-test-chart-extra.yaml" ''
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: extra-from-file
+                  namespace: test
+              '')
             ];
             extraFieldDefinitions = {
               spec = {
@@ -256,6 +264,7 @@ in
         machine.wait_until_succeeds("kubectl wait --for=condition=complete job/chart-hello")
         machine.wait_until_succeeds("kubectl wait --for=condition=complete job/chart-values-file")
         machine.wait_until_succeeds("kubectl -n test wait --for=condition=complete job/chart-advanced")
+        machine.succeed("kubectl -n test get configmap extra-from-file")
 
       with subtest("Output of manifest test job"):
         hello_output = machine.succeed("kubectl logs -l batch.kubernetes.io/job-name=manifest-hello")


### PR DESCRIPTION
## Description

Building `services.k3s.autoDeployCharts` (and the rke2 equivalent) required
[import-from-derivation] (IFD): YAML `values` files and path/derivation
`extraDeploy` items were parsed into Nix at *evaluation* time via a `yq`
derivation, only to be immediately re-serialized by `pkgs.formats.*.generate`.
The parsed values were never used as Nix data — parsing at eval time is the IFD.

This PR assembles the whole multi-document manifest in a **single build step**
instead:

- the HelmChart custom resource and attrs `values`/`extraDeploy` items are
  written as JSON files (`writeJSON`),
- file/derivation items are converted by `yq` at build time,
- one `yq eval-all` call wraps everything into the `List` document,
  emitting YAML (k3s) or JSON (rke2) as before.

As a result the k3s and rke2 modules evaluate with
`--option allow-import-from-derivation false`. The eval-time `yq` round-trip
(`fromYaml`) is deleted; `values` given as attrs still emit JSON, which is a
YAML subset and is what the Helm controller expects.

The VM test (`nixos/tests/rancher/auto-deploy.nix`) now also covers an
`extraDeploy` item given as a YAML file and asserts the resulting ConfigMap
is deployed.

[import-from-derivation]: https://nix.dev/manual/nix/2.25/language/import-from-derivation

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Note on testing: the affected module's auto-deploy tests are the full k3s/rke2
VM tests in `nixos/tests/rancher/`, which need a big build; the generated
manifest derivations themselves were built and inspected locally
(`chart-hello`, `chart-values-file`, `chart-advanced` with both attrs and
file `extraDeploy` items, plus rke2's JSON manifest mode), and module
evaluation was verified with IFD disabled. Running the full VM tests locally
is recommended before merge.

Assisted-by: OpenCode + GLM 5.3-flash

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test