### PR TITLE
hashcat: remove cudatoolkit, modernize

### DIFF
--- a/pkgs/by-name/ha/hashcat/package.nix
+++ b/pkgs/by-name/ha/hashcat/package.nix
@@ -12,7 +12,7 @@
   ocl-icd,
   perl,
   python3,
-  rocmPackages ? { },
+  rocmPackages,
   rocmSupport ? config.rocmSupport,
   xxhash,
   zlib,
@@ -93,15 +93,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup =
     let
-      LD_LIBRARY_PATH = builtins.concatStringsSep ":" (
+      LD_LIBRARY_PATH = lib.makeLibraryPath (
         [
-          "${ocl-icd}/lib"
+          ocl-icd
         ]
         ++ lib.optionals cudaSupport [
-          "${cudaPackages.cudatoolkit}/lib"
+          cudaPackages.cuda_nvrtc
+          cudaPackages.cuda_cudart
         ]
         ++ lib.optionals rocmSupport [
-          "${rocmPackages.clr}/lib"
+          rocmPackages.clr
         ]
       );
     in

--- a/pkgs/by-name/ha/hashcat/package.nix
+++ b/pkgs/by-name/ha/hashcat/package.nix
@@ -17,15 +17,19 @@
   xxhash,
   zlib,
   libiconv,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hashcat";
   version = "7.1.2";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchurl {
     url = "https://hashcat.net/files/hashcat-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-lUamMm10dTC0T8wHm6utQDBKh/MtPJCAAW1Ys5z8i5Y=";
+    hash = "sha256-lUamMm10dTC0T8wHm6utQDBKh/MtPJCAAW1Ys5z8i5Y=";
   };
 
   postPatch = ''
@@ -116,6 +120,9 @@ stdenv.mkDerivation (finalAttrs: {
         addDriverRunpath "$program"
       done
     '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Fast password cracker";


### PR DESCRIPTION
- **hashcat: cleanup ldpath, remove cudatoolkit**
- **hashcat: enable strictDeps, structuredAttrs, add versionCheckHook**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tested with `hashcat -I`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
