### PR TITLE
nextcloud-talk-desktop: 2.2.3 -> 2.2.4, fix screenshare issue

### DIFF
--- a/pkgs/by-name/ne/nextcloud-talk-desktop/package.nix
+++ b/pkgs/by-name/ne/nextcloud-talk-desktop/package.nix
@@ -29,14 +29,15 @@
   undmg,
   makeWrapper,
   libpulseaudio,
+  pipewire,
 }:
 let
   pname = "nextcloud-talk-desktop";
-  version = "2.2.3"; # Ensure both hashes (Linux and Darwin) are updated!
+  version = "2.2.4"; # Ensure both hashes (Linux and Darwin) are updated!
 
   hashes = {
-    linux = "sha256-6YoAlMGKPeSJoXd211cufdE/XgroojH3djwaSEwlBjs=";
-    darwin = "sha256-BpyVJXyCYC1qH4ecDobHBVLLTeVDx/MPWBsnXgrnKhE=";
+    linux = "sha256-veIuQqxLxhvJuezJ1dL0+ranMrf9p3YEJ2hFhzuZj0I=";
+    darwin = "sha256-YLD4adfWlRRndQMjSXxERK1aCjLUVq0YoV9bJyu+0BA=";
   };
 
   # Only x86_64-linux is supported with Darwin support being universal
@@ -113,6 +114,9 @@ let
 
       # Fixes input/output audio device selection
       libpulseaudio
+
+      # Electron dynamically loads PipeWire for Wayland screen sharing.
+      pipewire
     ];
 
     desktopItems = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/nextcloud/talk-desktop/releases/tag/v2.2.4

Also fixes an issue where the app was not allowing me to sharescreen, adding pipewire fixed that.

Supersedes: https://github.com/NixOS/nixpkgs/pull/553280

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
