### PR TITLE
testdisk: move to pkgs/by-name

### DIFF
--- a/pkgs/by-name/te/testdisk/package.nix
+++ b/pkgs/by-name/te/testdisk/package.nix
@@ -5,7 +5,6 @@
   ncurses,
   libuuid,
   pkg-config,
-  wrapQtAppsHook,
   libjpeg,
   zlib,
   libewf-legacy,
@@ -14,16 +13,12 @@
   enableExtFs ? !stdenv.hostPlatform.isDarwin,
   e2fsprogs ? null,
   enableQt ? false,
-  qtbase ? null,
-  qttools ? null,
-  qwt ? null,
+  qt5,
+  libsForQt5,
 }:
 
 assert enableNtfs -> ntfs3g != null;
 assert enableExtFs -> e2fsprogs != null;
-assert enableQt -> qtbase != null;
-assert enableQt -> qttools != null;
-assert enableQt -> qwt != null;
 
 stdenv.mkDerivation rec {
   pname = "testdisk";
@@ -50,15 +45,15 @@ stdenv.mkDerivation rec {
   ++ lib.optional enableNtfs ntfs3g
   ++ lib.optional enableExtFs e2fsprogs
   ++ lib.optionals enableQt [
-    qtbase
-    qttools
-    qwt
+    qt5.qtbase
+    qt5.qttools
+    libsForQt5.qwt
   ];
 
   nativeBuildInputs = [
     pkg-config
   ]
-  ++ lib.optional enableQt wrapQtAppsHook;
+  ++ lib.optional enableQt qt5.wrapQtAppsHook;
 
   env.NIX_CFLAGS_COMPILE = "-Wno-unused";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2957,8 +2957,6 @@ with pkgs;
     callPackage ../development/tools/continuous-integration/woodpecker/server.nix
       { };
 
-  testdisk = libsForQt5.callPackage ../tools/system/testdisk { };
-
   testdisk-qt = testdisk.override { enableQt = true; };
 
   tweet-hs = haskell.lib.compose.justStaticExecutables haskellPackages.tweet-hs;


### PR DESCRIPTION
Should have no rebuilds (tested on darwin).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
