### PR TITLE
home-assistant: 2026.9.1 -> 2026.9.2

### DIFF
--- a/pkgs/development/python-modules/gcal-sync/default.nix
+++ b/pkgs/development/python-modules/gcal-sync/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "gcal-sync";
-  version = "9.1.0";
+  version = "9.1.1";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "allenporter";
     repo = "gcal_sync";
     tag = version;
-    hash = "sha256-9hSe2cHWG1biDQuYTVsvMz5LjUoyTkkwgay8OIlQeco=";
+    hash = "sha256-IgfNngtbNRqrVcyr5J2dzcIsy6ibjiw6ZqVMhnD1Efo=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -11,19 +11,20 @@
   pycryptodome,
   platformdirs,
   typing-extensions,
+  pytest-asyncio,
   pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "midea-local";
-  version = "10.1.0";
+  version = "11.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "midea-lan";
     repo = "midea-local";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aCQsA9N6s4r2x466DNTUFqxRP4dfXZBSD9rrC9Bvrb4=";
+    hash = "sha256-9Yx3i/zZvVqZrlsbLxkWWFAITFnwOAaaiBoFfjaYbKw=";
   };
 
   build-system = [ setuptools ];
@@ -39,7 +40,10 @@ buildPythonPackage (finalAttrs: {
     typing-extensions
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "midealocal" ];
 

--- a/pkgs/development/python-modules/pyenphase/default.nix
+++ b/pkgs/development/python-modules/pyenphase/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyenphase";
-  version = "4.0.1";
+  version = "4.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pyenphase";
     repo = "pyenphase";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-t/89z0Gx9vZgIb0rXAPstx6o90xUEclagnNsiwsG6z8=";
+    hash = "sha256-1p/QaPK9sDymbG7gzJ+81TtzIT2jINLfMs3/1i12jVA=";
   };
 
   pythonRelaxDeps = [ "tenacity" ];

--- a/pkgs/development/python-modules/python-roborock/default.nix
+++ b/pkgs/development/python-modules/python-roborock/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "python-roborock";
-  version = "7.2.3";
+  version = "7.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Python-roborock";
     repo = "python-roborock";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rrtAH12oSvF3CgLBuSQ50Q32Cr/wfsGVskeSUa3v3/M=";
+    hash = "sha256-dSkIO5XgnT+NsNeiq4wCTsGXrgN/uSnxYMrxcBdFMio=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/pyvicare/default.nix
+++ b/pkgs/development/python-modules/pyvicare/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyvicare";
-  version = "2.62.0";
+  version = "2.62.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openviess";
     repo = "PyViCare";
     tag = finalAttrs.version;
-    hash = "sha256-E3eUXffXZsQsm2XPpsIxaHo2HW3VqWFiud5Cg1cFKLc=";
+    hash = "sha256-l999lP9uW6yCnaA0pk3sM7yVkGOns6Tpve8NZK7WyH8=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/reolink-aio/default.nix
+++ b/pkgs/development/python-modules/reolink-aio/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "reolink-aio";
-  version = "0.21.15";
+  version = "0.21.16";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "starkillerOG";
     repo = "reolink_aio";
     tag = finalAttrs.version;
-    hash = "sha256-I50EOpG4pdmx2xDVocwoUtkcT2rrnDNSBIeMXPln6OU=";
+    hash = "sha256-aTPXma80N8LZCaI1Jn9gOribVYIGn/tny7VRATFf7wM=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/satel-integra/default.nix
+++ b/pkgs/development/python-modules/satel-integra/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "satel-integra";
-  version = "1.3.1";
+  version = "1.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "c-soft";
     repo = "satel_integra";
     tag = version;
-    hash = "sha256-lNlre+0mOmIjrmYsAqt0QERERsXzKi0wRfbs1c//f/c=";
+    hash = "sha256-SGeCIiEi9Gkmpr2hjtPskOIxpK67G0vuEZZVQhYyse0=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/waterfurnace/default.nix
+++ b/pkgs/development/python-modules/waterfurnace/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "waterfurnace";
-  version = "1.8.0";
+  version = "1.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sdague";
     repo = "waterfurnace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-o5C964T53JgSBG2M3LP45xNika70CXZmR5Z4ThGdxSE=";
