### PR TITLE
python3Packages.imapclient: 3.1.0 -> 4.0.1

### DIFF
--- a/pkgs/development/python-modules/imapclient/default.nix
+++ b/pkgs/development/python-modules/imapclient/default.nix
@@ -2,24 +2,23 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  six,
   pytestCheckHook,
+  setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "imapclient";
-  version = "3.1.0";
-
-  format = "setuptools";
+  version = "4.0.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mjs";
     repo = "imapclient";
-    tag = version;
-    hash = "sha256-J+pB+jXAoZItvaR8o+97sETFYxWj+uslmvsAe/Q0Gzc=";
+    tag = finalAttrs.version;
+    hash = "sha256-FqQfHO1kVdX5AreQichJYCMzXRRLzVJRYm/t9RouAxw=";
   };
 
-  propagatedBuildInputs = [ six ];
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -32,6 +31,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    changelog = "https://github.com/mjs/imapclient/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://imapclient.readthedocs.io";
     description = "Easy-to-use, Pythonic and complete IMAP client library";
     license = lib.licenses.bsd3;
@@ -40,4 +40,4 @@ buildPythonPackage rec {
       dotlambda
     ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/mjs/imapclient/compare/3.1.0...4.0.1

Changelog: 
https://github.com/mjs/imapclient/releases/tag/4.0.0
           https://github.com/mjs/imapclient/releases/tag/4.0.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
