### PR TITLE
ocamlPackages.cstruct: 6.2.0 → 6.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -9,19 +9,16 @@
 
 buildDunePackage (finalAttrs: {
   pname = "cstruct";
-  version = "6.2.0";
-
-  minimalOCamlVersion = "4.08";
-  duneVersion = "3";
+  version = "6.3.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cstruct/releases/download/v${finalAttrs.version}/cstruct-${finalAttrs.version}.tbz";
-    hash = "sha256-mngHM5JYDoNJFI+jq0sbLpidydMNB0AbBMlrfGDwPmI=";
+    hash = "sha256-lWsknd+1X9I1hMF2evKPZIcDPTZIiCF6FCddiY69d1Q=";
   };
 
   buildInputs = [ fmt ];
 
-  doCheck = true;
+  doCheck = false; # Tests depend on cstruct-sexp
   checkInputs = [
     alcotest
     crowbar

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -6,7 +6,8 @@
   sexplib,
   ppxlib,
   ocaml-migrate-parsetree-2,
-  ounit,
+  crowbar,
+  fmt,
   cppo,
   ppx_sexp_conv,
   cstruct-unix,
@@ -21,8 +22,6 @@ else
     pname = "ppx_cstruct";
     inherit (cstruct) version src meta;
 
-    minimalOCamlVersion = "4.08";
-
     propagatedBuildInputs = [
       cstruct
       ppxlib
@@ -32,7 +31,8 @@ else
     doCheck = !lib.versionAtLeast ocaml.version "5.1";
     nativeCheckInputs = [ cppo ];
     checkInputs = [
-      ounit
+      crowbar
+      fmt
       ppx_sexp_conv
       cstruct-sexp
       cstruct-unix

--- a/pkgs/development/ocaml-modules/cstruct/sexp.nix
+++ b/pkgs/development/ocaml-modules/cstruct/sexp.nix
@@ -3,6 +3,7 @@
   buildDunePackage,
   ocaml,
   alcotest,
+  crowbar,
   cstruct,
   sexplib,
 }:
@@ -15,11 +16,11 @@ else
     pname = "cstruct-sexp";
     inherit (cstruct) version src meta;
 
-    minimalOCamlVersion = "4.08";
-    duneVersion = "3";
-
     doCheck = true;
-    checkInputs = [ alcotest ];
+    checkInputs = [
+      alcotest
+      crowbar
+    ];
 
     propagatedBuildInputs = [
       cstruct


### PR DESCRIPTION
See #562179.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
