### PR TITLE
mcp-clickhouse: init at 0.6.0

### DIFF
--- a/nixos/tests/clickhouse/default.nix
+++ b/nixos/tests/clickhouse/default.nix
@@ -22,6 +22,12 @@
       inherit package;
     };
   };
+  mcp = runTest {
+    imports = [ ./mcp.nix ];
+    _module.args = {
+      inherit package;
+    };
+  };
   s3 = runTest {
     imports = [ ./s3.nix ];
     _module.args = {

--- a/nixos/tests/clickhouse/mcp.nix
+++ b/nixos/tests/clickhouse/mcp.nix
@@ -1,0 +1,60 @@
+{ pkgs, package, ... }:
+
+{
+  name = "clickhouse-mcp";
+
+  meta.maintainers = with pkgs.lib.maintainers; [
+    jpds
+    thevar1able
+  ];
+
+  nodes.machine =
+    { config, ... }:
+    {
+      virtualisation.memorySize = 4096;
+
+      services.clickhouse = {
+        enable = true;
+        inherit package;
+      };
+
+      # Define an mcp-clickhouse systemd service
+      systemd.services.mcp-clickhouse = {
+        after = [ "clickhouse.service" ];
+        requires = [ "clickhouse.service" ];
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          ExecStart = pkgs.lib.getExe pkgs.mcp-clickhouse;
+          Environment = [
+            "CLICKHOUSE_HOST=127.0.0.1"
+            "CLICKHOUSE_PORT=8123"
+            "CLICKHOUSE_USER=default"
+            "CLICKHOUSE_PASSWORD="
+            "CLICKHOUSE_SECURE=false"
+            "CLICKHOUSE_VERIFY=false"
+            "CLICKHOUSE_MCP_SERVER_TRANSPORT=http"
+            "CLICKHOUSE_MCP_BIND_HOST=127.0.0.1"
+            "CLICKHOUSE_MCP_BIND_PORT=8000"
+            "CLICKHOUSE_MCP_AUTH_TOKEN=test-token"
+          ];
+          DynamicUser = true;
+          Restart = "on-failure";
+          RestartSec = "5s";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("clickhouse.service")
+    machine.wait_for_open_port(8123)
+
+    machine.wait_for_unit("mcp-clickhouse.service")
+    machine.wait_for_open_port(8000)
+
+    # /health performs a ClickHouse probe and only returns 200 OK when the
+    # connection succeeds.
+    machine.succeed("curl -fsS http://127.0.0.1:8000/health | grep -qx OK")
+  '';
+}

--- a/pkgs/by-name/mc/mcp-clickhouse/package.nix
+++ b/pkgs/by-name/mc/mcp-clickhouse/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+  nixosTests,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "mcp-clickhouse";
+  version = "0.6.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ClickHouse";
+    repo = "mcp-clickhouse";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IwtH6YWzMpLVKUt+62nwvOt91OklGlmi08VFIgi03X0=";
+  };
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    cachetools
+    clickhouse-connect
+    fastmcp
+    pydantic
+    python-dotenv
+    simplejson
+    starlette
+    truststore
+    uvicorn
+  ];
+
+  pythonImportsCheck = [ "mcp_clickhouse" ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests.clickhouse) mcp;
+    };
+  };
+
+  meta = {
+    description = "MCP server for ClickHouse";
+    homepage = "https://github.com/ClickHouse/mcp-clickhouse";
+    changelog = "https://github.com/ClickHouse/mcp-clickhouse/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jpds
+      thevar1able
+    ];
+    mainProgram = "mcp-clickhouse";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
https://github.com/clickhouse/mcp-clickhouse - depends on #560102.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
