### PR TITLE
rocqPackages.equations: 1.3.2+9.2 -> 1.3.2+9.3

### DIFF
--- a/pkgs/development/rocq-modules/equations/default.nix
+++ b/pkgs/development/rocq-modules/equations/default.nix
@@ -17,6 +17,7 @@
       case = case: out: { inherit case out; };
     in
     lib.switch coq.coq-version [
+      (case "9.3" "1.3.2+9.3")
       (case "9.2" "1.3.2+9.2")
       (case "9.1" "1.3.1+9.1")
       (case "9.0" "1.3.1+9.0")
@@ -86,6 +87,8 @@
   release."1.3.1+9.1".hash = "sha256-LtYbAR3jt+JbYcqP+m1n3AZhAWSMIeOZtmdSJwg7L1A=";
   release."1.3.2+9.2".rev = "v1.3.2-9.2";
   release."1.3.2+9.2".hash = "sha256-wpl6Uxy3M2xYuBZPLdsvkvBfXqzplHRrNjyePgLi2X4=";
+  release."1.3.2+9.3".rev = "v1.3.2-9.3";
+  release."1.3.2+9.3".hash = "sha256-V7uHxLkd5rqmu5IqI7KPAGU9rtH2fbroYvwcDuOm3vw=";
 
   mlPlugin = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
