### PR TITLE
jarl: 0.5.0 -> 0.6.0-unstable-2026-08-30

### DIFF
--- a/pkgs/by-name/ja/jarl/package.nix
+++ b/pkgs/by-name/ja/jarl/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   git,
+  installShellFiles,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -26,7 +27,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-TnpkGOs8/IFJ1trzMijOTmX3BR2P3GsBhyv0GVCwHsc=";
 
   # integrations test require git at build time (jarl >= 0.5.0)
-  nativeBuildInputs = [ git ];
+  nativeBuildInputs = [
+    git
+    installShellFiles
+  ];
 
   # Don't run integration_tests for jarl-lsp, because it doesn't see
   # the CARGO_BIN_EXE_jarl env var even if exported in preCheck
@@ -40,7 +44,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
 
+  # TODO: Upstream also provides Elvish and PowerShell completions,
+  # but `installShellCompletion` only has support for Bash, Zsh and Fish at the moment.
   postInstall = ''
+    installShellCompletion --cmd jarl \
+      --bash <(COMPLETE=bash $out/bin/jarl) \
+      --fish <(COMPLETE=fish $out/bin/jarl) \
+      --zsh <(COMPLETE=zsh $out/bin/jarl) \
+
     rm $out/bin/xtask_codegen
   '';
 

--- a/pkgs/by-name/ja/jarl/package.nix
+++ b/pkgs/by-name/ja/jarl/package.nix
@@ -3,19 +3,17 @@
   rustPlatform,
   fetchFromGitHub,
   git,
-  versionCheckHook,
-  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "jarl";
-  version = "0.5.0";
+  version = "0.6.0-unstable-2026-08-30"; # TODO revert unstable with next version
 
   src = fetchFromGitHub {
     owner = "etiennebacher";
     repo = "jarl";
-    tag = finalAttrs.version;
-    hash = "sha256-MFP1xMNnJ9mfHuUu6hqE9B7nRgI2HfXBpblo3sFnAwo=";
+    rev = "0abcc17f335010419fa9cae463d746ad1343477e";
+    hash = "sha256-zUOCHL/AKDzOmWbnpP6BccEJ+tmtRvI1vQ+T/sCnXvY=";
   };
 
   postPatch = ''
@@ -25,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
                    '(?:/nix)?/(?:build)/(?:nix[\-0-9]+/)?'
   '';
 
-  cargoHash = "sha256-Rhv9Wku/bRl28nrXYof+6VAgl2K4ysILRQa1v19r0pU=";
+  cargoHash = "sha256-TnpkGOs8/IFJ1trzMijOTmX3BR2P3GsBhyv0GVCwHsc=";
 
   # integrations test require git at build time (jarl >= 0.5.0)
   nativeBuildInputs = [ git ];
@@ -40,15 +38,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # "--test integration_tests"
   ];
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   postInstall = ''
     rm $out/bin/xtask_codegen
   '';
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Just another R linter";


### PR DESCRIPTION
This is intended to upgrade jarl to version 0.6.0. However, the Cargo.lock file had some [inconsistencies](https://github.com/etiennebacher/jarl/issues/704#issue-5408294677) that broke the build in nix, and won't be fixed upstream. I decided to upgrade to a commit beyond 0.6.0 which fixes the lock file. It has very little additional changes after release, so it should be just as good. This means:

- Disabled versionCheckHook
- Disabled automatic upgrades

These temporary changes in the first commit should be reverted upon new release.

The second commit adds shell completion support, which is new in 0.6.0 (hence the rush to upgrade :) )

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
