### PR TITLE
nixos/gitwatch: escape shell args, nixos/tests/gitwatch: init

### DIFF
--- a/nixos/modules/services/monitoring/gitwatch.nix
+++ b/nixos/modules/services/monitoring/gitwatch.nix
@@ -6,11 +6,14 @@
 }:
 let
   inherit (lib)
+    escapeShellArg
+    escapeShellArgs
     maintainers
     mapAttrs'
     mkEnableOption
     mkOption
     nameValuePair
+    optionals
     optionalString
     types
     ;
@@ -18,7 +21,12 @@ let
     name: cfg:
     nameValuePair "gitwatch-${name}" (
       let
-        getvar = flag: var: optionalString (cfg."${var}" != null) "${flag} ${cfg."${var}"}";
+        getvar =
+          flag: var:
+          optionals (cfg."${var}" != null) [
+            flag
+            cfg."${var}"
+          ];
         branch = getvar "-b" "branch";
         remote = getvar "-r" "remote";
         message = getvar "-m" "message";
@@ -35,10 +43,20 @@ let
           openssh
         ];
         script = ''
-          if [ -n "${cfg.remote}" ] && ! [ -d "${cfg.path}" ]; then
-            git clone ${branch} "${cfg.remote}" "${cfg.path}"
-          fi
-          gitwatch ${remote} ${message} ${branch} ${cfg.path}
+          ${optionalString (cfg.remote != null) ''
+            if ! [ -d ${escapeShellArg cfg.path} ]; then
+              git clone ${
+                escapeShellArgs (
+                  branch
+                  ++ [
+                    cfg.remote
+                    cfg.path
+                  ]
+                )
+              }
+            fi
+          ''}
+          exec gitwatch ${escapeShellArgs (remote ++ message ++ branch ++ [ cfg.path ])}
         '';
         serviceConfig.User = cfg.user;
       }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -752,6 +752,7 @@ in
   };
   gitolite = runTest ./gitolite.nix;
   gitolite-fcgiwrap = runTest ./gitolite-fcgiwrap.nix;
+  gitwatch = runTest ./gitwatch.nix;
   glance = runTest ./glance.nix;
   glances = runTest ./glances.nix;
   glitchtip = runTest ./glitchtip.nix;

