### PR TITLE
[Backport release-26.05] installAgentSkills: init

### DIFF
--- a/doc/hooks/installAgentSkills.section.md
+++ b/doc/hooks/installAgentSkills.section.md
@@ -1,0 +1,47 @@
+# `installAgentSkills` {#installAgentSkills}
+
+This hook automatically installs LLM agent skills into the proper location in `$out/share/skills/($pname|$base)/$skill/`.
+
+Agents do not scan package outputs themselves. Expose skills via `environment.pathsToLink = [ "/share/skills" ];` and symlink the wanted `share/skills/<pname>/<skill>` directories into the agent's skill directory (e.g. `~/.claude/skills/`).
+
+The automatic behavior of the hook can be disabled by setting the `dontInstallAgentSkills` variable to true.
+
+Additionally, it exposes the `installSkill` function that can be used from `postInstall`
+
+## `installSkill` {#installAgentSkills-installSkill}
+
+The `installSkill` function takes one or two arguments: a directory to copy to the install location, and an optional base directory.
+
+NB: passing a SKILL.md file directly as the first argument will fail as skills often contain other examples and tooling within the same directory.
+
+### Example Usage {#installAgentSkills-installSkill-exampleusage}
+
+```nix
+{
+  nativeBuildInputs = [ installAgentSkills ];
+
+  postInstall = ''
+    installSkill skills/skill-xyz
+  '';
+  # installs to $out/share/skills/$pname/skill-xyz
+
+  # OR
+
+  postInstall = ''
+    installSkill skills/skill-xyz random-base
+  '';
+  # installs to $out/share/skills/random-base/skill-xyz
+}
+```
+
+Where `skills/skill-xyz` may look like:
+
+```
+skills/skill-xyz:
+  - SKILL.md
+  - scripts/
+  - references/
+  - assets/
+  - ...
+```
+

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -137,6 +137,15 @@
   "inkscape-plugins": [
     "index.html#inkscape-plugins"
   ],
+  "installAgentSkills": [
+    "index.html#installAgentSkills"
+  ],
+  "installAgentSkills-installSkill": [
+    "index.html#installAgentSkills-installSkill"
+  ],
+  "installAgentSkills-installSkill-exampleusage": [
+    "index.html#installAgentSkills-installSkill-exampleusage"
+  ],
   "installfonts": [
     "index.html#installfonts"
   ],

--- a/pkgs/by-name/in/installAgentSkills/package.nix
+++ b/pkgs/by-name/in/installAgentSkills/package.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  callPackage,
+  makeSetupHook
+}:
+
+# used installFonts, installShellFiles as reference
+# See the header comment in ./setup-hook.sh for example usage.
+makeSetupHook {
+  name = "install-agent-skills";
+  meta = {
+    description = "Tools to install Agent skills into the correct directories";
+    license = lib.licenses.mit;
+  };
+} ./setup-hook.sh

