### PR TITLE
libhwy: fix CMake config

### DIFF
--- a/pkgs/by-name/li/libhwy/package.nix
+++ b/pkgs/by-name/li/libhwy/package.nix
@@ -82,6 +82,11 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 hwy/tests/*.h -t $out/include/hwy/tests/
   '';
 
+  postFixup = ''
+    substituteInPlace $dev/lib/cmake/hwy/hwy-config-release.cmake \
+      --replace-fail "\''${_IMPORT_PREFIX}/lib" "$out/lib"
+  '';
+
   # hydra's darwin machines run into https://github.com/libjxl/libjxl/issues/408
   doCheck = !stdenv.hostPlatform.isDarwin;
 


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nixpkgs/pull/557544#issuecomment-5623092289

I've used `nix-shell -I nixpkgs=$HOME/Documents/nixpkgs -p cmake libhwy --run "printf 'cmake_minimum_required(VERSION 3.10)\nproject(test)\nfind_package(hwy REQUIRED)\n' > CMakeLists.txt && cmake ."` to reproduce.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