--- a/nixos/tests/gitwatch.nix
+++ b/nixos/tests/gitwatch.nix
@@ -1,0 +1,126 @@
+{ pkgs, lib, ... }:
+{
+  name = "gitwatch";
+  meta.maintainers = with lib.maintainers; [ h7x4 ];
+
+  containers.machine =
+    let
+      inherit (import ./ssh-keys.nix pkgs)
+        snakeOilEd25519PrivateKey
+        snakeOilEd25519PublicKey
+        ;
+    in
+    {
+      programs.git = {
+        enable = true;
+        config = {
+          init.defaultBranch = "main";
+          user.name = "gitwatch";
+          user.email = "gitwatch@localhost";
+        };
+      };
+
+      services.openssh = {
+        enable = true;
+        hostKeys = [
+          {
+            type = "ed25519";
+            path = "/etc/ssh/ssh_host_ed25519_key";
+          }
+        ];
+      };
+      environment.etc."ssh/ssh_host_ed25519_key" = {
+        source = snakeOilEd25519PrivateKey;
+        mode = "0600";
+      };
+      users.users.root.openssh.authorizedKeys.keys = [ snakeOilEd25519PublicKey ];
+      systemd.tmpfiles.rules = [
+        "d /root/.ssh 0700 root root -"
+        "C+ /root/.ssh/id_ed25519 0600 root root - ${snakeOilEd25519PrivateKey}"
+      ];
+      programs.ssh = {
+        systemd-ssh-proxy.enable = false;
+        knownHosts.localhost = {
+          hostNames = [
+            "localhost"
+            "127.0.0.1"
+          ];
+          publicKey = snakeOilEd25519PublicKey;
+        };
+      };
+
+      services.gitwatch = {
+        file-remote = {
+          enable = true;
+          path = "/var/lib/gitwatch/file-remote";
+          remote = "/srv/git/file-remote.git";
+          branch = "main";
+          message = "Auto-commit by gitwatch on %d";
+        };
+        ssh-remote = {
+          enable = true;
+          path = "/var/lib/gitwatch/ssh-remote";
+          remote = "ssh://root@localhost/srv/git/ssh-remote.git";
+          branch = "main";
+        };
+      };
+
+      # Started by the test script, once the upstreams exist.
+      systemd.services.gitwatch-file-remote.wantedBy = lib.mkForce [ ];
+      systemd.services.gitwatch-ssh-remote.wantedBy = lib.mkForce [ ];
+    };
+
+  testScript = ''
+    repos = ["file-remote", "ssh-remote"]
+
+    def wait_for_upstream(repo: str, cmd: str) -> None:
+        machine.wait_until_succeeds(f"git --git-dir=/srv/git/{repo}.git {cmd}")
+
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    for repo in repos:
+        machine.succeed(
+            f"git init --bare --initial-branch=main /srv/git/{repo}.git",
+            f"git clone /srv/git/{repo}.git /tmp/{repo}",
+            f"echo initial > /tmp/{repo}/README",
+            f"git -C /tmp/{repo} add README",
+            f"git -C /tmp/{repo} commit -m 'Initial commit'",
+            f"git -C /tmp/{repo} push origin main",
+            f"rm -rf /tmp/{repo}",
+        )
+
+    with subtest("Gitwatch clones the remote when started"):
+        for repo in repos:
+            machine.systemctl(f"start gitwatch-{repo}.service")
+            machine.wait_for_file(f"/var/lib/gitwatch/{repo}/README")
+
+    with subtest("New files are pushed upstream"):
+        for repo in repos:
+            machine.succeed(f"echo hello > /var/lib/gitwatch/{repo}/greeting")
+            wait_for_upstream(repo, "show main:greeting | grep -q '^hello$'")
+
+    with subtest("Modifications are pushed upstream"):
+        for repo in repos:
+            machine.succeed(f"echo goodbye > /var/lib/gitwatch/{repo}/greeting")
+            wait_for_upstream(repo, "show main:greeting | grep -q '^goodbye$'")
+
+    with subtest("Deletions are pushed upstream"):
+        for repo in repos:
+            machine.succeed(f"rm /var/lib/gitwatch/{repo}/greeting")
+            wait_for_upstream(
+                repo, "log -1 --name-status --format= main | grep -q '^D.greeting$'"
+            )
+
+    with subtest("The commit message is configurable"):
+        # `%d` is expanded to the current date by gitwatch.
+        wait_for_upstream(
+            "file-remote",
+            "log --format=%s main | grep -E '^Auto-commit by gitwatch on [0-9]{4}-'"
+        )
+        wait_for_upstream(
+            "ssh-remote",
+            "log --format=%s main | grep -F 'Scripted auto-commit on change'"
+        )
+  '';
+}

--- a/pkgs/by-name/gi/gitwatch/package.nix
+++ b/pkgs/by-name/gi/gitwatch/package.nix
@@ -10,6 +10,8 @@
   gnused,
   openssh,
   inotify-tools,
+
+  nixosTests,
 }:
 runCommand "gitwatch"
   rec {
@@ -22,6 +24,10 @@ runCommand "gitwatch"
       hash = "sha256-O8Qk2fGBAT7NGJYd+PIGOaiDQAnexsDm1y+KFHabQEM=";
     };
     nativeBuildInputs = [ makeWrapper ];
+
+    passthru.tests = {
+      inherit (nixosTests) gitwatch;
+    };
 
     meta = {
       description = "Watch a filesystem and automatically stage changes to a git";


### PR DESCRIPTION
Specifying a message with spaces was not possible earlier due to insufficient quoting.

Wrote a NixOS test to verify that everything works as expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
