### PR TITLE
tirith: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/by-name/ti/tirith/package.nix
+++ b/pkgs/by-name/ti/tirith/package.nix
@@ -8,15 +8,15 @@
 }:
 rustPlatform.buildRustPackage (final: {
   pname = "tirith";
-  version = "0.4.1";
+  version = "0.4.2";
   src = fetchFromGitHub {
     owner = "sheeki03";
     repo = "tirith";
     tag = "v${final.version}";
-    hash = "sha256-WyLcLKQ75UVaE6WtT0CaxfDS4qY/ShO9roMxQJPp5qE=";
+    hash = "sha256-5feylgprI/k+Y3dNeEdl3/TpNBdvjRA6u8RjD4eMQP4=";
   };
 
-  cargoHash = "sha256-MYYAltyAFFt1BSkOwWpMEKw5rzQfduzDG7JcBEzKbOg=";
+  cargoHash = "sha256-J58LW86QbSU4us6MCq8I0Oh8+uSHsSigEQwsXVNu4LU=";
 
   cargoBuildFlags = [
     "-p"


### PR DESCRIPTION
Updated with `nix-update`. [0.4.2 changelog](https://github.com/sheeki03/tirith/blob/v0.4.2/CHANGELOG.md).

Regenerated after upstream replaced `v0.4.2` before publishing release assets. This update targets commit `7fd35101568bb06ee0d361dc1d4a4d193c5f60fd` and supersedes the earlier source hash and verification.

[Verification](https://github.com/sheeki03/tirith/actions/runs/34620833298) used Nixpkgs `aff8a0b28396750446e5537a96461bc4facdb287`: sandboxed x86_64-linux build, install version check, and 17 installed CLI/shell-helper checks with Bash, zsh, and fish. Missing FHS helpers were simulated in private hook copies; no NixOS VM was tested. The run artifact contains the patch and logs.

Package changes and commit message were generated by `nix-update`; verification and this summary were assisted by Codex (GPT-6).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
