### PR TITLE
nixos/suricata: add support for --drop-conf rules

### DIFF
--- a/nixos/modules/services/networking/suricata/default.nix
+++ b/nixos/modules/services/networking/suricata/default.nix
@@ -149,7 +149,20 @@ in
         "2270007"
       ];
       description = ''
-        List of rules that should be disabled.
+        List of matchers specifying which rules should be disabled.
+        These can be raw SID numbers or something like "group:emerging-coinminer.rules".
+      '';
+    };
+
+    dropRules = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = literalExpression ''
+        [ "2274852" "4327876" "902244405" ]
+      '';
+      description = ''
+        List of matchers specifying which rules should be converted to drop rules.
+        These can be raw SID numbers or something like "group:emerging-coinminer.rules".
       '';
     };
   };
@@ -230,7 +243,8 @@ in
               ${concatStringsSep "\n" enabledSourcesCmds}
               ${python.interpreter} ${pkg}/bin/suricata-update update-sources
               ${python.interpreter} ${pkg}/bin/suricata-update update --suricata-conf ${cfg.configFile} --no-test \
-                --disable-conf ${pkgs.writeText "suricata-disable-conf" "${concatStringsSep "\n" cfg.disabledRules}"}
+                --disable-conf ${pkgs.writeText "suricata-disable-conf" "${concatStringsSep "\n" cfg.disabledRules}"} \
+                --drop-conf ${pkgs.writeText "suricata-drop.conf" "${concatStringsSep "\n" cfg.dropRules}"}
             '';
           serviceConfig = {
             Type = "oneshot";


### PR DESCRIPTION
Added a module option to specify contents of drop.conf for `suricata-update`. This is a way to convert alert rules to drop rules using `suricata-update`. No NixOS test because the existing one disables `suricata-update` due to internet connection requirement. I ran the modified module on my machine using ranges of numeric SIDs in `dropRules` and it seemed to work as expected, replacing alert rules with drop rules.

These changes are important for users that want to use Suricata's intrusion prevention capabilities rather than detection only, as the popular rulesets ship with alert rules, not drop rules.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
