### PR TITLE
tcpcrypt: fix bug, nixos/tcpcrypt: fix eval, nixos/tests/tcpcrypt: init

### DIFF
--- a/nixos/modules/services/networking/tcpcrypt.nix
+++ b/nixos/modules/services/networking/tcpcrypt.nix
@@ -37,8 +37,12 @@ in
 
     users.users.tcpcryptd = {
       uid = config.ids.uids.tcpcryptd;
+      group = "tcpcryptd";
+      isSystemUser = true;
       description = "tcpcrypt daemon user";
     };
+
+    users.groups.tcpcryptd = { };
 
     systemd.services.tcpcrypt = {
       description = "tcpcrypt";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1873,6 +1873,7 @@ in
   taskchampion-sync-server = runTest ./taskchampion-sync-server.nix;
   taskserver = runTest ./taskserver.nix;
   tayga = runTest ./tayga.nix;
+  tcpcrypt = runTest ./tcpcrypt.nix;
   tdarr = runTest ./tdarr.nix;
   technitium-dns-server = runTest ./technitium-dns-server.nix;
   teeworlds = runTest ./teeworlds.nix;

--- a/nixos/tests/tcpcrypt.nix
+++ b/nixos/tests/tcpcrypt.nix
@@ -1,0 +1,111 @@
+{ lib, ... }:
+{
+  name = "tcpcrypt";
+  meta.maintainers = [ lib.maintainers.h7x4 ];
+
+  nodes = {
+    server =
+      {
+        config,
+        pkgs,
+        lib,
+        ...
+      }:
+      {
+        networking.tcpcrypt.enable = true;
+        networking.firewall.allowedTCPPorts = map lib.toInt config.systemd.sockets.echo.listenStreams;
+
+        environment.systemPackages = [ pkgs.tcpcrypt ];
+
+        systemd.sockets.echo = {
+          wantedBy = [ "sockets.target" ];
+          listenStreams = [
+            "4242"
+            "4243"
+          ];
+          socketConfig.Accept = true;
+        };
+
+        systemd.services."echo@".serviceConfig = {
+          ExecStart = lib.getExe' pkgs.coreutils "cat";
+          StandardInput = "socket";
+        };
+
+        specialisation.without-tcpcrypt.configuration = {
+          networking.tcpcrypt.enable = lib.mkForce false;
+        };
+      };
+
+    client =
+      { pkgs, ... }:
+      {
+        networking.tcpcrypt.enable = true;
+
+        environment.systemPackages = [
+          pkgs.tcpcrypt
+          pkgs.socat
+        ];
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      port1 = lib.elemAt nodes.server.systemd.sockets.echo.listenStreams 0;
+      port2 = lib.elemAt nodes.server.systemd.sockets.echo.listenStreams 1;
+    in
+    ''
+      def test_connection(message: str, port: int) -> None:
+          client.succeed("truncate -s 0 /tmp/reply")
+          client.succeed(
+              "systemd-run "
+              "--collect "
+              "--setenv=PATH=/run/current-system/sw/bin "
+              "--property=Type=oneshot "
+              "--no-block "
+              f"socat TCP:server:{port} SYSTEM:'echo {message}; cat > /tmp/reply'"
+          )
+          client.wait_until_succeeds(f"grep -q {message} /tmp/reply")
+
+      def session_id(machine: BaseMachine, port: int) -> str | None:
+          for line in machine.succeed("tcnetstat").splitlines()[1:]:
+              local, foreign, sid = line.split()
+              if local.endswith(f":{port}") or foreign.endswith(f":{port}"):
+                  return sid
+          return None
+
+      start_all()
+
+      server.wait_for_unit("tcpcrypt.service")
+      server.wait_for_unit("echo.socket")
+      client.wait_for_unit("tcpcrypt.service")
+
+      with subtest("Traffic is diverted to tcpcryptd"):
+          for machine in [server, client]:
+              machine.succeed("iptables -t raw -C PREROUTING -j nixos-tcpcrypt")
+              machine.succeed("iptables -t mangle -C POSTROUTING -j nixos-tcpcrypt")
+
+      with subtest("Connection is encrypted"):
+          test_connection("encrypted", ${port1})
+          sid = session_id(client, ${port1})
+          assert sid is not None, "client negotiated no tcpcrypt session"
+          assert len(bytes.fromhex(sid)) > 0
+
+          assert sid == session_id(server, ${port1}), "session ids differ between the two ends"
+
+      with subtest("Firewall rules are removed"):
+          server.succeed(
+              "/run/current-system/specialisation/without-tcpcrypt/bin/switch-to-configuration test"
+          )
+          server.wait_until_fails("systemctl is-active tcpcrypt.service")
+          server.fail("iptables -t raw -C PREROUTING -j nixos-tcpcrypt")
+          server.fail("iptables -t mangle -C POSTROUTING -j nixos-tcpcrypt")
+          server.fail("iptables -t raw -L nixos-tcpcrypt")
+          server.fail("iptables -t mangle -L nixos-tcpcrypt")
+
+      with subtest("Fallback to plaintext"):
+          server.wait_for_unit("echo.socket")
+          test_connection("plaintext", ${port2})
+          assert session_id(client, ${port2}) is None, "client negotiated tcpcrypt with a plain host"
+    '';
+}

--- a/pkgs/by-name/tc/tcpcrypt/package.nix
+++ b/pkgs/by-name/tc/tcpcrypt/package.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation (finalAttrs: {
     libnetfilter_queue
   ];
 
+  # https://github.com/sorbo/tcpcrypt/blob/b2673e88570d3370e6b37698f58d5ee9bb116d8d/user/src/checksum.c#L64
+  #
+  # in_cksum() casts a `struct tcp_ph` through `unsigned short *`, so with
+  # strict aliasing and optimization enabled, GCC breaks the program.
+  env.CFLAGS = "-O2 -fno-strict-aliasing";
+
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/by-name/tc/tcpcrypt/package.nix
+++ b/pkgs/by-name/tc/tcpcrypt/package.nix
@@ -9,6 +9,7 @@
   libnfnetlink,
   libnetfilter_conntrack,
   libnetfilter_queue,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -48,6 +49,8 @@ stdenv.mkDerivation (finalAttrs: {
   env.CFLAGS = "-O2 -fno-strict-aliasing";
 
   enableParallelBuilding = true;
+
+  passthru.tests.nixos = nixosTests.tcpcrypt;
 
   meta = {
     broken = stdenv.hostPlatform.isDarwin;


### PR DESCRIPTION
Compilation produced broken code

Module didn't eval anymore after treating the `nogroup` default as an error.

The test ensures that the software works as intended, with automatic encryption for two hosts running tcpcrypt and automatic defaulting back to plaintext when one part does not run tcpcrypt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
