### PR TITLE
alibuild: 1.17.42 -> 1.17.44, fix build

### DIFF
--- a/pkgs/by-name/al/alibuild/package.nix
+++ b/pkgs/by-name/al/alibuild/package.nix
@@ -6,20 +6,18 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "alibuild";
-  version = "1.17.42";
+  version = "1.17.44";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-QFNyb6lmTGOaAj4qyDo/mTW7J6LHfALnjo+b0WTllDQ=";
+    hash = "sha256-hLFbxJVOWp1j8pV2v3h7UBZ691EONGb5HNIDrizyq6E=";
   };
 
   build-system = with python3Packages; [
     setuptools
     setuptools-scm
   ];
-
-  nativeBuildInputs = with python3Packages; [ pip ];
 
   dependencies = with python3Packages; [
     requests
@@ -29,9 +27,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
     distro
   ];
 
-  pythonRelaxDeps = [ "boto3" ];
-
-  doCheck = false;
+  postPatch = ''
+    # strip setuptools_scm upper bound limit
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools_scm[toml]>=6.2,<10" "setuptools_scm[toml]>=6.2"
+    substituteInPlace setup.py \
+      --replace-fail "setuptools_scm>=6.2,<10" "setuptools_scm>=6.2"
+  '';
 
   meta = {
     homepage = "https://alisw.github.io/alibuild/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Hydra error log: https://hydra.nixos.org/build/343284566

Release: https://github.com/alisw/alibuild/releases/tag/v1.17.44
Changelog: https://github.com/alisw/alibuild/compare/v1.17.42...v1.17.44

Tested functionality by creating a test workspace to clone the recipes (alidist) and source code using `aliBuild init O2Physics@master` and testing dependencies using `aliDoctor O2Physics`
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
