### PR TITLE
ruffle: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/by-name/ru/ruffle/package.nix
+++ b/pkgs/by-name/ru/ruffle/package.nix
@@ -30,13 +30,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ruffle";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "ruffle-rs";
     repo = "ruffle";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/x9blMac62JqA5eWUBqye3g2PWVWYJlOaPysXNSahgA=";
+    hash = "sha256-mllB1T3Fws/AQsj2MRAC6QagEi5Nw9BK8QduKA/2eF8=";
   };
 
   postPatch =
@@ -52,12 +52,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
                        "OpenH264Version(${major}, ${minor}, ${patch})"
     '';
 
-  cargoHash = "sha256-DSSKisWHbI0Cwiuqyg6EzvHIXB6fdV17nhXDQnqQIdM=";
+  cargoHash = "sha256-nSxVZXAjusE/VZvAjVeDoZasGlX19elPrgWmZuUS0B8=";
   cargoBuildFlags = lib.optional withRuffleTools "--workspace";
 
   env =
     let
-      commitDate = "2026-07-19";
+      commitDate = "2026-09-06";
     in
     {
       VERGEN_IDEMPOTENT = "1";


### PR DESCRIPTION
Diff : https://github.com/ruffle-rs/ruffle/compare/v0.5.0...v0.6.0
Changelog : https://github.com/ruffle-rs/ruffle/releases/tag/v0.6.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
