### PR TITLE
linyaps: fix sandboxed apps failing to start after system update

### DIFF
--- a/pkgs/by-name/li/linyaps/fix-host-path.patch
+++ b/pkgs/by-name/li/linyaps/fix-host-path.patch
@@ -1,17 +1,16 @@
 diff --git a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
-index 787e70cb..a71df46a 100644
+index 72d5890..ac63c57 100644
 --- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
 +++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
-@@ -19,6 +19,8 @@
+@@ -30,6 +30,7 @@
  #include <iomanip>
  #include <iostream>
- #include <vector>
+ #include <sstream>
 +#include <unordered_map>
-+#include <unordered_set>
+ #include <vector>
  
- #include <sys/stat.h>
- #include <sys/types.h>
-@@ -432,19 +434,67 @@ ContainerCfgBuilder &ContainerCfgBuilder::bindHostRoot() noexcept
+ #include <grp.h>
+@@ -596,19 +597,36 @@ ContainerCfgBuilder &ContainerCfgBuilder::bindHostRoot() noexcept
  
  ContainerCfgBuilder &ContainerCfgBuilder::bindHostStatics() noexcept
  {
@@ -27,16 +26,27 @@ index 787e70cb..a71df46a 100644
 +        { "/etc/machine-id", "" },
 +        { "/var/cache/fontconfig", "" },
 +
-+        { "/run/current-system/sw/lib/locale", "/usr/lib/locale"},
++        { "/run/current-system/sw/lib/locale", "/usr/lib/locale" },
 +        { "/run/current-system/sw/share/X11/fonts", "/usr/share/fonts" },
 +        { "/run/current-system/sw/share/icons", "/usr/share/icons" },
 +        { "/run/current-system/sw/share/themes", "/usr/share/themes" },
++
++        // Bind the whole host store read-only instead of chasing symlinks under
++        // /run/current-system/sw/share/{X11/fonts,icons,themes} and mounting each
++        // resolved /nix/store/<hash> entry at the same volatile path inside the
++        // sandbox: whenever a system update changes any store path, ll-box would
++        // have to create the new mount point below the cached (persistent,
++        // deepin-linglong-owned) overlay layer, which fails with EACCES and
++        // leaves the container permanently unstartable. A single stable
++        // destination decouples the mount set from the host generation. This is
++        // not a sandbox boundary change: the sandbox already exposes the whole
++        // host rootfs at /run/host/rootfs.
++        { "/nix/store", "" },
      };
  
      hostStaticsMount = std::vector<Mount>{};
 -    for (const auto &loc : statics) {
 -        bindIfExist(*hostStaticsMount, loc);
-+    auto nixStorePaths = std::unordered_set<std::string>{};
 +    for (const auto &[source, destination] : statics) {
 +        if (!std::filesystem::exists(source)) {
 +            std::cerr << "[bindHostStatics] Skipping non-existent path: " << source << std::endl;
@@ -44,48 +54,6 @@ index 787e70cb..a71df46a 100644
 +        }
 +
 +        bindIfExist(*hostStaticsMount, source, destination);
-+
-+        std::string sourcePathPrefix = "/run/current-system/sw/share/";
-+        std::string nixStorePrefix = "/nix/store/";
-+
-+        if (source.string().rfind(sourcePathPrefix, 0) != 0)
-+            continue;
-+
-+        std::error_code ec;
-+        for (const std::filesystem::directory_entry &dir_entry :
-+             std::filesystem::recursive_directory_iterator(source, std::filesystem::directory_options::skip_permission_denied, ec)) 
-+        {
-+            if (ec) {
-+                std::cerr << "[bindHostStatics] Failed to iterate directory: " << source << ", error: " << ec.message() << std::endl;
-+                break;
-+            }
-+
-+            if (!dir_entry.is_symlink(ec) || ec) {
-+                if (ec)
-+                    std::cerr << "[bindHostStatics] Failed to check symlink: " << dir_entry.path() << ", error: " << ec.message() << std::endl;
-+                continue;
-+            }
-+
-+            std::filesystem::path targetPath = std::filesystem::canonical(dir_entry.path(), ec);
-+            if (ec) {
-+                std::cerr << "[bindHostStatics] Failed to resolve symlink: " << dir_entry.path() << ", error: " << ec.message() << std::endl;
-+                continue;
-+            }
-+
-+            std::string target = targetPath.string();
-+            if (target.rfind(nixStorePrefix, 0) != 0)
-+                continue;
-+
-+            auto endPos = target.find('/', nixStorePrefix.length());
-+            if (endPos != std::string::npos)
-+                nixStorePaths.insert(target.substr(0, endPos));
-+            else
-+                nixStorePaths.insert(target);
-+        }
-+    }
-+
-+    for (const std::string &path : nixStorePaths) {
-+        bindIfExist(*hostStaticsMount, path);
      }
  
      return *this;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

`fix-host-path.patch` does two things: it bind-mounts
`/run/current-system/sw/lib/locale` and `/run/current-system/sw/share/{X11/fonts,icons,themes}`
to `/usr/lib/locale` and `/usr/share/{fonts,icons,themes}` inside the sandbox,
and it resolves every `/nix/store/<hash>` symlink target reachable from those
`share` trees, bind-mounting each entry at the same path inside the sandbox.
Those per-path mount destinations are generation-dependent: whenever a system
update changes any of those store paths, ll-box (running as the invoking user)
has to `mkdirat()` the new mount points inside the persistent overlay cache
layer owned by the `deepin-linglong` daemon user (mode 0755), which fails with
`EACCES` and leaves the container unstartable until the overlay cache is
manually removed (#561856).

The cache layer and its initial mount-point directories (including
`/nix/store` itself) are materialized once, when the daemon first builds the
container's overlay cache — which is why the very same app works right after
installation and only breaks after an update. Only mount points missing from
the cache, i.e. paths introduced by later system updates, are left for ll-box
to create.

This patch keeps the `sw/share/… → /usr/share/…` destination mappings
unchanged and replaces the per-path store mounts with a single read-only bind
of the host `/nix/store` at `/nix/store` inside the sandbox — a destination
that already exists in the cache regardless of the system generation.

- The mount set no longer depends on the current system generation, so a store
  path change can never require a new mount point; containers whose cache is
  already in the stale state recover without manual cleanup.
- The symlink walk at container-config build time goes away.
- This is not a sandbox boundary change: upstream `ContainerCfgBuilder::bindHostRoot`
  already rbinds the host `/` read-only at `/run/host/rootfs`, and `/nix/store`
  is readable by every user on the host.
- Nothing that exists behind `/nix/store` in the sandbox is shadowed: the
  sandbox rootfs (deepin runtime) ships no `/nix` of its own — the only thing
  behind that path was the per-path mount set created by the previous version
  of this patch.

Resolves #561856.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Testing done

The patch is developed and functionally tested against linyaps 1.14.0
(nixpkgs `de0ba0a8`); `container_cfg_builder.cpp` is unchanged between 1.14.0
and 1.14.1, and the patch also builds on current master (nixpkgs `8415b0a8`,
linyaps 1.14.1), where a container smoke test (base container start, full
`/nix/store` visibility, CJK font matching) also passes. Details below are
from the 1.14.0 runs.

On NixOS unstable, with `pkgs.linyaps` rebuilt with only this patch changed:

1. Reproduced the failure mode from the issue. For a stopped `org.deepin.base`
   container with a populated persistent cache, renamed one entry in its cache
   layer:
   `sudo mv /var/lib/linglong/cache/<layer-commit>/<container-id>/overlay/upperdir/nix/store/<hash>-X11-fonts{,.old-simulate-update}`
   (simulating a store path that changed after the cache was written). The
   unpatched `ll-cli run org.deepin.base` then fails with
   `mkdirat(…/rootfs/nix/store, "<hash>-X11-fonts") = -1 EACCES` (strace) and
   exits with `retval=65280` (exit status 255), matching the evidence in #561856.
2. With the patched `ll-cli`, the same container (cache still in the stale
   state) starts fine: `/nix/store` is fully visible inside the sandbox and
   fonts still resolve through the existing `/usr/share/fonts` mapping
   (`fc-match "sans-serif:lang=zh-cn"` → Noto Sans CJK SC).
3. Installed GUI apps (WeChat, WeMeet) launch and run normally with the patched
   `ll-cli`, including CJK input via the existing fcitx5 environment
   passthrough (with their overlay caches intact — healthy caches also start
   with the unpatched build, so this item is a regression check of the new
   mount scheme; stale-cache recovery was only verified for `org.deepin.base`). The
   patched build is now deployed as the daily linyaps on my machine
   (dogfood via a local overlay), and installed apps keep working across
   reboots.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

---

**Disclosure:** the patch and this PR description were drafted with an LLM
assistant; the testing steps above were executed on the affected machine and
the strace results are quoted from those runs. I have reviewed the change and
can answer questions about it.