--- a/pkgs/by-name/in/installAgentSkills/package.nix
+++ b/pkgs/by-name/in/installAgentSkills/package.nix
@@ -1,13 +1,27 @@
 {
   lib,
   callPackage,
-  makeSetupHook
+  makeSetupHook,
+  hunk,
+  worktrunk,
+  gh-stack,
 }:
 
 # used installFonts, installShellFiles as reference
 # See the header comment in ./setup-hook.sh for example usage.
 makeSetupHook {
   name = "install-agent-skills";
+  passthru = {
+    tests =
+      lib.packagesFromDirectoryRecursive {
+        inherit callPackage;
+        directory = ./tests;
+      }
+      // {
+        # few consumers that are good to test
+        inherit worktrunk hunk gh-stack;
+      };
+  };
   meta = {
     description = "Tools to install Agent skills into the correct directories";
     license = lib.licenses.mit;

--- a/pkgs/by-name/in/installAgentSkills/setup-hook.sh
+++ b/pkgs/by-name/in/installAgentSkills/setup-hook.sh
@@ -1,0 +1,78 @@
+# shellcheck shell=bash
+
+# Setup hook for the `installAgentSkills` package
+# Example usage in a derivation:
+#
+#   { ..., installAgentSkills, ... }:
+#   stdenv.mkDerivation {
+#     ...
+#     nativeBuildInputs = [ installAgentSkills ];
+#     ...
+#   }
+#
+# This hook also provides an `installSkill` function that can be used to install
+# skills manually into their respective folder
+#
+# Reference on skills standard here:
+#   https://github.com/agentskills/agentskills
+#
+#   An agent "skill" is structured:
+#     - SKILL.md - required: metadata + instructions
+#     - scripts/ - optional: executable code
+#     - references/ - optional: documentation
+#     - assets/ - optional: templates
+#     - ... - optional additional files/directories
+#
+
+preInstallHooks+=(installSkills)
+
+installSkill() {
+  if (($# != 1 && $# != 2)); then
+    nixErrorLog "expected 1 or 2 arguments!"
+    nixErrorLog "usage: installSkill skillDir [skillBase]"
+    nixErrorLog "where skillDir is \`dirname $1\` and skillBase is the skill parent directory"
+    nixErrorLog "unless set otherwise, skillBase=\$pname"
+    exit 1
+  fi
+
+  local skillName
+  skillName=$(basename -- "$1")
+  local base="${2:-${pname-}}"
+
+  if [ -z "$base" ]; then
+    nixErrorLog "error: no skillBase given and \$pname is unset"
+    exit 1
+  fi
+
+  if [ ! -d "$1" ]; then
+    nixErrorLog "expected ${skillName} to be a directory"
+    exit 1
+  fi
+
+  if [ ! -f "$1/SKILL.md" ]; then
+    nixErrorLog "error: ${skillName} doesn't contain a SKILL.md file"
+    exit 1
+  fi
+
+  local destdir="$out/share/skills/${base}"
+  local target="$destdir/$skillName"
+  if [ -e "$target" ]; then
+    nixErrorLog "error: $target already exists"
+    exit 1
+  fi
+
+  nixInfoLog "installing skill $1"
+  mkdir -p "$destdir"
+  cp -RLT -- "$1" "$target"
+}
+
+installSkills() {
+  if [ "${dontInstallAgentSkills-}" == 1 ]; then return; fi
+
+  (
+    shopt -s globstar nullglob
+    for skill in **/SKILL.md; do
+      installSkill "$(dirname -- "$skill")"
+    done
+  )
+}

--- a/pkgs/by-name/in/installAgentSkills/tests/dont-install-skills.nix
+++ b/pkgs/by-name/in/installAgentSkills/tests/dont-install-skills.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenvNoCC,
+  installAgentSkills,
+}:
+
+stdenvNoCC.mkDerivation {
+  # explicit pname is rquired for the hook to work but
+  # name is manually set to keep drvPath consistent across
+  # tests for installAgentSkills
+  pname = "test";
+  name = "install-agent-skills--dont-install-skills";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # src is required to be passed to mkDerivation
+  src = null;
+  dontUnpack = true;
+
+  nativeBuildInputs = [ installAgentSkills ];
+
+  dontInstallAgentSkills = true;
+
+  # build phase happens before the hook is called to install the skills
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p test-skill/
+    touch test-skill/SKILL.md
+
+    runHook postBuild
+  '';
+
+  # if the skill file is created then the test should fail
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    if test -f $out/share/skills/$pname/test-skill/SKILL.md; then
+      exit 1
+    fi
+
+    touch $out
+
+    runHook postInstallCheck
+  '';
+  doInstallCheck = true;
+
+  meta.platforms = lib.platforms.all;
+}

--- a/pkgs/by-name/in/installAgentSkills/tests/install-skill-skillBase.nix
+++ b/pkgs/by-name/in/installAgentSkills/tests/install-skill-skillBase.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  installAgentSkills,
+  runCommandLocal,
+}:
+
+runCommandLocal "install-agent-skills--install-skill-skillBase"
+  {
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    nativeBuildInputs = [ installAgentSkills ];
+    meta.platforms = lib.platforms.all;
+  }
+  ''
+    # required to functions/hook to work. this is a contrived example
+    # so its fine to manually set here
+    export pname=test-skillBase
+    export base=random-base
+
+    mkdir -p skill-xyz
+    echo "This is a test agent skill!" > skill-xyz/SKILL.md
+
+    installSkill ./skill-xyz $base
+    installSkill ./skill-xyz
+
+    cmp skill-xyz/SKILL.md $out/share/skills/$base/skill-xyz/SKILL.md
+    cmp $out/share/skills/$base/skill-xyz/SKILL.md $out/share/skills/$pname/skill-xyz/SKILL.md
+  ''

--- a/pkgs/by-name/in/installAgentSkills/tests/install-skill.nix
+++ b/pkgs/by-name/in/installAgentSkills/tests/install-skill.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  installAgentSkills,
+  runCommandLocal,
+}:
+
+runCommandLocal "install-agent-skills--install-skill"
+  {
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    nativeBuildInputs = [ installAgentSkills ];
+    meta.platforms = lib.platforms.all;
+  }
+  ''
+    # required to functions/hook to work. this is a contrived example
+    # so its fine to manually set here
+    export pname=test-installSkill
+
+    mkdir -p skill-xyz
+    echo "This is a test agent skill!" > skill-xyz/SKILL.md
+
+    installSkill ./skill-xyz
+
+    cmp skill-xyz/SKILL.md $out/share/skills/$pname/skill-xyz/SKILL.md
+  ''

