### PR TITLE
comfyui: 0.34.1 -> 0.35.0 

### DIFF
--- a/pkgs/by-name/co/comfyui/package.nix
+++ b/pkgs/by-name/co/comfyui/package.nix
@@ -74,7 +74,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "comfyui";
-  version = "0.34.1";
+  version = "0.35.0";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -83,7 +83,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "Comfy-Org";
     repo = "ComfyUI";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ep0ghTptdzn82a5Mwwgzu4Ka7v7PrNBb3pAWqrykdcM=";
+    hash = "sha256-ffT9euBDsxpmq4wzd9R2QUcCgI/YnfQOsvC5HuAekUM=";
   };
 
   nativeBuildInputs = [ makeBinaryWrapper ];

--- a/pkgs/development/python-modules/comfy-aimdo/default.nix
+++ b/pkgs/development/python-modules/comfy-aimdo/default.nix
@@ -21,14 +21,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "comfy-aimdo";
-  version = "0.4.15";
+  version = "0.5.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Comfy-Org";
     repo = "comfy-aimdo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-R16WN7C4TOPVJmrwONNCb9szAUB6qz5Ytj+o2yZ7QDQ=";
+    hash = "sha256-oHK1+kwPbfhCS5WBo2qCvCWH+t6B6MKvevpcsD9JflE=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/comfy-kitchen/default.nix
+++ b/pkgs/development/python-modules/comfy-kitchen/default.nix
@@ -17,7 +17,7 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "comfy-kitchen";
-  version = "0.2.31";
+  version = "0.2.33";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -25,7 +25,7 @@ buildPythonPackage (finalAttrs: {
     repo = "comfy-kitchen";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-apa7N9Y0bt4fpbMTP0qRUC0QnMuJvoxoCOeWONWCExo=";
+    hash = "sha256-2wiUIF6zWSn8y/FK0czuKcuH5wD1HWNhyiQ2yC7AFT4=";
   };
 
   buildInputs = lib.optionals cudaSupport (

--- a/pkgs/development/python-modules/comfyui-embedded-docs/default.nix
+++ b/pkgs/development/python-modules/comfyui-embedded-docs/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-embedded-docs";
-  version = "0.5.10";
+  version = "0.5.11";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_embedded_docs";
     inherit (finalAttrs) version;
-    hash = "sha256-n+rSPl4vztj+Wz0oVbPNPGmvziYeHyh0fbEh03NaKuo=";
+    hash = "sha256-HetjmoWqXFY7ULa+ImvTPbG7OpeReI0sP7TYiMwv2n0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/comfyui-frontend-package/default.nix
+++ b/pkgs/development/python-modules/comfyui-frontend-package/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-frontend-package";
-  version = "1.49.6";
+  version = "1.51.10";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_frontend_package";
     inherit (finalAttrs) version;
-    hash = "sha256-CBChUGNYpF4PHwLAaPn4ISBXmC+A1/IFmuYU563mWNk=";
+    hash = "sha256-li4bsdMGeQawCcYLyys1vL2ux0YCFyuXJ0Ww+ymNjcc=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/comfyui-workflow-templates-core/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-core/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-workflow-templates-core";
-  version = "0.3.322";
+  version = "0.3.337";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_workflow_templates_core";
     inherit (finalAttrs) version;
-    hash = "sha256-+odtVI5o5YP+u5P4T90NaWTSFlxtBm9XxYXyai8r0yk=";
+    hash = "sha256-JqN1DwmBwar8gT5U4FP7/W5e6YQTLqlgcM1fOl9l2fM=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/comfyui-workflow-templates-json/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-json/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-workflow-templates-json";
-  version = "0.1.57";
+  version = "0.1.72";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_workflow_templates_json";
     inherit (finalAttrs) version;
-    hash = "sha256-IvtKBhnYRqreS2w8t7xJE65F97B3Aai9+MWYR+CdINw=";
+    hash = "sha256-m35dJtD1KYDmGkhLG5I9/dXKd2Pq9U6pJLn655SmpiA=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/comfyui-workflow-templates-media-assets-01/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates-media-assets-01/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-workflow-templates-media-assets-01";
-  version = "0.1.35";
+  version = "0.1.43";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_workflow_templates_media_assets_01";
     inherit (finalAttrs) version;
-    hash = "sha256-xrzUGrvjhWyUhYxs4H2QNIf5PsbEBXTsu4OU3eEkk6M=";
+    hash = "sha256-QJYhpsaQmLfgaE+9bLDOmeKXhp6nw7VOKdbQquRX+Hk=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "comfyui-workflow-templates";
-  version = "0.11.48";
+  version = "0.11.57";
   pyproject = true;
 
   src = fetchPypi {
     pname = "comfyui_workflow_templates";
     inherit (finalAttrs) version;
-    hash = "sha256-UQ/tuOOO9504uDc5kFfaJN6CnwbKCZUL6WxprxQlVD8=";
+    hash = "sha256-oGnYJKPnU8YDJI30/w3c7GjogQOsaik10mIZ+u8ndiI=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
