### PR TITLE
nixos/coder: add url to Coder configuration reference

### DIFF
--- a/nixos/modules/services/web-apps/coder.nix
+++ b/nixos/modules/services/web-apps/coder.nix
@@ -11,6 +11,7 @@ with lib;
 let
   cfg = config.services.coder;
   name = "coder";
+  configRefUrl = "https://coder.com/docs/@main/admin/setup/configuration-reference";
 in
 {
   options = {
@@ -82,7 +83,10 @@ in
       environment = {
         extra = mkOption {
           type = types.attrs;
-          description = "Extra environment variables to pass run Coder's server with. See Coder documentation.";
+          description = ''
+            Extra environment variables to pass run Coder's server with.
+            See [Coder configuration reference](${configRefUrl}).
+          '';
           default = { };
           example = {
             CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS = true;
@@ -91,7 +95,10 @@ in
         };
         file = mkOption {
           type = types.nullOr types.path;
-          description = "Systemd environment file to add to Coder.";
+          description = ''
+            Systemd environment file to add to Coder.
+            See [Coder configuration reference](${configRefUrl}).
+          '';
           default = null;
         };
       };


### PR DESCRIPTION
linked to `@main` documentation so that link stays hopefully stable

**EDIT:** sorry, the ping to GitHub user `@main` was not intended


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
