### PR TITLE
nixos/esphome: add stateDir option

### DIFF
--- a/nixos/modules/services/home-automation/esphome.nix
+++ b/nixos/modules/services/home-automation/esphome.nix
@@ -16,8 +16,6 @@ let
 
   cfg = config.services.esphome;
 
-  stateDir = "/var/lib/esphome";
-
   esphomeParams =
     if cfg.enableUnixSocket then
       "--socket /run/esphome/esphome.sock"
@@ -100,6 +98,13 @@ in
         Use this option for setting the dashboard password.
       '';
     };
+    stateDir = mkOption {
+      default = "/var/lib/esphome";
+      type = types.str;
+      description = ''
+        The place where esphome stores its state.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -111,7 +116,7 @@ in
     # See: https://github.com/NixOS/nixpkgs/issues/339557
     users.users.esphome = {
       isSystemUser = true;
-      home = stateDir;
+      home = cfg.stateDir;
       group = "esphome";
     };
 
@@ -126,26 +131,26 @@ in
       environment = {
         # Set PLATFORMIO_CORE_DIR to a real path (not a symlink) so PlatformIO
         # and its downloaded toolchains can resolve paths correctly.
-        PLATFORMIO_CORE_DIR = "${stateDir}/.platformio";
+        PLATFORMIO_CORE_DIR = "${cfg.stateDir}/.platformio";
         # platformio needs a writable HOME for its configuration
-        HOME = stateDir;
+        HOME = cfg.stateDir;
       }
       // lib.optionalAttrs cfg.usePing { ESPHOME_DASHBOARD_USE_PING = "true"; }
       // cfg.environment;
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/esphome dashboard ${esphomeParams} ${stateDir}";
+        ExecStart = "${cfg.package}/bin/esphome dashboard ${esphomeParams} ${cfg.stateDir}";
         User = "esphome";
         Group = "esphome";
-        WorkingDirectory = stateDir;
+        WorkingDirectory = cfg.stateDir;
         StateDirectory = "esphome";
         StateDirectoryMode = "0750";
         Restart = "on-failure";
         RuntimeDirectory = mkIf cfg.enableUnixSocket "esphome";
         RuntimeDirectoryMode = "0750";
         EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
-        ReadWritePaths = [ stateDir ];
-        ExecPaths = [ stateDir ];
+        ReadWritePaths = [ cfg.stateDir ];
+        ExecPaths = [ cfg.stateDir ];
 
         # Hardening
         CapabilityBoundingSet = "";


### PR DESCRIPTION
Changed the state directory path to be an option instead of being hard coded. It gives the user control over where the application state is saved while keeping the original default behavior.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
