### PR TITLE
electron: fix update script

### DIFF
--- a/pkgs/development/tools/electron/update.py
+++ b/pkgs/development/tools/electron/update.py
@@ -118,9 +118,9 @@ def get_chromium_gn_source(chromium_tag: str) -> dict:
 def get_electron_yarn_data(electron_tag: str) -> dict:
     print(f"yarn-berry-fetcher prefetch", file=sys.stderr)
     with tempfile.TemporaryDirectory() as tmp_dir:
-        print(f"Patching yarn.lock for yarn 4.14 support", file=sys.stderr)
+        print(f"Patching yarn.lock for yarn 4.18 support", file=sys.stderr)
         yarn_lock_file=get_electron_file(electron_tag, "yarn.lock")
-        patched_yarn_lock_file=yarn_lock_file.replace('version: 8', 'version: 9', count=1)
+        patched_yarn_lock_file=yarn_lock_file.replace('version: 8', 'version: 10', count=1)
         with open(tmp_dir + "/yarn.lock", "w") as f:
             f.write(patched_yarn_lock_file)
         missing_hashes_str = (


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/555729 changed yarn hashes but didn't apply the changes to the electron update script.

Base is set to `staging` to resolve conflicts when merging `staging-next` into `staging`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
