### PR TITLE
cbconvert{,-gui}: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/cb/cbconvert/gui.nix
+++ b/pkgs/by-name/cb/cbconvert/gui.nix
@@ -23,7 +23,10 @@ buildGoModule (finalAttrs: {
   ];
   buildInputs = cbconvert.buildInputs ++ [ gtk3 ];
 
-  vendorHash = "sha256-oMW5zfAw2VQSVaB+Z1pE51OtNIFr+PnRMM+oBYNLWxk=";
+  env.GOWORK = "off";
+
+  proxyVendor = true;
+  vendorHash = "sha256-jG8pQdY01MMCumNLBiHdgZ1pvp653WWaUCXD/gEuSpk=";
   modRoot = "cmd/cbconvert-gui";
 
   ldflags = [

--- a/pkgs/by-name/cb/cbconvert/package.nix
+++ b/pkgs/by-name/cb/cbconvert/package.nix
@@ -13,16 +13,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "cbconvert";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "gen2brain";
     repo = "cbconvert";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-C2Eox6fpKS0fPB7KFgBn62HKbWYacSVMJK0CkT6+FBU=";
+    hash = "sha256-fLAVX3AlHUp2jmb8AiFeqB4IhVcWxYk0tkjvwWiKwPc=";
   };
 
-  vendorHash = "sha256-uV8aIUKy9HQdZvR3k8CTTrHsh9TyBw21gFTdjR1XJlg=";
+  env.GOWORK = "off";
+
+  vendorHash = "sha256-lR1ZbEDNjJ9+bl8ijdI5/ifC5uIB1rdbnXQh5D2T7NM=";
   modRoot = "cmd/cbconvert";
 
   # The extlib tag forces the github.com/gen2brain/go-unarr module to use external libraries instead of bundled ones.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Hydra error logs:
cbconvert-gui: https://hydra.nixos.org/build/343721304
cbconvert: https://hydra.nixos.org/build/343289676

Release: https://github.com/gen2brain/cbconvert/releases/tag/v1.2.0
Diff: https://github.com/gen2brain/cbconvert/compare/v1.1.0...v1.2.0

Tested by converting two comics from `.pdf` to `.cbt` and `.cbz`.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
