### PR TITLE
nix-store-veritysetup-generator: 1.0.1 -> 1.1.0

### DIFF
--- a/nixos/modules/system/boot/nix-store-veritysetup.nix
+++ b/nixos/modules/system/boot/nix-store-veritysetup.nix
@@ -7,6 +7,8 @@
 
 let
   cfg = config.boot.initrd.nix-store-veritysetup;
+
+  json = pkgs.formats.json { };
 in
 {
   meta.maintainers = with lib.maintainers; [ nikstur ];
@@ -27,6 +29,15 @@ in
       contents = {
         "/etc/systemd/system-generators/nix-store-veritysetup-generator".source =
           "${lib.getExe pkgs.nix-store-veritysetup-generator}";
+
+        "/etc/systemd/generator-environment.json".source =
+          json.generate "systemd-generator-environment.json"
+            {
+              SYSTEMD_VERITYSETUP_PATH = "${config.boot.initrd.systemd.package}/lib/systemd/systemd-veritysetup";
+            };
+
+        "/etc/systemd/system-environment-generators/env-generator".source =
+          "${config.system.nixos-init.package}/bin/env-generator";
       };
 
       storePaths = [

--- a/pkgs/by-name/ni/nix-store-veritysetup-generator/package.nix
+++ b/pkgs/by-name/ni/nix-store-veritysetup-generator/package.nix
@@ -8,23 +8,22 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nix-store-veritysetup-generator";
-  version = "1.0.1";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "nikstur";
     repo = "nix-store-veritysetup-generator";
-    rev = finalAttrs.version;
-    hash = "sha256-4VIPyhvPKRlEgX7roUMIyhSBqfrWPbbsdhyccxH8EIM=";
+    tag = finalAttrs.version;
+    hash = "sha256-xZNUqbI6a+RJfaJXBQYf5pAJNIiQdJ1PybeDR0TAfjk=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/rust";
 
-  cargoHash = "sha256-nL9GiluLV12J/Kwkq2gAYmOWtPr6sG4ELoLj3UCgDtg=";
+  cargoHash = "sha256-ZTTHeScm4bSWfKHNgmfsxuBS6zTgn7OpFGiBYo0vcfY=";
 
-  env = {
-    SYSTEMD_VERITYSETUP_PATH = "${systemd}/lib/systemd/systemd-veritysetup";
-    SYSTEMD_ESCAPE_PATH = "${systemd}/bin/systemd-escape";
-  };
+  nativeCheckInputs = [
+    systemd
+  ];
 
   # Use a fake path in tests so that they are not dependent on specific Nix
   # Store paths and thus don't break on different Nixpkgs invocations. This is
@@ -42,6 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Systemd unit generator for a verity protected Nix Store";
     homepage = "https://github.com/nikstur/nix-store-veritysetup-generator";
+    changelog = "https://github.com/nikstur/nix-store-veritysetup-generator/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ nikstur ];
     mainProgram = "nix-store-veritysetup-generator";


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
