### PR TITLE
headplane: 0.7.0 -> 0.7.1

### DIFF
--- a/pkgs/by-name/he/headplane/package.nix
+++ b/pkgs/by-name/he/headplane/package.nix
@@ -13,14 +13,14 @@
 }:
 let
   pname = "headplane";
-  version = "0.7.0";
-  goVendorHash = "sha256-MvrqKMD+A+qBZmzQv+T9920U5uJop+pjfJpZdm2ZqEA=";
-  pnpmDepsHash = "sha256-OBerkCnB/QL5HGYp2kehzFYEIKSuqpBt0dTFHIypc00=";
+  version = "0.7.1";
+  goVendorHash = "sha256-Q5lRDbx7bg3WsrF+ukVPl7rTSJcqKFhYM9lWtqfiIw4=";
+  pnpmDepsHash = "sha256-2W/BTqarSlTMKIByB106xsyitRtK2bIeWeVKe2P96j8=";
   src = fetchFromGitHub {
     owner = "tale";
     repo = "headplane";
     tag = "v${version}";
-    hash = "sha256-UMAGsrG2xfpgWlsDhf4aWJKoOrUbruucDNOhCJcYmQQ=";
+    hash = "sha256-hRM+TTAKUxonJF3YHHvz9fpZeRo1kUpe7gHVyZy6sDc=";
   };
 
   headplaneSshWasm = buildGoModule {
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Feature-complete Web UI for Headscale";
     homepage = "https://github.com/tale/headplane";
-    changelog = "https://github.com/tale/headplane/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/tale/headplane/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       igor-ramazanov


### PR DESCRIPTION
Diff: https://github.com/tale/headplane/compare/v0.7.0...v0.7.1

Changelog: https://github.com/tale/headplane/releases/tag/v0.7.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
