### PR TITLE
yarn-berry: patch `got` dependency

### DIFF
--- a/pkgs/by-name/ya/yarn-berry/got-npm-11.8.2.patch
+++ b/pkgs/by-name/ya/yarn-berry/got-npm-11.8.2.patch
@@ -1,0 +1,49 @@
+diff --git a/dist/source/as-promise/index.js b/dist/source/as-promise/index.js
+index 9575c09d653037596ddf945afccedbbc672c4ee6..4560ce3bdcfdca11b7eaeaba1ff83a28f7a0caac 100644
+--- a/dist/source/as-promise/index.js
++++ b/dist/source/as-promise/index.js
+@@ -30,6 +30,7 @@ function asPromise(normalizedOptions) {
+     let globalRequest;
+     let globalResponse;
+     const emitter = new events_1.EventEmitter();
++    let promiseSettled = false;
+     const promise = new PCancelable((resolve, reject, onCancel) => {
+         const makeRequest = (retryCount) => {
+             const request = new core_1.default(undefined, normalizedOptions);
+@@ -37,7 +38,10 @@ function asPromise(normalizedOptions) {
+             request._noPipe = true;
+             onCancel(() => request.destroy());
+             onCancel.shouldReject = false;
+-            onCancel(() => reject(new types_1.CancelError(request)));
++            onCancel(() => {
++                promiseSettled = true;
++                reject(new types_1.CancelError(request))
++            });
+             globalRequest = request;
+             request.once('response', async (response) => {
+                 var _a;
+@@ -118,12 +122,14 @@ function asPromise(normalizedOptions) {
+                     return;
+                 }
+                 globalResponse = response;
++                promiseSettled = true;
+                 resolve(request.options.resolveBodyOnly ? response.body : response);
+             });
+             const onError = (error) => {
+                 if (promise.isCanceled) {
+                     return;
+                 }
++                promiseSettled = true;
+                 const { options } = request;
+                 if (error instanceof types_1.HTTPError && !options.throwHttpErrors) {
+                     const { response } = error;
+@@ -135,6 +141,9 @@ function asPromise(normalizedOptions) {
+             request.once('error', onError);
+             const previousBody = request.options.body;
+             request.once('retry', (newRetryCount, error) => {
++                if (promiseSettled) {
++                    return;
++                }
+                 var _a, _b;
+                 if (previousBody === ((_a = error.request) === null || _a === void 0 ? void 0 : _a.options.body) && is_1.default.nodeStream((_b = error.request) === null || _b === void 0 ? void 0 : _b.options.body)) {
+                     onError(error);

--- a/pkgs/by-name/ya/yarn-berry/package.nix
+++ b/pkgs/by-name/ya/yarn-berry/package.nix
@@ -1,5 +1,7 @@
 {
   fetchFromGitHub,
+  unzip,
+  zip,
   lib,
   pkgs,
   nodejs,
@@ -35,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     yarn
+    unzip
+    zip
   ];
 
   strictDeps = true;
@@ -43,6 +47,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildPhase = ''
     runHook preBuild
+
+    (
+      # Remove when Yarn updates or removes the `got` dependency
+      # https://github.com/yarnpkg/berry/issues/7245#issuecomment-5538874542
+      GOT_CACHE_PATH=$(printf '%s' $(pwd)/.yarn/cache/got-npm-11.8.2-c1eb105458-*.zip)
+      cd $(mktemp -d)
+      unzip $GOT_CACHE_PATH -d .
+      rm $GOT_CACHE_PATH
+      patch -p1 -d node_modules/got < ${./got-npm-11.8.2.patch}
+      zip -Xr got-patched.zip node_modules
+      mv got-patched.zip $GOT_CACHE_PATH
+    )
+
     yarn workspace @yarnpkg/cli build:cli
     runHook postBuild
   '';


### PR DESCRIPTION
## Things done

Addresses https://github.com/NixOS/nixpkgs/pull/560469#issuecomment-5595878948 build failures

For details: https://github.com/yarnpkg/berry/issues/7245#issuecomment-5538874542

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
