### PR TITLE
plakar: 1.1.5 -> 1.1.6

### DIFF
--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -11,7 +11,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "plakar";
-  version = "1.1.5";
+  version = "1.1.6";
 
   # to avoid having all the Test(Get|Set|Validate)Service.* tests fail on darwin
   __darwinAllowLocalNetworking = true;
@@ -22,12 +22,12 @@ buildGoModule (finalAttrs: {
     owner = "PlakarKorp";
     repo = "plakar";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6uw20jqAtJnPEeNrMsK/jA7+stdY4tAEkPe+mov6UNo=";
+    hash = "sha256-AnVhWvfE2H5GfsgZyS14nla4vWZy7iIlD3lBP+LAJvA=";
   };
 
   vendorHash = "sha256-s/4vTHFFfOuGnVc3FK0B5aa9kRATr356/mGydw4cMng=";
 
-  # Remove in next release
+  # Remove in next next release
   patches = [
     (fetchpatch {
       name = "backup-allow-multiple-ignore-files.patch";
@@ -36,6 +36,11 @@ buildGoModule (finalAttrs: {
       hash = "sha256-9uxkXpuWs758xlu3afANB14hqhVut7agvIeOlcm+98k=";
     })
   ];
+
+  # broken test introduce in 1.1.6
+  postPatch = ''
+    rm login/completion_code_test.go
+  '';
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Diff : https://github.com/PlakarKorp/plakar/compare/v1.1.5...v1.1.6
Changelog : https://github.com/PlakarKorp/plakar/releases/tag/v1.1.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
