### PR TITLE
sby: 0.68 -> 0.69

### DIFF
--- a/pkgs/by-name/sb/sby/package.nix
+++ b/pkgs/by-name/sb/sby/package.nix
@@ -20,13 +20,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sby";
-  version = "0.68";
+  version = "0.69";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "sby";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WRZp4+gwUgDKCWAdBK/36ArM2KFGyLBZ20S32k7YN+8=";
+    hash = "sha256-BNxSMDtfnNrIOrXYxXD7XAHNJUGifEFRYrYpyteAMHQ=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/sb/sby/package.nix
+++ b/pkgs/by-name/sb/sby/package.nix
@@ -13,7 +13,9 @@
 }:
 
 let
-  pythonEnv = python3.withPackages (ps: with ps; [ click ]);
+  pythonDeps = ps: with ps; [ click ];
+  pythonEnv = python3.withPackages pythonDeps;
+  checkPythonEnv = python3.withPackages (ps: pythonDeps ps ++ [ ps.xmlschema ]);
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -68,8 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeCheckInputs = [
-    python3
-    python3.pkgs.xmlschema
+    checkPythonEnv
     yosys
     yices
     z3

--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
-    patchShebangs tests
+    patchShebangs tests ./misc/yosys-config.in
     substituteInPlace tests/aiger/generate_mk.py \
       --replace-fail 'SHELL := /usr/bin/env bash' 'SHELL := ${stdenv.shell}'
   ''

--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -122,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ]
   ++ lib.optionals enablePython [
-    python3
+    pythonEnv
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
As far as version upgrade this is just a retag of v0.68 https://github.com/YosysHQ/sby/compare/v0.68...v0.69

But also, this:
* fixes sby test not actually running anything
* fixes yosys-ghdl and yosys-bluespec not building (also addressed in https://github.com/NixOS/nixpkgs/pull/559059)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
