### PR TITLE
emacs: enable lexical-binding in some files to fix warnings

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/elpa2nix.el
+++ b/pkgs/applications/editors/emacs/build-support/elpa2nix.el
@@ -1,3 +1,5 @@
+;; -*- lexical-binding: t; -*-
+
 (require 'package)
 (package-initialize)
 

--- a/pkgs/applications/editors/emacs/build-support/melpa2nix.el
+++ b/pkgs/applications/editors/emacs/build-support/melpa2nix.el
@@ -1,3 +1,5 @@
+;; -*- lexical-binding: t; -*-
+
 (require 'package-recipe)
 (require 'package-build)
 

--- a/pkgs/applications/editors/emacs/build-support/mk-wrapper-subdirs.el
+++ b/pkgs/applications/editors/emacs/build-support/mk-wrapper-subdirs.el
@@ -1,3 +1,5 @@
+;; -*- lexical-binding: t; -*-
+
 (defmacro mk-subdirs-expr (path)
   `(setq load-path
          (delete-dups (append '(,path)


### PR DESCRIPTION
Emacs 31 introduces warnings like this:

>  Warning (files): Missing `lexical-binding' cookie in "/nix/store/hash-elpa2nix.el".
>  You can add one with `M-x elisp-enable-lexical-binding RET'.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
