### PR TITLE
nixos/qemu-vm: restore 9p support for darwin; add darwin.linux-builder back to release blocker

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -24,6 +24,8 @@ let
 
   hostPkgs = cfg.host.pkgs;
 
+  useVirtiofs = hostPkgs.stdenv.hostPlatform.isLinux;
+
   consoles = lib.concatMapStringsSep " " (c: "console=${c}") cfg.qemu.consoles;
 
   driveOptions =
@@ -324,23 +326,25 @@ let
         ''
     )}
 
-    echo "Starting virtiofs daemons..."
-    NIX_VIRTIOFS_DIR=$(mktemp -d)
-    ${lib.concatLines (
-      lib.mapAttrsToList (tag: share: ''
-        ${lib.getExe hostPkgs.virtiofsd} \
-          --socket-path="$NIX_VIRTIOFS_DIR"/"${tag}" \
-          --shared-dir="${share.source}" \
-          ${if share.writable then "--writeback" else "--readonly"} \
-          --sandbox=none \
-          --seccomp=none \
-          --cache=always \
-          --no-announce-submounts \
-          --translate-uid=host:65534:0:1 \
-          --translate-gid=host:65534:0:1 \
-          &
-      '') cfg.sharedDirectories
-    )}
+    ${lib.optionalString useVirtiofs ''
+      echo "Starting virtiofs daemons..."
+      NIX_VIRTIOFS_DIR=$(mktemp -d)
+      ${lib.concatLines (
+        lib.mapAttrsToList (tag: share: ''
+          ${lib.getExe hostPkgs.virtiofsd} \
+            --socket-path="$NIX_VIRTIOFS_DIR"/"${tag}" \
+            --shared-dir="${share.source}" \
+            ${if share.writable then "--writeback" else "--readonly"} \
+            --sandbox=none \
+            --seccomp=none \
+            --cache=always \
+            --no-announce-submounts \
+            --translate-uid=host:65534:0:1 \
+            --translate-gid=host:65534:0:1 \
+            &
+        '') cfg.sharedDirectories
+      )}
+    ''}
 
     # Start QEMU.
     exec ${
@@ -437,11 +441,11 @@ in
     (mkRemovedOptionModule [
       "virtualisation"
       "msize"
-    ] "9p was replaced with virtiofs and thus this option is obsolete.")
+    ] "The 9p msize is no longer configurable.")
     (mkRemovedOptionModule [
       "virtualisation"
       "nixStore9pCache"
-    ] "9p was replaced with virtiofs and thus this option is obsolete.")
+    ] "The 9p cache mode for the Nix store is no longer configurable.")
   ];
 
   options = {
@@ -592,8 +596,9 @@ in
       };
       description = ''
         An attributes set of directories that will be shared with the
-        virtual machine using VirtFS (9P filesystem over VirtIO).
-        The attribute name will be used as the 9P mount tag.
+        virtual machine using virtiofs on Linux hosts and VirtFS (9P filesystem
+        over VirtIO) on other hosts. The attribute name will be used as the
+        mount tag.
       '';
     };
 
@@ -1278,10 +1283,20 @@ in
         "-machine memory-backend=mem0"
       ])
       (lib.flatten (
-        lib.mapAttrsToList (tag: share: [
-          "-chardev socket,id=${tag},path=$NIX_VIRTIOFS_DIR/${tag}"
-          "-device vhost-user-fs-pci,chardev=${tag},tag=${tag}"
-        ]) cfg.sharedDirectories
+        lib.mapAttrsToList (
+          tag: share:
+          if useVirtiofs then
+            [
+              "-chardev socket,id=${tag},path=$NIX_VIRTIOFS_DIR/${tag}"
+              "-device vhost-user-fs-pci,chardev=${tag},tag=${tag}"
+            ]
+          else
+            [
+              "-virtfs local,path=${share.source},security_model=none,mount_tag=${tag}${
+                lib.optionalString (!share.writable) ",readonly=on"
+              }"
+            ]
+        ) cfg.sharedDirectories
       ))
       (
         let
@@ -1373,9 +1388,20 @@ in
         name = share.target;
         value = {
           device = tag;
-          fsType = "virtiofs";
+          fsType = if useVirtiofs then "virtiofs" else "9p";
           neededForBoot = true;
-          options = lib.mkIf (!share.writable) [ "ro" ];
+          options =
+            if useVirtiofs then
+              lib.mkIf (!share.writable) [ "ro" ]
+            else
+              [
+                "trans=virtio"
+                "version=9p2000.L"
+                "msize=16384"
+                "x-systemd.requires=modprobe@9pnet_virtio.service"
+              ]
+              ++ lib.optional (tag == "nix-store") "cache=loose"
+              ++ lib.optional (!share.writable) "ro";
         };
       }) cfg.sharedDirectories)
       {
@@ -1488,8 +1514,6 @@ in
         (isEnabled "VIRTIO_PCI")
         (isEnabled "VIRTIO_NET")
         (isEnabled "EXT4_FS")
-        (isEnabled "NET_9P_VIRTIO")
-        (isEnabled "9P_FS")
         (isYes "BLK_DEV")
         (isYes "PCI")
         (isYes "NETDEVICES")
@@ -1497,6 +1521,15 @@ in
         (isYes "INET")
         (isYes "NETWORK_FILESYSTEMS")
       ]
+      ++ (
+        if useVirtiofs then
+          [ (isEnabled "VIRTIO_FS") ]
+        else
+          [
+            (isEnabled "NET_9P_VIRTIO")
+            (isEnabled "9P_FS")
+          ]
+      )
       ++ optionals (!cfg.graphics) [
         (isYes "SERIAL_8250_CONSOLE")
         (isYes "SERIAL_8250")

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -138,6 +138,7 @@ let
             jobs.stdenv.aarch64-darwin
             jobs.vim.aarch64-darwin
             jobs.cachix.aarch64-darwin
+            jobs.darwin.linux-builder.aarch64-darwin
 
             # UI apps
             # jobs.firefox-unwrapped.aarch64-darwin
@@ -220,6 +221,7 @@ let
         jobs.vim.aarch64-darwin
         jobs.inkscape.aarch64-darwin
         jobs.qt5.qtmultimedia.aarch64-darwin
+        jobs.darwin.linux-builder.aarch64-darwin
         /*
           jobs.tests.cc-wrapper.default.aarch64-darwin
           jobs.tests.cc-wrapper.llvmPackages.clang.aarch64-darwin


### PR DESCRIPTION
Keep virtiofs for linux, but use 9p otherwise. This restores darwin support -
which is used both for `darwin.linux-builder` and `build-vm` nixpkgs VMs.

This patch does not restore removed options: their utility is not immediately
clear to me, and restoring the options would complicate the code for unclear
gains. Hopefully, the reduced scope also makes it more palatable for
maintainers to accept this functionality back in.

With this change, I can build `darwin.linux-builder` and run NixOS tests again.

~~This should not affect linux rebuilds, hence posting to master.~~
Meh, there's a single newline change. Targeting to staging-nixos.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
