### PR TITLE
netexec: fix broken ldap protocol

### DIFF
--- a/pkgs/by-name/ne/netexec/package.nix
+++ b/pkgs/by-name/ne/netexec/package.nix
@@ -15,7 +15,7 @@ let
           owner = "fortra";
           repo = "impacket";
           rev = "caba5facdd3a01b5d0decc6daf5871839f22f792";
-          hash = "sha256-jyn5qSSAipGYhHm2EROwDHa227mnmW+d+0H0/++i1OY=";
+          hash = "sha256-W7wXgUq34xzqbi/vEyUoKguaBmKeKGd6u3Oce39JHFc=";
         };
         # Fix version to be compliant with Python packaging rules
         postPatch = ''
@@ -23,6 +23,11 @@ let
             --replace 'version="{}.{}.{}.{}{}"' 'version="{}.{}.{}"'
         '';
       };
+      certipy-ad = super.certipy-ad.overridePythonAttrs (old: {
+        # NetExec pins impacket to a 0.14.0 dev revision; certipy-ad still
+        # declares impacket~=0.13.0, so relax it to build against 0.14.0.
+        pythonRelaxDeps = (old.pythonRelaxDeps or [ ]) ++ [ "impacket" ];
+      });
     };
   };
 in


### PR DESCRIPTION
Supersedes #561330 (that PR could not be reopened after a force-push).

netexec pins impacket to the fortra commit `caba5fac` (0.14.0), but the recorded
`hash` was actually impacket 0.13.0's. Since `fetchFromGitHub` is content-addressed
by `hash`, Nix serves the cached 0.13.0 source and ignores `rev`, so netexec ships
impacket 0.13.0. That version's `LDAPConnection.__init__` has no `signing` argument,
so every `nxc ldap` run fails with:

    TypeError: LDAPConnection.__init__() got an unexpected keyword argument 'signing'

Fix:
- Correct the impacket `hash` so the intended 0.14.0 (`caba5fac`) is actually fetched.
- `certipy-ad` still constrains `impacket~=0.13.0`; relax it so the closure builds
  against 0.14.0.

AI assistance: this change was prepared with the help of Claude Code (Claude Opus 5);
it was manually reviewed and verified (build + `nxc ldap` runtime check). Disclosed
per the automation/AI policy via the `Assisted-by:` trailer on the commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test