### PR TITLE
{_7zz,_7zip-zstd}/setup-hook.sh: don't extract alternate streams; allow safe parent symlinks; _7zip-zstd: install 7z.so on darwin

### DIFF
--- a/pkgs/by-name/_7/_7zip-zstd/package.nix
+++ b/pkgs/by-name/_7/_7zip-zstd/package.nix
@@ -119,11 +119,12 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       runHook preInstall
 
+      # Upstream always names this module 7z.so on Unix, including Darwin.
       install -Dt "$out/${if isWindows then "bin" else "lib"}/7zip" \
         CPP/7zip/Bundles/Alone/b/*/7za${extensions.executable} \
         CPP/7zip/Bundles/Alone2/b/*/7zz${extensions.executable} \
         CPP/7zip/Bundles/Alone7z/b/*/7zr${extensions.executable} \
-        CPP/7zip/Bundles/Format7zF/b/*/7z${extensions.sharedLibrary} \
+        CPP/7zip/Bundles/Format7zF/b/*/7z${if isWindows then extensions.sharedLibrary else ".so"} \
         CPP/7zip/UI/Console/b/*/7z${extensions.executable}
       install -D CPP/7zip/Bundles/SFXCon/b/*/7zCon${extensions.executable} "$out/lib/7zip/7zCon.sfx"
 

--- a/pkgs/by-name/_7/_7zip-zstd/setup-hook.sh
+++ b/pkgs/by-name/_7/_7zip-zstd/setup-hook.sh
@@ -3,10 +3,10 @@ unpackCmdHooks+=(_tryUnpackDmg)
 
 _try7zip() {
   if ! [[ $curSrc =~ \.7z$ ]]; then return 1; fi
-  7z x "$curSrc"
+  7z x -snld "$curSrc"
 }
 
 _tryUnpackDmg() {
   if ! [[ $curSrc =~ \.dmg$ ]]; then return 1; fi
-  7z x -sns- "$curSrc"
+  7z x -sns- -snld "$curSrc"
 }

--- a/pkgs/by-name/_7/_7zip-zstd/setup-hook.sh
+++ b/pkgs/by-name/_7/_7zip-zstd/setup-hook.sh
@@ -8,5 +8,5 @@ _try7zip() {
 
 _tryUnpackDmg() {
   if ! [[ $curSrc =~ \.dmg$ ]]; then return 1; fi
-  7z x "$curSrc"
+  7z x -sns- "$curSrc"
 }

--- a/pkgs/by-name/_7/_7zz/setup-hook.sh
+++ b/pkgs/by-name/_7/_7zz/setup-hook.sh
@@ -1,5 +1,5 @@
 unpackCmdHooks+=(_tryUnpackDmg)
 _tryUnpackDmg() {
     if ! [[ "$curSrc" =~ \.dmg$ ]]; then return 1; fi
-    7zz x "$curSrc"
+    7zz x -sns- "$curSrc"
 }

--- a/pkgs/by-name/_7/_7zz/setup-hook.sh
+++ b/pkgs/by-name/_7/_7zz/setup-hook.sh
@@ -1,5 +1,5 @@
 unpackCmdHooks+=(_tryUnpackDmg)
 _tryUnpackDmg() {
     if ! [[ "$curSrc" =~ \.dmg$ ]]; then return 1; fi
-    7zz x -sns- "$curSrc"
+    7zz x -sns- -snld "$curSrc"
 }

--- a/pkgs/by-name/bb/bbedit/package.nix
+++ b/pkgs/by-name/bb/bbedit/package.nix
@@ -18,11 +18,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ _7zz ];
 
-  # 7zz extracts APFS alternate data streams as separate files, breaking the seal
-  postUnpack = ''
-    find . -name "*:com.apple.*" -delete
-  '';
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/cm/cmux/package.nix
+++ b/pkgs/by-name/cm/cmux/package.nix
@@ -19,11 +19,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-+MKcMChZTFiDF482mVIh6mzeyKghDMV9gLA+6BjamXw=";
   };
 
-  # -snld prevents "ERROR: Dangerous symbolic link path was ignored"
-  # -xr'!*:com.apple.*' avoids extended attributes being extracted as files
-  # from the APFS image, which would corrupt the .app bundle.
-  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
-
   nativeBuildInputs = [
     _7zz
     makeBinaryWrapper

--- a/pkgs/by-name/gh/ghostty-bin/package.nix
+++ b/pkgs/by-name/gh/ghostty-bin/package.nix
@@ -17,14 +17,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   sourceRoot = ".";
 
-  # otherwise fails to unpack with:
-  # ERROR: Dangerous link path was ignored : Ghostty.app/Contents/Resources/terminfo/67/ghostty : ../78/xterm-ghostty
-  unpackPhase = lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
-    runHook preUnpack
-    7zz -snld x $src
-    runHook postUnpack
-  '';
-
   nativeBuildInputs = [
     _7zz
     makeBinaryWrapper

--- a/pkgs/by-name/jp/jprofiler/package.nix
+++ b/pkgs/by-name/jp/jprofiler/package.nix
@@ -105,7 +105,7 @@ let
     unpackPhase = ''
       runHook preUnpack
 
-      7zz x $src -x!JProfiler/\[\]
+      7zz x -snld $src -x!JProfiler/\[\]
 
       runHook postUnpack
     '';

--- a/pkgs/by-name/ki/kitty-bin/package.nix
+++ b/pkgs/by-name/ki/kitty-bin/package.nix
@@ -18,10 +18,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-+AT1juS2nHb4TrMoHhQHSCaaY/P0qBYBWo3sKgbSsZU=";
   };
 
-  # undmg can't read the APFS dmg; -snld keeps the .app's symlinks intact.
   nativeBuildInputs = [ _7zz ];
   sourceRoot = ".";
-  unpackCmd = "7zz x -snld $curSrc";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/li/linear/package.nix
+++ b/pkgs/by-name/li/linear/package.nix
@@ -21,11 +21,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   sourceRoot = "Linear";
 
-  # -snld prevents "ERROR: Dangerous symbolic link path was ignored".
-  # -xr'!*:com.apple.*' prevents macOS extended attributes from being
-  # extracted as regular files, which corrupts the .app bundle.
-  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/lm/lmstudio/darwin.nix
+++ b/pkgs/by-name/lm/lmstudio/darwin.nix
@@ -51,12 +51,5 @@ stdenv.mkDerivation {
   # LM Studio ships Scripts inside the App Bundle, which may be messed up by standard fixups
   dontFixup = true;
 
-  # undmg doesn't support APFS and 7zz does break the xattr. Took that approach from https://github.com/NixOS/nixpkgs/blob/a3c6ed7ad2649c1a55ffd94f7747e3176053b833/pkgs/by-name/in/insomnia/package.nix#L52
-  # NOTE (djmaxus): even with hdiutil, a check `xattr -lr LM\ Studio.app` returns nothing,
-  # meaning that xattrs are lost anyway? So, I brought back simple 7zip unpacking
-  unpackPhase = ''
-    7zz x -snld $src
-  '';
-
   inherit passthru;
 }

--- a/pkgs/by-name/op/openusage/package.nix
+++ b/pkgs/by-name/op/openusage/package.nix
@@ -15,8 +15,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-ycKm7kzOM+fv5Jhjv3JrG+oyK3LEOj9Ps7ll2Pz0T9c=";
   };
 
-  unpackCmd = "7zz -snld x $src";
-
   nativeBuildInputs = [ _7zz ];
 
   sourceRoot = ".";

--- a/pkgs/by-name/or/orbstack/package.nix
+++ b/pkgs/by-name/or/orbstack/package.nix
@@ -20,13 +20,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-fKd4aPOg19n1ez+YYVqtMMxZ0jzIS7/xP3iEbfC0k9Q=";
   };
 
-  # -snld prevents "ERROR: Dangerous symbolic link path was ignored"
-  # -xr'!*:com.apple.*' prevents macOS extended attributes (e.g. macl or
-  # quarantine) being turned into real files when extracting an APFS .dmg
-  # (e.g. Info.plist:com.apple.macl or Info.plist:com.apple.quarantine).
-  # These bogus files corrupt the .app bundle and prevent it from launching.
-  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
-
   nativeBuildInputs = [
     _7zz
     installShellFiles

--- a/pkgs/by-name/pr/proxyman/darwin.nix
+++ b/pkgs/by-name/pr/proxyman/darwin.nix
@@ -23,8 +23,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     makeWrapper
   ];
 
-  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/qu/quba/package.nix
+++ b/pkgs/by-name/qu/quba/package.nix
@@ -66,7 +66,7 @@ let
       hash = "sha256-dVi4PAOEfIcqgP5ljqvN4X2y4fAuq1p5xDFBUI/YW6I=";
     };
 
-    unpackCmd = "7zz x -bd -osource -xr'!*/Applications' -xr'!*com.apple.provenance' $curSrc";
+    unpackCmd = "7zz x -bd -sns- -snld -osource -xr'!*/Applications' $curSrc";
 
     nativeBuildInputs = [ _7zz ];
 

