### PR TITLE
renderdoc: 1.45 -> 1.46

### DIFF
--- a/pkgs/by-name/re/renderdoc/package.nix
+++ b/pkgs/by-name/re/renderdoc/package.nix
@@ -36,13 +36,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "renderdoc";
-  version = "1.45";
+  version = "1.46";
 
   src = fetchFromGitHub {
     owner = "baldurk";
     repo = "renderdoc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-0XwKOLzkFN5u2ItRKPxNVC3hP3X6RVZyEL82LvYS0EA=";
+    hash = "sha256-NW0gqSTKL5X6PWda/l/+qjdENySwh9dmD4k5CBr2kG0=";
   };
 
   outputs = [
@@ -51,15 +51,12 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
+  # https://github.com/baldurk/renderdoc/issues/2945
+  # https://github.com/baldurk/renderdoc/issues/3902
   patches = [
-    (fetchpatch {
-      # https://github.com/baldurk/renderdoc/issues/2945
-      # https://github.com/baldurk/renderdoc/commit/adf8acbccd642c8bc62256fb5580795320364895
-      name = "devendor-pcre.patch";
-      url = "https://github.com/baldurk/renderdoc/commit/adf8acbccd642c8bc62256fb5580795320364895.patch?full_index=1";
-      hash = "sha256-uQoSVmgU09tw7ccTnH1MrisDisTUbaXTelA1YdsYPlM=";
-      revert = true;
-    })
+    # custom revert of
+    # https://github.com/baldurk/renderdoc/commit/adf8acbccd642c8bc62256fb5580795320364895
+    ./remove-pcre.patch
   ];
   swig_patches = [
     # use PCRE2 instead of PCRE

--- a/pkgs/by-name/re/renderdoc/remove-pcre.patch
+++ b/pkgs/by-name/re/renderdoc/remove-pcre.patch
@@ -1,0 +1,34 @@
+diff --git a/qrenderdoc/CMakeLists.txt b/qrenderdoc/CMakeLists.txt
+index 218c1ab..039fe4e 100644
+--- a/qrenderdoc/CMakeLists.txt
++++ b/qrenderdoc/CMakeLists.txt
+@@ -159,29 +159,9 @@ if(NOT ${CMAKE_VERSION} VERSION_LESS "3.24")
+     cmake_policy(SET CMP0135 NEW)
+ endif()
+ 
+-CHECK_INCLUDE_FILE(pcre.h PCRE_HEADER)
+-
+ set(PCRE_PREFIX_PATH "")
+ 
+-if(PCRE_HEADER)
+-    message(STATUS "pcre library is found, using it as-is")
+-
+     add_custom_target(local_pcre)
+-else()
+-    message(STATUS "pcre header is not found! building pcre locally")
+-    
+-    # fetch pcre if missing
+-    ExternalProject_Add(local_pcre
+-        # using an URL to a zip directly so we don't clone the history etc
+-        URL ${RENDERDOC_PCRE_PACKAGE}
+-        BUILD_IN_SOURCE 1
+-        CONFIGURE_COMMAND autoreconf -f -v > /dev/null 2>&1
+-        COMMAND CC=${SWIG_CONFIGURE_CC} CXX=${SWIG_CONFIGURE_CXX} CFLAGS=-fPIC CXXFLAGS=-fPIC ${SET_SYSTEM_PATH_COMMAND} ./configure --prefix=${CMAKE_BINARY_DIR} --disable-shared > /dev/null
+-        BUILD_COMMAND ${GENERATOR_MAKE} ${GENERATOR_MAKE_PARAMS} > /dev/null 2>&1
+-        INSTALL_COMMAND ${GENERATOR_MAKE} install > /dev/null 2>&1)
+-
+-    set(PCRE_PREFIX_PATH "--with-pcre-prefix=${CMAKE_BINARY_DIR}")
+-endif()
+ 
+ # Compile our custom SWIG that will do scoped/strong enum classes
+ ExternalProject_Add(custom_swig


### PR DESCRIPTION
[Upstream still won't budge on PCRE](https://github.com/baldurk/renderdoc/issues/3902), so I authored a new patch to replace the reverted commit that no longer applies.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
