### PR TITLE
fcitx5-areca: 4.0.3 -> 6.0.1

### DIFF
--- a/pkgs/by-name/fc/fcitx5-areca/package.nix
+++ b/pkgs/by-name/fc/fcitx5-areca/package.nix
@@ -2,22 +2,27 @@
   lib,
   stdenv,
   cmake,
+  dbus,
   fcitx5,
   fetchFromGitHub,
+  fontconfig,
   go,
-  pkg-config,
+  libinput,
   ninja,
   nix-update-script,
+  pkg-config,
+  sdl3,
+  udev,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "fcitx5-areca";
-  version = "4.0.3";
+  version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "xhkzeroone";
     repo = "ArecaIME";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tjNKRU3yTIOGxkpE2RSuTa7lLZtQvFcUQ0ELCQyinVc=";
+    hash = "sha256-ud7dwE912TN8z3CWtzuVxygYAB4xV5mBo83SyrUUt+0=";
     fetchSubmodules = true;
   };
 
@@ -33,7 +38,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    dbus
     fcitx5
+    fontconfig
+    libinput
+    sdl3
+    udev
   ];
 
   preConfigure = ''


### PR DESCRIPTION
Changes:
- Add dependencies: `dbus`, `sdl3`, `fontconfig`, `libinput`, `udev`

Changelog: https://github.com/xhkzeroone/ArecaIME/compare/v4.0.3...v6.0.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
