### PR TITLE
espeak-ng: fix `mbrola.patch`

### DIFF
--- a/pkgs/by-name/es/espeak-ng/mbrola.patch
+++ b/pkgs/by-name/es/espeak-ng/mbrola.patch
@@ -7,7 +7,7 @@ index e3e4b702..de06dd21 100644
  
  		snprintf(charbuf, sizeof(charbuf), "%g", mbr_volume);
 -		execlp("mbrola", "mbrola", "-e", "-v", charbuf,
-+		execlp("@mbrola/bin/mbrola@", "mbrola", "-e", "-v", charbuf,
++		execlp("@mbrola@/bin/mbrola", "mbrola", "-e", "-v", charbuf,
  		       voice_path, "-", "-.wav", (char *)NULL);
  		/* if execution reaches this point then the exec() failed */
  		snprintf(mbr_errorbuf, sizeof(mbr_errorbuf),
@@ -20,7 +20,7 @@ index 5f9b0458..26a05635 100644
  		return ENS_MBROLA_NOT_FOUND;
  
 -	sprintf(path, "%s/mbrola/%s", path_home, mbrola_voice);
-+	sprintf(path, "%s/@mbrola@/%s", path_home, mbrola_voice);
++	sprintf(path, "@mbrola@/share/mbrola/voices/%s/%s", mbrola_voice, mbrola_voice);
  #if PLATFORM_POSIX
  	// if not found, then also look in
  	//   $data_dir/mbrola/xx, $data_dir/mbrola/xx/xx, $data_dir/mbrola/voices/xx


### PR DESCRIPTION
The patch file contained badly formatted search-and-replace markers (e.g., `@mbrola/bin/mbrola@` instead of `@mbrola@/bin/mbrola`).

<!--^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
