### PR TITLE
nixos.tests.forgejo: terminate forgejo logind session

### DIFF
--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -297,6 +297,19 @@ let
               server.succeed(
                   "su -l forgejo -c 'GITEA_WORK_DIR=/var/lib/forgejo forgejo actions generate-runner-token' | sed 's/^/TOKEN=/' | tee /var/lib/forgejo/runner_token"
               )
+
+              # The `su -l forgejo` invocations above register a logind session and start a
+              # `user@<uid>.service` manager for the forgejo user, which logind tears down
+              # asynchronously once `su` exits. If `switch-to-configuration` runs while that
+              # teardown is still in progress, its per-user activation step races against the
+              # vanishing session bus (`/run/user/<uid>` still exists, but the bus already
+              # refuses connections) and the whole switch fails with exit code 4. This race is
+              # hit frequently on slower machines (e.g. aarch64). Terminate the session and wait
+              # for its runtime directory to disappear to make the following switches deterministic.
+              forgejo_uid = server.succeed("id -u forgejo").strip()
+              server.succeed("loginctl terminate-user forgejo || true")
+              server.wait_until_fails(f"test -e /run/user/{forgejo_uid}", timeout=30)
+
               server.succeed("${serverSystem}/specialisation/gitea-actions-runner/bin/switch-to-configuration test")
               server.wait_for_unit("gitea-runner-test.service")
               server.succeed("journalctl -o cat -u gitea-runner-test.service | grep -q 'Runner registered successfully'")


### PR DESCRIPTION
Tests on aarch64-linux frequently fail when run by user as seen below. This
appears to be caused by a race condition where the user session hasn't been
fully torn down yet but still partially exists. I think Copilot's result here
is correct, I hadn't been able to determine the cause myself and threw some
work tokens at the problem. The documentation is overly verbose while I
continue to diagnose, will clean up before marking ready for review.

[user@.service systemd docs](https://www.freedesktop.org/software/systemd/man/latest/user@.service.html)

```
server # reloading user units for forgejo...
server # Error: Failed to open dbus connection
server #     Failed to connect to socket /run/user/998/bus: Connection refused
server # warning: user activation for forgejo failed
```

Assisted-By: GitHub Copilot:Claude Opus 4.8


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
