### PR TITLE
linphonePackages.linphone-desktop: fix crashes on GNOME

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
@@ -24,6 +24,7 @@
   symlinkJoin,
   xercesc,
   zxing-cpp,
+  wrapGAppsHook3,
 }:
 let
   grammars = symlinkJoin {
@@ -99,7 +100,10 @@ stdenv.mkDerivation (finalAttrs: {
     qt6Packages.wrapQtAppsHook
     python3
     doxygen
+    wrapGAppsHook3
   ];
+
+  dontWrapGApps = true;
 
   cmakeFlags = [
     "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
@@ -152,7 +156,8 @@ stdenv.mkDerivation (finalAttrs: {
   # those just need to be linked manually below.
   preFixup = ''
     qtWrapperArgs+=(
-      --unset QML2_IMPORT_PATH \
+      "''${gappsWrapperArgs[@]}"
+      --unset QML2_IMPORT_PATH
       --set MEDIASTREAMER_PLUGINS_DIR $out/lib/mediastreamer/plugins
     )
   '';

--- a/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
@@ -146,12 +146,17 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # In order to find mediastreamer plugins, mediastreamer package was patched to
-  # support an environment variable pointing to the plugin directory. Set that
-  # environment variable by wrapping the Linphone executable.
-  #
+  # support an environment variable pointing to the plugin directory.
   # It is quite likely that there are some other files still missing and
   # Linphone will randomly crash when it tries to access those files. Then,
   # those just need to be linked manually below.
+  preFixup = ''
+    qtWrapperArgs+=(
+      --unset QML2_IMPORT_PATH \
+      --set MEDIASTREAMER_PLUGINS_DIR $out/lib/mediastreamer/plugins
+    )
+  '';
+
   postInstall = ''
     mkdir -p $out/lib/mediastreamer/plugins
     ln -s ${msopenh264}/lib/mediastreamer/plugins/* $out/lib/mediastreamer/plugins/
@@ -166,10 +171,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/share/sounds/linphone/
     ln -s ${liblinphone}/share/sounds/linphone/rings $out/share/sounds/linphone/rings
-
-    wrapProgram $out/bin/linphone \
-      --unset QML2_IMPORT_PATH \
-      --set MEDIASTREAMER_PLUGINS_DIR $out/lib/mediastreamer/plugins
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Without this linphone crashes on GNOME when opening a file chooser.
#495741

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
