### PR TITLE
nixos/systemd: don't restart systemd-bless-boot.service on switch

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -820,6 +820,10 @@ in
     systemd.services.systemd-random-seed.restartIfChanged = false;
     systemd.services.systemd-remount-fs.restartIfChanged = false;
     systemd.services.systemd-update-utmp.restartIfChanged = false;
+    # `systemd-bless-boot good` fails once the current boot has been blessed.
+    systemd.services.systemd-bless-boot = lib.mkIf cfg.package.withBootloader {
+      restartIfChanged = false;
+    };
     systemd.targets.local-fs.unitConfig.X-StopOnReconfiguration = true;
     systemd.targets.remote-fs.unitConfig.X-StopOnReconfiguration = true;
     systemd.services.systemd-importd = lib.mkIf cfg.package.withImportd {


### PR DESCRIPTION
`systemd-bless-boot.service` strips the boot counter suffix from the boot loader entry named by the `LoaderBootCountPath` EFI variable, marking the current boot as good. That variable is written by the boot loader at boot and does not change afterwards, so re-running the unit later in the same boot always targets an entry that has already been blessed, and `systemd-bless-boot good` exits 1:

```
systemd-bless-boot[104747]: Can't find boot counter source file for '/loader/entries/nixos-....conf'.
systemd[1]: systemd-bless-boot.service: Main process exited, code=exited, status=1/FAILURE
```

This is reachable on every systemd update. The unit definition changes, so `switch-to-configuration` restarts it, the run fails, and the unit stays failed for the rest of the boot. From then on every switch re-triggers it. `switch-to-configuration` clears the failed state with `reset-failed`, and `basic.target` is still active and still wants the unit through the symlink that `systemd-bless-boot-generator` drops into `basic.target.wants`, so the unit is pulled back in. Each switch exits 4 and the system stays `degraded` until the next reboot.

Mark the unit as not to be restarted on switch, like the other boot-time one-shots directly above it. The unit is still started normally at boot, so boot counting and the automatic rollback it drives are unaffected. The `lib.mkIf cfg.package.withBootloader` guard matches `upstreamSystemUnits`, which only lists this unit when systemd is built with bootloader support; without it, a systemd built without bootloader support would get a standalone `systemd-bless-boot.service` unit file with no `ExecStart`, because the default `overrideStrategy` is `asDropinIfExists`.

Upstream took the same approach for the equivalent soft-reboot case in systemd/systemd#40386, fixed by systemd/systemd#40399: suppress the spurious invocation at the caller rather than making the verb idempotent.

cc @julienmalka @edolstra

### Verification

On an x86_64-linux machine with `boot.loader.systemd-boot.bootCounting.enable = true`, using an equivalent drop-in:

- Before: a switch across a systemd update restarted the unit, it failed, and every later switch in that boot failed again and exited 4.
- After: a switch that changes the unit definition reports `NOT restarting the following changed units: systemd-bless-boot.service`, the unit keeps its original `InvocationID`, and `systemctl is-system-running` stays `running`.
- After a reboot, `systemd-bless-boot good` runs at boot as usual and logs `Marked boot as 'good'. (Boot attempt counter is at 1.)`.

The `systemd-boot` NixOS tests that cover boot counting and switching pass with this change: `bootCounting`, `defaultEntryWithBootCounting`, `bootCountingSpecialisation`, and `switch-test`.

### Related
#558850 fixes a different way `systemd-bless-boot` can fail after a switch, where online garbage collection removes the entry while it is still counted. That fix lives in the builder's collection logic, so the two changes touch different files and do not conflict. I am cherry-picking #558850 on top of this branch to build it and run the `systemd-boot` tests with both changes applied, and will report the result here.

## AI disclosure

Claude Code with Opus 5 medium (Anthropic) contributed two things. It proposed how to track this failure down, through the `switch-to-configuration-ng` source, the generated unit and drop-in files, and the journal of the affected boots. It also wrote the change. I ran the investigation and the verification on the affected machine myself, and reviewed the diff in full.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test