### PR TITLE
nixosTests.hickory-dns: add basic zone query test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -861,6 +861,7 @@ in
   hibernate-systemd-stage-1 = handleTestOn [ "x86_64-linux" ] ./hibernate.nix {
     systemdStage1 = true;
   };
+  hickory-dns = runTest ./hickory-dns.nix;
   hister = runTest ./hister.nix;
   hitch = runTest ./hitch;
   hledger-web = runTest ./hledger-web.nix;

--- a/nixos/tests/hickory-dns.nix
+++ b/nixos/tests/hickory-dns.nix
@@ -1,0 +1,41 @@
+{ pkgs, ... }:
+{
+  name = "hickory-dns";
+
+  meta.maintainers = with pkgs.lib.maintainers; [ adamcstephens ];
+
+  containers.machine = {
+    environment.systemPackages = [ pkgs.doggo ];
+
+    services.hickory-dns = {
+      enable = true;
+      settings.zones = [
+        {
+          zone = "example.test";
+          file = pkgs.writeText "example.test.zone" ''
+            $ORIGIN example.test.
+            $TTL 3600
+            @ IN SOA ns.example.test. hostmaster.example.test. (1 3600 600 86400 3600)
+            @ IN NS ns.example.test.
+            ns IN A 127.0.0.1
+            www IN A 192.0.2.1
+          '';
+        }
+      ];
+    };
+  };
+
+  testScript = ''
+    import json
+
+    machine.start()
+    machine.wait_for_unit("hickory-dns.service")
+    machine.wait_for_open_port(53)
+
+    response = json.loads(machine.succeed("doggo @127.0.0.1 www.example.test. A --json"))
+    answers = response["responses"][0]["answers"]
+    assert [(answer["name"], answer["type"], answer["address"]) for answer in answers] == [
+        ("www.example.test.", "A", "192.0.2.1")
+    ], response
+  '';
+}

--- a/pkgs/by-name/hi/hickory-dns/package.nix
+++ b/pkgs/by-name/hi/hickory-dns/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   lib,
   nix-update-script,
+  nixosTests,
   rustPlatform,
   versionCheckHook,
 }:
@@ -80,7 +81,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     substituteInPlace crates/resolver/src/lib.rs --replace-fail '//! ```rust' '//! ```rust,no_run'
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = {
+      inherit (nixosTests) hickory-dns;
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Rust based DNS client, server, and resolver";


### PR DESCRIPTION
Assisted-By: OpenAI Codex GPT-6 Astra


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
