### PR TITLE
Remove `rocqPackages` sub-attributes

### DIFF
--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -28,12 +28,9 @@ let
     self: coq:
     let
       callPackage = self.callPackage;
-      rocqPackages = self // {
-        recurseForDerivations = false;
-      };
     in
     {
-      inherit rocqPackages lib;
+      inherit lib;
 
       metaFetch = import ../build-support/rocq/meta-fetch/default.nix {
         inherit
@@ -43,7 +40,7 @@ let
           fetchurl
           ;
       };
-      mkRocqDerivation = lib.makeOverridable (callPackage ../build-support/rocq { });
+      mkRocqDerivation = lib.makeOverridable (callPackage ../build-support/rocq { rocqPackages = self; });
       mkCoqDerivation =
         args:
         self.mkRocqDerivation (

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -22,10 +22,6 @@ let
     in
     {
       inherit lib;
-      rocqPackages = self // {
-        __attrsFailEvaluation = true;
-        recurseForDerivations = false;
-      };
 
       metaFetch = import ../build-support/rocq/meta-fetch/default.nix {
         inherit
@@ -35,7 +31,7 @@ let
           fetchurl
           ;
       };
-      mkRocqDerivation = lib.makeOverridable (callPackage ../build-support/rocq { });
+      mkRocqDerivation = lib.makeOverridable (callPackage ../build-support/rocq { rocqPackages = self; });
 
       coq = callPackage ../applications/science/logic/coq {
         ocamlPackages_4_09 = null;


### PR DESCRIPTION
As requested by @SuperSandro2000 in https://github.com/NixOS/nixpkgs/pull/541797#issuecomment-5633847333.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
