### PR TITLE
kdePackages.k3b: add /run/wrappers/bin to the PATH

### DIFF
--- a/nixos/modules/programs/k3b.nix
+++ b/nixos/modules/programs/k3b.nix
@@ -15,10 +15,7 @@
 
         Additionally to installing `k3b` enabling this will
         add `setuid` wrappers in `/run/wrappers/bin`
-        for both `cdrdao` and `cdrecord`. On first
-        run you must manually configure the path of `cdrdae` and
-        `cdrecord` to correspond to the appropriate paths under
-        `/run/wrappers/bin` in the "Setup External Programs" menu.
+        for both `cdrdao` and `cdrecord`.
       '';
     };
   };
@@ -48,6 +45,5 @@
         source = "${pkgs.cdrtools}/bin/cdrecord";
       };
     };
-
   };
 }

--- a/pkgs/kde/gear/k3b/default.nix
+++ b/pkgs/kde/gear/k3b/default.nix
@@ -42,7 +42,7 @@ mkKdeDerivation {
   ];
 
   qtWrapperArgs = [
-    "--prefix PATH : ${
+    "--prefix PATH : /run/wrappers/bin:${
       lib.makeBinPath [
         cdrdao
         cdrtools


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This fixes an issue where you have to imperatively set these values by hand.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
