### PR TITLE
nixos/tests/distccd: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -542,6 +542,7 @@ in
     imports = [ ./discourse.nix ];
     _module.args.package = pkgs.discourseAllPlugins;
   };
+  distccd = runTest ./distccd.nix;
   dnscrypt-proxy = runTestOn [ "x86_64-linux" ] ./dnscrypt-proxy.nix;
   dnsdist = import ./dnsdist.nix { inherit pkgs runTest; };
   doas = runTest ./doas.nix;

--- a/nixos/tests/distccd.nix
+++ b/nixos/tests/distccd.nix
@@ -1,0 +1,71 @@
+{
+  pkgs,
+  lib,
+  containers,
+  ...
+}:
+{
+  name = "distccd";
+  meta.maintainers = [ lib.maintainers.h7x4 ];
+
+  containers = {
+    server =
+      { containers, ... }:
+      {
+        services.distccd = {
+          enable = true;
+          allowedClients = [ containers.client.networking.primaryIPAddress ];
+          logLevel = "info";
+          openFirewall = true;
+        };
+      };
+
+    client =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = with pkgs; [
+          distcc
+          gcc
+        ];
+
+        environment.variables = {
+          DISTCC_HOSTS = "server";
+          # Don't compile locally
+          DISTCC_FALLBACK = "0";
+        };
+      };
+  };
+
+  testScript =
+    let
+      hello = pkgs.writeText "hello.c" ''
+        #include <stdio.h>
+
+        int main(void) {
+          printf("hello from distcc\n");
+          return 0;
+        }
+      '';
+    in
+    ''
+      start_all()
+
+      server.wait_for_unit("distccd.service")
+      server.wait_for_open_port(3632)
+
+      client.systemctl("start network-online.target")
+      client.wait_for_unit("network-online.target")
+      client.succeed("ping -n -c 1 server")
+
+      with subtest("Compile a C program on the client, offloading to the server"):
+          client.succeed("cd /tmp && distcc gcc -c ${hello} -o hello.o")
+          client.succeed("cd /tmp && gcc hello.o -o hello && ./hello")
+
+      with subtest("Verify with server logs that it ran the compilation"):
+          journal = server.succeed("journalctl -u distccd --no-pager")
+          assert "COMPILE_OK" in journal, f"distccd did not report a successful compile:\n{journal}"
+          assert (
+              "${containers.client.networking.primaryIPAddress}" in journal
+          ), f"distccd did not serve the client:\n{journal}"
+    '';
+}

--- a/pkgs/development/tools/misc/distcc/default.nix
+++ b/pkgs/development/tools/misc/distcc/default.nix
@@ -16,6 +16,7 @@
   libiberty_static,
   runtimeShell,
   gitUpdater,
+  nixosTests,
   sysconfDir ? "", # set this parameter to override the default value $out/etc
   static ? false,
 }:
@@ -97,6 +98,7 @@ let
           fi
         '');
 
+      tests.nixos = nixosTests.distccd;
       updateScript = gitUpdater {
         rev-prefix = "v";
       };


### PR DESCRIPTION
Adds a NixOS test compiling a small C program where the compilation is offloaded to distccd on another host.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
