### PR TITLE
nixos/komodo-periphery: fix path issues for docker, git, and system tools

### DIFF
--- a/nixos/modules/services/admin/komodo-periphery.nix
+++ b/nixos/modules/services/admin/komodo-periphery.nix
@@ -560,6 +560,16 @@ in
       ++ lib.optional (cfg.dockerHost == null) "docker.service";
       wantedBy = [ "multi-user.target" ];
 
+      # Periphery shells out to `docker`, `docker compose` and `git` through `sh -c`.
+      path = [
+        pkgs.git
+        config.virtualisation.docker.package
+      ]
+      ++ lib.optionals (!cfg.disableTerminals) [
+        "/run/current-system/sw"
+        "/run/wrappers"
+      ];
+
       serviceConfig = {
         Type = "simple";
         User = cfg.user;
@@ -603,11 +613,6 @@ in
           }
           // cfg.environment
         );
-
-        ExecSearchPath = lib.mkIf (!cfg.disableTerminals) [
-          "/run/current-system/sw/bin"
-          "/run/wrappers/bin"
-        ];
 
         EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
 

--- a/nixos/tests/komodo-periphery.nix
+++ b/nixos/tests/komodo-periphery.nix
@@ -44,6 +44,11 @@
   };
 
   testScript = ''
+    def with_unit_path(node, cmd):
+        """Run cmd with the PATH systemd hands to komodo-periphery.service."""
+        unit_path = "$(systemctl show -p Environment --value komodo-periphery | grep -o 'PATH=[^ ]*' | cut -d= -f2)"
+        node.succeed(f"export PATH={unit_path}; {cmd}")
+
     start_all()
 
     with subtest("Inbound periphery starts and serves /version"):
@@ -59,9 +64,15 @@
         periphery.succeed("test -d /var/lib/komodo-periphery/keys")
         periphery.succeed("test -d /var/lib/komodo-periphery/ssl")
 
+    with subtest("Service PATH provides docker, docker compose and git"):
+        with_unit_path(periphery, "command -v docker && command -v git && docker compose version")
+
     with subtest("Outbound periphery stays active despite unreachable core"):
         peripheryOutbound.wait_for_unit("komodo-periphery.service")
         peripheryOutbound.sleep(15)
         peripheryOutbound.succeed("systemctl is-active komodo-periphery")
+
+    with subtest("Terminal-enabled periphery sees system-wide tools on PATH"):
+        with_unit_path(peripheryOutbound, "command -v bash")
   '';
 }


### PR DESCRIPTION
Periphery runs `docker`, `docker compose` and `git` via `sh -c`, but none of them were on the service PATH.

The module relied on `ExecSearchPath`, which has no effect on `$PATH` on NixOS: every unit already gets `Environment=PATH` from `enableDefaultPath`, and systemd only lets `ExecSearchPath` override `$PATH` when it is not set via `Environment=`.

Fix: replace `ExecSearchPath` with `path`.
- Always add `git` and `config.virtualisation.docker.package`. The docker CLI honours `DOCKER_HOST`, so remote Docker / Podman setups need it too.
- Add `/run/current-system/sw` and `/run/wrappers` when terminals are enabled.

Added new NixOS tests for `docker`, `docker compose`, `git`, and `bash`.
These tests resolve using the PATH provided to the unit by systemd.


Supersedes #561629 , thanks @RustyNova016 for the report.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
