### PR TITLE
vivaldi: 8.1.4087.75 -> 8.2.4133.47

### DIFF
--- a/pkgs/by-name/vi/vivaldi/package.nix
+++ b/pkgs/by-name/vi/vivaldi/package.nix
@@ -172,10 +172,6 @@ stdenv.mkDerivation rec {
         --set-rpath "${libPath}" \
         opt/vivaldi/$f
     done
-
-    for f in libqt5_shim.so libqt6_shim.so; do
-      patchelf --set-rpath "${libPath}" opt/vivaldi/$f
-    done
   ''
   + lib.optionalString proprietaryCodecs ''
     ln -s ${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so opt/vivaldi/libffmpeg.so.''${version%\.*\.*}

--- a/pkgs/by-name/vi/vivaldi/package.nix
+++ b/pkgs/by-name/vi/vivaldi/package.nix
@@ -66,7 +66,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vivaldi";
-  version = "8.1.4087.75";
+  version = "8.2.4133.47";
 
   suffix =
     {
@@ -79,8 +79,8 @@ stdenv.mkDerivation rec {
     url = "https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-1_${suffix}.deb";
     hash =
       {
-        aarch64-linux = "sha256-MyGnFbWXjbD5TzHzlXyV1Qg17dx/MjjNWRDRieqksCw=";
-        x86_64-linux = "sha256-nLfNB2SB3Z7PQ0gRXbegQ0JD6RHie2EVdQkuNLLUiZw=";
+        aarch64-linux = "sha256-oyS7p7B8kxRPl0KxXuWQBgEhIPkP36vI6MNDRfkl7UY=";
+        x86_64-linux = "sha256-St7C8XxA1PIegF1JDUoPHV9Q/UBuemKzcRfLQqWKX24=";
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
@@ -173,7 +173,7 @@ stdenv.mkDerivation rec {
         opt/vivaldi/$f
     done
 
-    for f in libGLESv2.so libqt5_shim.so libqt6_shim.so; do
+    for f in libqt5_shim.so libqt6_shim.so; do
       patchelf --set-rpath "${libPath}" opt/vivaldi/$f
     done
   ''


### PR DESCRIPTION
libGLESv2.so no longer ships with the 8.2 release; remove it from the rpath patch list.


[Changelog](https://vivaldi.com/fr/changelog-vivaldi-browser-8-2/)

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].