### PR TITLE
ariang-native: init at 1.3.14

### DIFF
--- a/pkgs/by-name/ar/ariang-native/package.nix
+++ b/pkgs/by-name/ar/ariang-native/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  copyDesktopItems,
+  icoutils,
+  makeWrapper,
+  makeDesktopItem,
+  electron,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "ariang-native";
+  version = "1.3.14";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mayswind";
+    repo = "AriaNg-Native";
+    tag = finalAttrs.version;
+    hash = "sha256-ByQPAZVQEqqjD7th0wq06NdOsAR7YchWpV3LHu4QzTk=";
+  };
+
+  dontNpmBuild = true;
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-mTu/QcsPq7YoUSuKtS34P+y38oIoB3zyuDL9ELQDoBQ=";
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    icoutils
+    makeWrapper
+  ];
+
+  desktopItems = with finalAttrs; [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "AriaNg Native";
+      genericName = meta.description;
+      comment = meta.description;
+      icon = pname;
+      exec = "${pname} %U";
+      mimeTypes = [ "x-scheme-handler/magnet" ];
+      categories = [ "Network" ];
+      startupWMClass = pname;
+    })
+  ];
+
+  postInstall = with finalAttrs; ''
+    # Create desktop icons
+    icotool -x assets/AriaNg.ico
+    ls *.png | sort -V | while read -r file; do
+      size=$(echo "$file" | awk -F '_' '{print $3}' | cut -d 'x' -f 1)
+      mkdir -p "$out/share/icons/hicolor/''${size}x''${size}/apps"
+      mv "$file" "$out/share/icons/hicolor/''${size}x''${size}/apps/${pname}.png"
+    done
+
+    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
+      --add-flags "$out/lib/node_modules/${pname}"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A better aria2 desktop frontend than AriaNg, with all features of AriaNg and providing more features for desktop usage";
+    homepage = "https://github.com/mayswind/AriaNg-Native";
+    changelog = "https://github.com/mayswind/AriaNg-Native/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ProxyVT ];
+    mainProgram = finalAttrs.pname;
+  };
+})


### PR DESCRIPTION
https://github.com/mayswind/AriaNg-Native


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
