### PR TITLE
exa-agent-skills: init at 2026.09.11-e7de871

### DIFF
--- a/pkgs/by-name/ex/exa-agent-skills/package.nix
+++ b/pkgs/by-name/ex/exa-agent-skills/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installAgentSkills,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "exa-agent-skills";
+  version = "2026.09.11-e7de871";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "exa-labs";
+    repo = "agent-skills";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XUMCRlom4VVVbdkYa9Ez1eWHOeEr0C74BGAzk7i5Nto=";
+  };
+
+  nativeBuildInputs = [ installAgentSkills ];
+
+  meta = {
+    description = "Skills for the Exa API";
+    homepage = "https://github.com/exa-labs/agent-skills";
+    downloadPage = "https://github.com/exa-labs/agent-skills";
+    changelog = "https://github.com/exa-labs/agent-skills/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+  };
+})


### PR DESCRIPTION
Note: this work was sponsored by exa.ai! 🐐


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
