### PR TITLE
loguru: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/by-name/lo/loguru/package.nix
+++ b/pkgs/by-name/lo/loguru/package.nix
@@ -2,34 +2,20 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "loguru";
-  version = "2.1.0-unstable-2023-04-06";
+  version = "2.2.0";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "emilk";
     repo = "loguru";
-    rev = "4adaa185883e3c04da25913579c451d3c32cfac1";
-    hash = "sha256-NpMKyjCC06bC5B3xqgDr2NgA9RsPEeiWr9GbHrHHzZ8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-b1aBpeIsHd/RxQkWZFFYnbg7yHI14Rfnz7k6C65vgq0=";
   };
-
-  patches = [
-    # See https://github.com/emilk/loguru/issues/249
-    # The following patches are coming from a fork and fix builds on Darwin
-    # Hopefully they will be merged in the main repository soon.
-    (fetchpatch {
-      url = "https://github.com/virtuosonic/loguru/commit/e1ffdc4149083cc221d44b666a0f7e3ec4a87259.patch";
-      hash = "sha256-fYdS8+qfgyj1J+T6H434jDGK/L+VYq+L22CQ7M/uiXE=";
-    })
-    (fetchpatch {
-      url = "https://github.com/virtuosonic/loguru/commit/743777bea361642349d4673e6a0a55912849c14f.patch";
-      hash = "sha256-3FhH7zdkzHuXSirSCr8A3uHg8UpSfEM02AkR0ZSG0Yw=";
-    })
-  ];
 
   cmakeFlags = [
     "-DLOGURU_WITH_STREAMS=1"
@@ -43,7 +29,7 @@ stdenv.mkDerivation {
     description = "Lightweight C++ logging library";
     homepage = "https://github.com/emilk/loguru";
     license = lib.licenses.unlicense;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ drupol ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
