### PR TITLE
tetex: add license

### DIFF
--- a/pkgs/by-name/te/tetex/package.nix
+++ b/pkgs/by-name/te/tetex/package.nix
@@ -91,5 +91,11 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ ];
     platforms = lib.platforms.unix;
     hydraPlatforms = [ ];
+    license =
+      with lib.licenses;
+      AND [
+        gpl2Plus # Bundles some GPL2+ dependencies
+        free # Package itself is miscellaneously free
+      ];
   };
 })


### PR DESCRIPTION
This package's licensing is a mess. Here's the text of LICENSE.src:

```
The files within this directory are all free software. Most of these
files are copyright by some author(s), but I have taken care that
the following conditions are true:
  - all files can be distributed: no license fee is required.
  - using these files (even for commercial purpose) is not restricted.
  - modification of files is allowed or an existing translation scheme
    effectively makes modification unnecessary. E.g. Knuth's WEB files
    must not be changed, but the build process allows you to change
    the generated .c files by "change files". Please, check the license
    of a file before you do modifications; you might need to mark those
    modifications or to rename the program.
  - the distribution of modified files and subsets of these files is
    allowed, but please check the licenses if you do that.
```

I settled on GPLv2+ because the changelog mentions adding a GPL dependency and it's included source has GPLv2+ headers. But I really don't know what to do for this, I don't think there's a good way to represent the license anywhere.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
