### PR TITLE
nixos/nftables: document flushRuleset default

### DIFF
--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -121,7 +121,17 @@ in
       '';
     };
 
-    networking.nftables.flushRuleset = lib.mkEnableOption "flushing the entire ruleset on each reload";
+    networking.nftables.flushRuleset = lib.mkOption {
+      type = lib.types.bool;
+      description = "flushing the entire ruleset on each reload";
+      default =
+        lib.versionOlder config.system.stateVersion "23.11"
+        || (cfg.rulesetFile != null || cfg.ruleset != "");
+      defaultText = lib.literalExpression ''
+        lib.versionOlder config.system.stateVersion "23.11"
+        || (config.networking.nftables.rulesetFile != null || config.networking.nftables.ruleset != "")
+      '';
+    };
 
     networking.nftables.extraDeletions = lib.mkOption {
       type = lib.types.lines;
@@ -187,7 +197,7 @@ in
         The ruleset to be used with nftables.  Should be in a format that
         can be loaded using "/bin/nft -f".  The ruleset is updated atomically.
         Note that if the tables should be cleaned first, either:
-        - networking.nftables.flushRuleset = true; needs to be set (flushes all tables)
+        - networking.nftables.flushRuleset = true; needs to be set, and will be by default when this rulset is defined.
         - networking.nftables.extraDeletions needs to be set
         - or networking.nftables.tables can be used, which will clean up the table automatically
       '';
@@ -276,11 +286,6 @@ in
   config = lib.mkIf cfg.enable {
     boot.blacklistedKernelModules = [ "ip_tables" ];
     environment.systemPackages = [ pkgs.nftables ];
-    # versionOlder for backportability, remove afterwards
-    networking.nftables.flushRuleset = lib.mkDefault (
-      lib.versionOlder config.system.stateVersion "23.11"
-      || (cfg.rulesetFile != null || cfg.ruleset != "")
-    );
     systemd.services.nftables = {
       description = "nftables firewall";
       after = [ "sysinit.target" ];


### PR DESCRIPTION
This is currently a hidden default.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
