### PR TITLE
cadabra2: fix build

### DIFF
--- a/pkgs/by-name/ca/cadabra2/package.nix
+++ b/pkgs/by-name/ca/cadabra2/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
 
   cmake,
   pkg-config,
@@ -50,6 +51,18 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
     hash = "sha256-Pbk9SmJ64CZ+yxMj53JpxULBQye2ETDi8xNKw38cC9k=";
   };
+
+  patches = [
+    # Backport a MicroTeX fix for fontconfig >= 2.18.
+    # Remove once cadabra2 updates its MicroTeX submodule to 7944eb4 or later.
+    (fetchpatch2 {
+      name = "microtex-fix-recent-fontconfig-build.patch";
+      url = "https://github.com/kpeeters/MicroTeX/commit/7944eb496dec1b7ff8af4c13e0cfee279eea30b8.patch?full_index=1";
+      extraPrefix = "submodules/microtex/";
+      stripLen = 1;
+      hash = "sha256-mobQF8uZGF1bdddYoyAxrZ4XhbMwUuK8kLwjmVrZZh0=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Hydra error log: https://hydra.nixos.org/build/344945890

The compilation fails because the bundled microtex submodule's Cairo backend uses FcFreeTypeQuery without explicitly including Fontconfig's FreeType header. Recent Fontconfig and toolchain updates no longer provide this via transitive inclusion.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
