### PR TITLE
binwalk: dumpifs is unfree

### DIFF
--- a/pkgs/by-name/bi/binwalk/package.nix
+++ b/pkgs/by-name/bi/binwalk/package.nix
@@ -104,7 +104,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
           p7zip
           cabextract
           dmg2img
-          dumpifs
           jefferson
           vmlinux-to-elf
           lz4
@@ -119,7 +118,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
           unyaffs
           zstd
         ]
-        ++ lib.optionals enableUnfree [ unrar ]
+        ++ lib.optionals enableUnfree [
+          dumpifs
+          unrar
+        ]
       )
     }
   '';


### PR DESCRIPTION
The license metadata of *dumpifs* has been set to *unfree* via 7762802708f34eb6291ca7ff0e4fa4f6e8449da0. Gating the inclusion of the unfree package will allow *binwalk* to build properly on h.n.o as well as in setups which do not allow unfree packages.

---

Above is the commit message verbatim.

- fixes #562132
- [configurations disallowing nonfree licenses have caused eval errors](https://hydra.cloud.bsocat.net/eval/1453297#tabs-errors) due to #561360 
  - this is the default for many users

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
