### PR TITLE
cobra-cli: fix changelog url

### DIFF
--- a/pkgs/by-name/co/cobra-cli/package.nix
+++ b/pkgs/by-name/co/cobra-cli/package.nix
@@ -57,7 +57,7 @@ buildGoModule (finalAttrs: {
     description = "Cobra CLI tool to generate applications and commands";
     mainProgram = "cobra-cli";
     homepage = "https://github.com/spf13/cobra-cli/";
-    changelog = "https://github.com/spf13/cobra-cli/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/spf13/cobra-cli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.afl20;
     maintainers = [ lib.maintainers.ivankovnatsky ];
   };


### PR DESCRIPTION
changelog url returned 404, previous url lacked the v prefix of the version so I added it to the url to match the actual changelog url

related to #514132

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
