### PR TITLE
protobuf: add `proto` output to fix `protobufc` build

### DIFF
--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -41,7 +41,23 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "lib"
     "dev"
+    "proto"
   ];
+
+  outputChecks = {
+    out.disallowedReferences = [
+      "dev"
+    ];
+    lib.disallowedReferences = [
+      "out"
+      "dev"
+    ];
+    proto.disallowedReferences = [
+      "out"
+      "lib"
+      "dev"
+    ];
+  };
 
   patches =
     lib.optionals (lib.versionOlder version "22") [
@@ -178,6 +194,23 @@ stdenv.mkDerivation (finalAttrs: {
   env = lib.optionalAttrs (lib.versions.major version == "29") {
     GTEST_DEATH_TEST_STYLE = "threadsafe";
   };
+
+  # protoc expects to find `.proto` files relative to itself, so we put those to a separate output and add symlinks.
+  postFixup = ''
+    pushd "$dev" > /dev/null
+
+    find include -name '*.proto' -print0 | while IFS= read -r -d ''' FILE; do
+      mkdir -p "$proto/$(dirname "$FILE")"
+      mkdir -p "$out/$(dirname "$FILE")"
+
+      mv "$FILE" "$proto/$FILE"
+
+      ln -s "$proto/$FILE" "$out/$FILE"
+      ln -s "$proto/$FILE" "$dev/$FILE"
+    done
+
+    popd > /dev/null
+  '';
 
   passthru = {
     tests = {


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nixpkgs/pull/560607#issuecomment-5626754277

```console
$ du -sh $(nix-build -A protobuf.all)
1.8M    /nix/store/jicfp748rsfbyahgbhcvimn6jqd4d71g-protobuf-36.1
12M     /nix/store/yaw0bfk2vx6ahzwvg6vbif14f4i83h8d-protobuf-36.1-lib
5.8M    /nix/store/cq7vsbrg50yr4ihmd7i1mzp90zingws8-protobuf-36.1-dev
204K    /nix/store/4lajsaq9xsvlzh9cr9fxmvrzcr3kh472-protobuf-36.1-proto
103M    /nix/store/s03gznygfs4gs5gqk02sqxdk67s7pz5p-protobuf-36.1-debug
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
