### PR TITLE
microcad: support darwin

### DIFF
--- a/pkgs/by-name/mi/microcad/package.nix
+++ b/pkgs/by-name/mi/microcad/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromCodeberg,
   rustPlatform,
   pkg-config,
@@ -7,7 +8,6 @@
   cmake,
   ninja,
 }:
-
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "microcad";
   version = "0.5.0";
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ninja
     pkg-config
   ];
-  buildInputs = [ wayland ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ wayland ];
   cargoBuildFlags = [
     "-p"
     "microcad-viewer"
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.agpl3Plus;
     mainProgram = "microcad";
     donationPage = "https://opencollective.com/microcad/donate";
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ fred441a ];
   };
 })


### PR DESCRIPTION
Adds Darwin support to the `microcad` package.

Tested on macOS 15.7.4.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