--- a/pkgs/by-name/we/wechat/darwin.nix
+++ b/pkgs/by-name/we/wechat/darwin.nix
@@ -17,10 +17,6 @@ stdenvNoCC.mkDerivation {
 
   # dmg is APFS formatted
   nativeBuildInputs = [ _7zz ];
-  # ERROR: Dangerous link path was ignored : WeChat.app/Contents/MacOS/WeChatAppEx.app/Contents/Frameworks/WeChatAppEx Framework.framework/Versions/C/Libraries/xfile/libxfile_skia.dylib : ../xeditor/libxeditor_app.dylib
-  unpackCmd = ''
-    7zz x -snld "$curSrc"
-  '';
 
   sourceRoot = ".";
 


### PR DESCRIPTION
7z unpacks HFS / APFS file xattrs as "alternate streams" - creating actual
files per xattr. This is useless and breaks signature checks on bundles
(because unexpected files are present in .app directory).

The PR updates 7z unpack hooks to omit these files. It also adds -snld flag to
allow ../* symlinks as long as they don't escape the target directory.

This allows to clean up a bunch of hacks in packages that did this cleanup
manually before: now unpack hooks do the job.

While at it, also fixed 7z from `_7zip-zstd` on darwin: it was not loading archive
module correctly because the tool expects .so but we tried to install .dylib.

Fixes #561556

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
