### PR TITLE
nixos/suricata: reload suricata after ruleset update

### DIFF
--- a/nixos/modules/services/networking/suricata/default.nix
+++ b/nixos/modules/services/networking/suricata/default.nix
@@ -152,6 +152,14 @@ in
         List of rules that should be disabled.
       '';
     };
+    reloadOnRulesetUpdate = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to reload Suricata if it is running after an automated ruleset update.
+        This is a blocking reload, and may take some time depending on the number of rules and computational power of the host.
+      '';
+    };
   };
 
   config =
@@ -213,11 +221,20 @@ in
       };
 
       systemd.services = {
+        suricata-blocking-reload = lib.mkIf cfg.reloadOnRulesetUpdate {
+          description = "Refresh Runtime Suricata Ruleset";
+          serviceConfig = {
+            Type = "oneshot";
+            ExecCondition = "systemctl is-active --quiet suricata.service";
+            ExecStart = "${pkg}/bin/suricatasc -c reload-rules";
+          };
+        };
         suricata-update = {
           description = "Update Suricata Rules";
           wantedBy = [ "multi-user.target" ];
           wants = [ "network-online.target" ];
           after = [ "network-online.target" ];
+          onSuccess = lib.mkIf cfg.reloadOnRulesetUpdate [ "suricata-blocking-reload.service" ];
 
           script =
             let

--- a/nixos/tests/suricata.nix
+++ b/nixos/tests/suricata.nix
@@ -23,6 +23,7 @@
 
       services.suricata = {
         enable = true;
+        reloadOnRulesetUpdate = true;
         settings = {
           vars.address-groups.HOME_NET = "192.168.1.0/24";
           unix-command.enabled = true;
@@ -66,7 +67,7 @@
     # check that configuration has been applied correctly with suricatasc
     with subtest("suricata configuration test"):
         ids.wait_for_unit("suricata.service")
-        assert '1' in ids.succeed("suricatasc -c 'iface-list' | ${pkgs.jq}/bin/jq .message.count")
+        assert '1' in ids.wait_until_succeeds("suricatasc -c 'iface-list' | ${pkgs.jq}/bin/jq .message.count", 5)
 
     # test detection of events based on a static ruleset (output of id command)
     with subtest("suricata rule test"):
@@ -75,5 +76,9 @@
 
         ids.succeed("curl http://192.168.1.1/id/")
         assert "id check returned root [**] [Classification: Potentially Bad Traffic]" in ids.succeed("tail -n 1 /var/log/suricata/fast.log"), "Suricata didn't detect the output of id comment"
+
+    with subtest("suricata blocking reload test"):
+      ids.wait_for_unit("suricata.service")
+      assert ids.systemctl("start suricata-blocking-reload.service")[0] == 0
   '';
 }


### PR DESCRIPTION
Adds an option to enable reloading Suricata using its socket control API. This is needed for a *blocking* reload, while an async one could be accomplished just by sending `SIGUSR2`. As far as I can tell, rule reloads were to be done manually before, so updated rules wouldn't take effect immediately.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
