### PR TITLE
mir_2_15: Fix compat with gtest 1.18

### DIFF
--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -104,6 +104,14 @@ stdenv.mkDerivation (
         tests/unit-tests/CMakeLists.txt \
         tests/mir_test_framework/CMakeLists.txt \
         --replace-fail 'Boost::system' ""
+    ''
+    # Fix ambiguity (int/void*) of nullptr w/ gtest 1.18
+    # https://github.com/canonical/mir/commit/fae4944d3b9f3dc8431efc8aba1c79f677ae1c50
+    # https://github.com/canonical/mir/commit/fc0cac6fd6f8828f05fc4b876990641f2ae71523
+    # One hunk fails to apply
+    + lib.optionalString (lib.strings.versionOlder version "2.29.0") ''
+      substituteInPlace tests/unit-tests/console/test_linux_virtual_terminal.cpp \
+        --replace-fail ', nullptr' ', static_cast<void*>(nullptr)'
     '';
 
     strictDeps = true;


### PR DESCRIPTION
For fixing `mir_2_15` on current `staging-next`: #560469

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