+    hash = "sha256-PvcewNEs+EKygUGGXsjOD/RuZvLYkO2zuOM99Z0yI48=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "2.2.1";
+  version = "2.2.2";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha-device-handlers";
     tag = version;
-    hash = "sha256-Goh7xfOkUZVYfpjgXSHk1oTrdX2WUi+sF136D0BkiDc=";
+    hash = "sha256-3EcRB412I+0yazAXX2qtqhrSzR8D/52b4HZkuAmQaoM=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zha/default.nix
+++ b/pkgs/development/python-modules/zha/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "zha";
-  version = "2.2.1";
+  version = "2.2.2";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -35,7 +35,7 @@ buildPythonPackage (finalAttrs: {
     owner = "zigpy";
     repo = "zha";
     tag = finalAttrs.version;
-    hash = "sha256-Gmfi7ogDylvf3FKVQGkVjTzuT8zAfAbqIDfbWQOCF88=";
+    hash = "sha256-B8d+9kKJUXpL3lC9AV8ZQhU/AHrnYrnm2i9Ygxyz0aI=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "zigpy";
-  version = "2.1.0";
+  version = "2.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy";
     tag = finalAttrs.version;
-    hash = "sha256-zmgh+ihNgQMxGoWx3zQ+UWGh04IyXCQUfGf3ybJg3Sc=";
+    hash = "sha256-7HGS3nZ+xse6Hx4oj3iZIjvcjc8vhECz1uJfseYlUUY=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.9.1";
+  version = "2026.9.2";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/custom-components/adaptive_lighting/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/adaptive_lighting/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "basnijholt";
   domain = "adaptive_lighting";
-  version = "1.31.0";
+  version = "1.32.0";
 
   src = fetchFromGitHub {
     owner = "basnijholt";
     repo = "adaptive-lighting";
     tag = "v${version}";
-    hash = "sha256-L00M+74ZgJmUje5c/TBkBlsjCrqPt7i/8hH8SU5cnRc=";
+    hash = "sha256-+MO9wl4nu/yJ7Lyt1kf/thGcjNjR17cPkFAYZqfVzQ8=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
@@ -14,13 +14,13 @@
 buildHomeAssistantComponent rec {
   owner = "luuquangvu";
   domain = "blueprints_updater";
-  version = "2.14.5";
+  version = "2.14.6";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "blueprints-updater";
     tag = version;
-    hash = "sha256-aU7oyFMeQkaVAHQcMvMn28Kx0KZ7zanI3ZLNJtM1mu4=";
+    hash = "sha256-udj68ZlkSR2oldFfCEJh5A1gHF8GWb/iNluDrZ8L6us=";
   };
 
   patches = [

--- a/pkgs/servers/home-assistant/custom-components/browser-mod/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/browser-mod/package.nix
@@ -10,13 +10,13 @@
 buildHomeAssistantComponent rec {
   owner = "thomasloven";
   domain = "browser_mod";
-  version = "3.2.2";
+  version = "3.2.3";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "hass-browser_mod";
     tag = "v${version}";
-    hash = "sha256-OOMbMQkDC1eeljtu8UiY+YkenDIWReXNAfjoo64E2Rs=";
+    hash = "sha256-CRUNg9Wa5LEtTMTOSnh4Wx8kT71XWs41PFQXMjnFo28=";
   };
 
   nativeBuildInputs = [
@@ -27,7 +27,7 @@ buildHomeAssistantComponent rec {
 
   npmDeps = fetchNpmDeps {
     inherit src;
-    hash = "sha256-iwaECS2y7PWrPbeZMq2gsF4ixQFOQLIklLKRCRtwT9U=";
+    hash = "sha256-GgeXLnRh1bF3DFTRmjyhSgV/xJYf42zr9XCOlJYZwnA=";
   };
 
   npmBuildScript = "build";

--- a/pkgs/servers/home-assistant/custom-components/ecoflow_ble/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/ecoflow_ble/package.nix
@@ -18,13 +18,13 @@
 buildHomeAssistantComponent rec {
   owner = "rabits";
   domain = "ef_ble";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "rabits";
     repo = "ha-ef-ble";
     tag = "v${version}";
-    hash = "sha256-N1LDWje8CJBi07vZLleUbs89XFM1cWacofMnKzhdwi0=";
+    hash = "sha256-ccWhF+vslBcPW8rKZKKYMcprSc/T9lsy1FNs4XP9O/A=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/localthings/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/localthings/package.nix
@@ -12,13 +12,13 @@
 buildHomeAssistantComponent (finalAttrs: {
   owner = "mbillow";
   domain = "localthings";
-  version = "0.25.0";
+  version = "0.26.1";
 
   src = fetchFromGitHub {
     owner = "mbillow";
     repo = "localthings";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8azW50GPBSjD5RAfG371T0T4/HoDoyyyxvIqgVvF5hU=";
+    hash = "sha256-7hFLCqZWiE3lo08wehXsqNdiddE4lAp02nQhzsDO0hs=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "pymitsubishi";
   domain = "mitsubishi";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "pymitsubishi";
     repo = "homeassistant-mitsubishi";
     tag = "v${version}";
-    hash = "sha256-TGRAx2c/hJVBAn2ylUXkhDdXLRsbbdhqpy035Bo6I5Y=";
+    hash = "sha256-04QBtgkRDmrXI6Vl3FvzTiy7MqTDnJgCqExLwlzR4pw=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/sensi/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/sensi/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "iprak";
   domain = "sensi";
-  version = "2.1.6";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
     tag = "v${version}";
-    hash = "sha256-fXRfreuPVerQMPmF/NQgVk9fELUjpUB6lMqodhRHuzo=";
+    hash = "sha256-n9KjZDWyuucNdvPVl34gfye4LrqyasOMiO6M+5Vh4Kw=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/custom-components/tibber_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/tibber_local/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "marq24";
   domain = "tibber_local";
-  version = "2026.9.1";
+  version = "2026.9.3";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "ha-tibber-pulse-local";
     tag = version;
-    hash = "sha256-60umYYWt2LwEJeKoKYb6+nXThNs6aUTwwzXXZvWho2M=";
+    hash = "sha256-S5pdVjb1kX4C8x+nm6QirrVXZVFymL+ldv3DPJx4pOo=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "al-one";
   domain = "xiaomi_miot";
-  version = "1.1.4";
+  version = "1.1.5";
 
   src = fetchFromGitHub {
     owner = "al-one";
     repo = "hass-xiaomi-miot";
     rev = "v${version}";
-    hash = "sha256-t1kOPiZR0CxOsp2V4cJNi+aiDdr7VhqhX8jOAiKTemk=";
+    hash = "sha256-V8VPLaRJ1syTHiN9RvmzlxisOPkUMCtVP7My4BTIhgo=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/kiosk-mode/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/kiosk-mode/package.nix
@@ -12,20 +12,20 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "kiosk-mode";
-  version = "14.1.0";
+  version = "14.2.0";
 
   src = fetchFromGitHub {
     owner = "nemesisre";
     repo = "kiosk-mode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ei3ilYwIQIMojYFo5MeK4okzbJuUGiNGNu6EJLkP/BY=";
+    hash = "sha256-htFxbcoTu4yh3hNxpo++GdMdaQXK46gcdzkQfy6V/tA=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-d0u1jGF6vBMSyr5fgCMjNW0eL8BtaTPtJmVhx3JBkYM=";
+    hash = "sha256-AYwWqjY+RDxmDPB0FFPOz0PzwRxTLnXfQ2JTe3imW9s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/tankerkoenig-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/tankerkoenig-card/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "tankerkoenig-card";
-  version = "1.7.4";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "timmaurice";
     repo = "lovelace-tankerkoenig-card";
     tag = finalAttrs.version;
-    hash = "sha256-gWxG0yWbZLP6SzpY7tQuPgO5GgpJhGfQH4oxVjZkZdM=";
+    hash = "sha256-RhaXF7avYC75j9/4TRkg0fy7OTdU/X0nADwsW9Bb4+o=";
   };
 
-  npmDepsHash = "sha256-IRne9ECGXlN+9CJtZekmbb2vLp4eiJ8YJIZWy8rCILQ=";
+  npmDepsHash = "sha256-OWToUfhL9AvomltUXtBwh1SFCJtPvqz7gFGb4OS1JnU=";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -133,15 +133,6 @@ let
         doCheck = false; # no tests
       });
 
-      openhomedevice = super.openhomedevice.overridePythonAttrs (oldAttrs: rec {
-        version = "2.2";
-        src = fetchFromGitHub {
-          inherit (oldAttrs.src) owner repo;
-          tag = version;
-          hash = "sha256-GGp7nKFH01m1KW6yMkKlAdd26bDi8JDWva6OQ0CWMIw=";
-        };
-      });
-
       plexapi = super.plexapi.overrideAttrs (oldAttrs: rec {
         version = "4.15.16";
         src = fetchFromGitHub {
@@ -180,17 +171,6 @@ let
           "test_async_add_tasks"
           "test_send_heartbeat"
         ];
-      });
-
-      # Pinned due to API changes >0.3.5.3
-      pyatag = super.pyatag.overridePythonAttrs (oldAttrs: rec {
-        version = "0.3.5.3";
-        src = fetchFromGitHub {
-          owner = "MatsNl";
-          repo = "pyatag";
-          rev = version;
-          sha256 = "00ly4injmgrj34p0lyx7cz2crgnfcijmzc0540gf7hpwha0marf6";
-        };
       });
 
       pyflume = super.pyflume.overridePythonAttrs (oldAttrs: rec {
@@ -271,7 +251,7 @@ let
   extraBuildInputs = extraPackages python3Packages;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.9.1";
+  hassVersion = "2026.9.2";
 
 in
 python3Packages.buildPythonApplication rec {
@@ -292,13 +272,13 @@ python3Packages.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-YaTWD5uKRjA9T0VKVh0miusR7nVuGZCsexPlYfED7ew=";
+    hash = "sha256-JBGydiQydkIDPl1HybR7OK8Y1iuqht3olOlzY1tz/KQ=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-zeCzwWuVoVuBgtLz64dOc2ifcui87rY5nUKVJyQIFCs=";
+    hash = "sha256-CnnNTxNkK+pO0YczaZiRoNplH2s74fzCv7XEWdxvd+E=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage (finalAttrs: {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20260826.6";
+  version = "20260826.7";
   format = "wheel";
 
   src = fetchPypi {
@@ -17,7 +17,7 @@ buildPythonPackage (finalAttrs: {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-S6t752u/8ug8+p7q6Lwio90SHceE7sLeRCwyWUgz/pI=";
+    hash = "sha256-onFP3Bup+sKeOArjtXo3oaBMvG8PWL/zRYwigbkVKpQ=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.364";
+  version = "0.13.365";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-4SWeD3K2SDIjRoC90TT/CMh+zjrjcNS5I5ezVZby6r4=";
+    hash = "sha256-ETvPBSmFySu10Q2MLeKAZNEdb2XnYxTzThSSg6bkG8Y=";
   };
 
   patches = [

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.9.1";
+  version = "2026.9.2";
   pyproject = true;
 
   disabled = python.version != home-assistant.python3Packages.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-PAlj4zScClRRn6AbSyurF4Rb8njItAmjbLLP4fLcha0=";
+    hash = "sha256-VL420WZG/C5Ru5tAkR2n15CCFW0UQ5f3hjTE31mGj+k=";
   };
 
   build-system = [


### PR DESCRIPTION
Diff: https://github.com/home-assistant/core/compare/2026.9.1...2026.9.2

Changelog: https://github.com/home-assistant/core/releases/tag/2026.9.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
