### PR TITLE
[Backport release-26.05] aurral: init at 2.8.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -827,6 +827,7 @@
   ./services/misc/anki-sync-server.nix
   ./services/misc/apache-kafka.nix
   ./services/misc/atuin.nix
+  ./services/misc/aurral.nix
   ./services/misc/autobrr.nix
   ./services/misc/autofs.nix
   ./services/misc/autorandr.nix

--- a/nixos/modules/services/misc/aurral.nix
+++ b/nixos/modules/services/misc/aurral.nix
@@ -1,0 +1,185 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.aurral;
+in
+{
+  options = {
+    services.aurral = {
+      enable = lib.mkEnableOption "Aurral is the Lidarr companion for self-hosted music discovery";
+
+      package = lib.mkPackageOption pkgs "aurral" { };
+
+      directories = lib.mkOption {
+        type = lib.types.listOf lib.types.externalPath;
+        default = [ ];
+        description = ''
+          Directories that Aurral needs access to. Other directories won't be visible by the app.
+          Environment variable `DOWNLOAD_FOLDER` is added automatically.
+          See BindPaths in {manpage}`systemd.exec(5)`.
+        '';
+      };
+
+      dataDir = lib.mkOption {
+        type = lib.types.externalPath;
+        default = "/var/lib/aurral";
+        description = ''
+          The directory where Aurral stores its stateful data.
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 3001;
+        description = "Port number";
+      };
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Open ports in the firewall for Aurral.
+        '';
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "aurral";
+        description = ''
+          User account under which Aurral runs.
+        '';
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "aurral";
+        description = ''
+          Group under which Aurral runs.
+        '';
+      };
+
+      environment = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        example = {
+          DOWNLOAD_FOLDER = "/media/downloads";
+          TRUST_PROXY = "true";
+        };
+        description = ''
+          Environment variables passed to the service.
+        '';
+      };
+
+      environmentFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          Environment file as defined in {manpage}`systemd.exec(5)` passed to the service.
+        '';
+      };
+
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.aurral = {
+      description = "Aurral";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = cfg.environment // {
+        AURRAL_DATA_DIR = cfg.dataDir;
+        PORT = toString cfg.port;
+      };
+
+      path = [ cfg.package ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        StateDirectory = lib.mkIf (cfg.dataDir == "/var/lib/aurral") "aurral";
+        WorkingDirectory = cfg.dataDir;
+        ReadWritePaths = "";
+        ProtectSystem = "strict";
+        BindPaths = [
+          cfg.dataDir
+        ]
+        ++ (lib.map (x: "-" + x) cfg.directories)
+        ++ lib.optional (cfg.environment ? DOWNLOAD_FOLDER) cfg.environment.DOWNLOAD_FOLDER;
+        BindReadOnlyPaths = [
+          builtins.storeDir
+          "${config.security.pki.caBundle}:/etc/ssl/certs/ca-certificates.crt"
+          "-/etc/resolv.conf"
+        ]
+        ++ lib.optionals config.services.resolved.enable [
+          "/run/systemd/resolve/stub-resolv.conf"
+          "/run/systemd/resolve/resolv.conf"
+        ];
+        RestrictSUIDSGID = true;
+        CapabilityBoundingSet = "";
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        SocketBindDeny = "any";
+        SocketBindAllow = toString cfg.port;
+        SystemCallErrorNumber = "EPERM";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0007";
+        SystemCallArchitectures = "native";
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        DevicePolicy = "closed";
+        PrivateIPC = true;
+        PrivatePIDs = true;
+        ProtectClock = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        ProtectHostname = true;
+        RemoveIPC = true;
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+        MemoryDenyWriteExecute = false;
+      };
+
+      confinement.enable = true;
+    };
+
+    systemd.tmpfiles.settings."10-aurral" = lib.mkIf (cfg.environment ? DOWNLOAD_FOLDER) {
+      ${cfg.environment.DOWNLOAD_FOLDER}.d = {
+        inherit (cfg) user group;
+        mode = "0770";
+      };
+    };
+
+    users.users = lib.mkIf (cfg.user == "aurral") {
+      aurral = {
+        isSystemUser = true;
+        home = cfg.dataDir;
+        group = cfg.group;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "aurral") {
+      aurral = { };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -245,6 +245,7 @@ in
   audiobookshelf = runTest ./audiobookshelf.nix;
   audit = runTest ./audit.nix;
   audit-testsuite = runTest ./audit-testsuite.nix;
+  aurral = runTest ./aurral.nix;
   auth-mysql = runTest ./auth-mysql.nix;
   authelia = runTest ./authelia.nix;
   auto-cpufreq = runTest ./auto-cpufreq.nix;

--- a/nixos/tests/aurral.nix
+++ b/nixos/tests/aurral.nix
@@ -1,0 +1,29 @@
+{ lib, ... }:
+{
+  name = "aurral";
+  meta = with lib.maintainers; {
+    maintainers = [ hougo ];
+  };
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        services.aurral = {
+          enable = true;
+          environment = {
+            DOWNLOAD_FOLDER = "/var/lib/aurral-downloads";
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("aurral.service")
+    machine.wait_for_open_port(3001)
+
+    machine.succeed('curl --fail http://localhost:3001/api/health')
+  '';
+}

--- a/pkgs/by-name/au/aurral/package.json.patch
+++ b/pkgs/by-name/au/aurral/package.json.patch
@@ -1,0 +1,15 @@
+diff --git a/package.json b/package.json
+index 5e1328e5..0f289597 100644
+--- a/package.json
++++ b/package.json
+@@ -4,9 +4,7 @@
+   "description": "Aurral artist request manager",
+   "private": true,
+   "type": "module",
+-  "engines": {
+-    "node": "22.23.x"
+-  },
++  "files": ["backend/*", "frontend/dist/*", "lib/*"],
+   "workspaces": [
+     "backend",
+     "frontend"

--- a/pkgs/by-name/au/aurral/package.nix
+++ b/pkgs/by-name/au/aurral/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  nodejs_26,
+  sqlite,
+  ffmpeg,
+  yt-dlp,
+  jemalloc,
+  runtimeShell,
+  makeFontsConf,
+  noto-fonts-color-emoji,
+  dejavu_fonts,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "aurral";
+  version = "2.8.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "lklynet";
+    repo = "aurral";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ceo5CHIGa+98XFLazqmAyAV64rzDYqB0gvJ95AKwfUk=";
+  };
+
+  # Specifies files to package leveraging npm & nix hooks. Not used by upstream.
+  # Remove engine constraint not matching upstream dockerfile.
+  patches = [
+    ./package.json.patch
+  ];
+
+  npmDepsHash = "sha256-Qa/TcKzMEY/w8FWKMiHUeqVB9cMxxWtEwF30y0nndkg=";
+
+  nodejs = nodejs_26;
+
+  env.VITE_APP_VERSION = finalAttrs.version;
+
+  npmInstallFlags = [
+    "--include=optional"
+    "--include-workspace-root=false"
+  ];
+
+  npmBuildFlags = [ "--workspace=frontend" ];
+
+  npmPruneFlags = [
+    "--workspace=backend"
+    "--include=optional"
+    "--include-workspace-root=false"
+  ];
+
+  postInstall = ''
+    mkdir $out/bin
+    cat > $out/bin/aurral <<EOL
+    #!${runtimeShell} -e
+    export LD_PRELOAD=${lib.getLib jemalloc}/lib/libjemalloc.so
+    export LD_LIBRARY_PATH=${
+      lib.makeLibraryPath [
+        sqlite
+      ]
+    }
+    export PATH=${
+      lib.makeBinPath [
+        finalAttrs.nodejs
+        ffmpeg
+        yt-dlp
+      ]
+    }\''${PATH:+:}\$PATH
+    export FONTCONFIG_FILE=${
+      makeFontsConf {
+        fontDirectories = [
+          noto-fonts-color-emoji
+          dejavu_fonts
+        ];
+      }
+    }
+    export APP_VERSION=${finalAttrs.version}
+    export NODE_ENV=production
+    case "\$1" in
+        resetAdminPassword)
+        exec node $out/lib/node_modules/aurral/backend/scripts/resetAdminPassword.js "\$@"
+        ;;
+        server|"")
+        exec node $out/lib/node_modules/aurral/backend/server.js
+        ;;
+        -h|--help|*)
+        echo "Usage: (server|resetAdminPassword)"
+        echo
+        echo "We recommend using it in the service namespace. Example:"
+        echo "sudo nsenter -t \\\$(systemctl show --property MainPID --value aurral.service) -a -e -S follow -G follow aurral resetAdminPassword -g"
+        ;;
+    esac
+    EOL
+    chmod +x $out/bin/aurral
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Aurral is the Lidarr companion for self-hosted music discovery";
+    mainProgram = "aurral";
+    homepage = "https://aurral.org";
+    changelog = "https://github.com/lklynet/aurral/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.intersectLists lib.platforms.linux (lib.platforms.x86_64 ++ lib.platforms.aarch64);
+    maintainers = with lib.maintainers; [
+      hougo
+      staticdev
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