--- a/pkgs/by-name/in/installAgentSkills/tests/install-skills.nix
+++ b/pkgs/by-name/in/installAgentSkills/tests/install-skills.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenvNoCC,
+  installAgentSkills,
+}:
+
+stdenvNoCC.mkDerivation {
+  # explicit pname is rquired for the hook to work but
+  # name is manually set to keep drvPath consistent across
+  # tests for installAgentSkills
+  pname = "test-installSkills";
+  name = "install-agent-skills--install-skills";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # src is required to be passed to mkDerivation
+  src = null;
+  dontUnpack = true;
+
+  nativeBuildInputs = [ installAgentSkills ];
+
+  # build phase happens before the hook is called to install the skills
+  buildPhase = ''
+    runHook preBuild
+
+    for skill in xyz abc nix; do
+      mkdir -p "skill-$skill"
+      echo "This is skill $skill" > "skill-$skill/SKILL.md"
+    done
+
+    runHook postBuild
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    for skill in xyz abc nix; do
+      cmp "skill-$skill/SKILL.md" "$out/share/skills/$pname/skill-$skill/SKILL.md"
+    done
+
+    runHook postInstallCheck
+  '';
+  doInstallCheck = true;
+
+  meta.platforms = lib.platforms.all;
+}

--- a/pkgs/by-name/in/installAgentSkills/tests/symlink-install-skills.nix
+++ b/pkgs/by-name/in/installAgentSkills/tests/symlink-install-skills.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  installAgentSkills,
+  runCommandLocal,
+}:
+
+runCommandLocal "install-agent-skills--symlink-install-skill"
+  {
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    nativeBuildInputs = [ installAgentSkills ];
+    meta.platforms = lib.platforms.all;
+  }
+  ''
+    # required to functions/hook to work. this is a contrived example
+    # so its fine to manually set here
+    export pname=test-installSkill
+
+    mkdir -p skill-xyz
+    echo "This is a test agent skill!" > skill-xyz/SKILL.md
+
+    ln -s skill-xyz skill-abc
+
+    installSkill ./skill-xyz
+    installSkill ./skill-abc
+
+    cmp skill-xyz/SKILL.md $out/share/skills/$pname/skill-xyz/SKILL.md
+    cmp $out/share/skills/$pname/skill-xyz/SKILL.md $out/share/skills/$pname/skill-abc/SKILL.md
+    if [ -L $out/share/skills/$pname/skill-abc ]; then exit 1; fi
+  ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
