### PR TITLE
dependabot-cli: use new proxy image

### DIFF
--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -18,9 +18,9 @@ let
   tag = "nixpkgs-dependabot-cli-${version}";
 
   # Get these hashes from
-  # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy --image-tag latest --final-image-name dependabot-update-job-proxy --final-image-tag ${tag}
-  updateJobProxy.imageDigest = "sha256:70cf9a8f006db9cde732faf9e33a4f60af895532bbe803268fc8fd2f70aa3202";
-  updateJobProxy.hash = "sha256-IBUBBSXHwepTqvcWJyo5St+ceCc80ml0Arf6R9v54Eg=";
+  # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/dependabot/proxy --image-tag latest --final-image-name dependabot-update-job-proxy --final-image-tag ${tag}
+  updateJobProxy.imageDigest = "sha256:56d8f53a1ea2da7ddd61cc4c36e68cdd0c3ae8dfcc64bdc20979d28be6dbbf92";
+  updateJobProxy.hash = "sha256-tcDYnLKT0eFKsAYu2k3M0LLF4uZZWZCCC7X4AKamoSs=";
 
   # Get these hashes from
   # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/dependabot/dependabot-updater-github-actions --image-tag latest --final-image-name dependabot-updater-github-actions --final-image-tag ${tag}
@@ -79,7 +79,7 @@ buildGoModule {
     postBuild =
       let
         updateJobProxyImage = dockerTools.pullImage {
-          imageName = "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy";
+          imageName = "ghcr.io/dependabot/proxy";
           finalImageName = "dependabot-update-job-proxy";
           finalImageTag = tag;
           inherit (updateJobProxy) imageDigest hash;

--- a/pkgs/by-name/de/dependabot-cli/update.sh
+++ b/pkgs/by-name/de/dependabot-cli/update.sh
@@ -23,7 +23,7 @@ fi
 SHA256="$(nix-prefetch-url --quiet --unpack https://github.com/dependabot/cli/archive/refs/tags/v${VERSION}.tar.gz)"
 HASH="$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$SHA256")"
 
-nix-prefetch-docker --json --quiet --final-image-name dependabot-update-job-proxy --final-image-tag "nixpkgs-dependabot-cli-$VERSION" ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy latest > "$temp_dir/dependabot-update-job-proxy.json"
+nix-prefetch-docker --json --quiet --final-image-name dependabot-update-job-proxy --final-image-tag "nixpkgs-dependabot-cli-$VERSION" ghcr.io/dependabot/proxy latest > "$temp_dir/dependabot-update-job-proxy.json"
 
 nix-prefetch-docker --json --quiet --final-image-name dependabot-updater-github-actions --final-image-tag "nixpkgs-dependabot-cli-$VERSION" ghcr.io/dependabot/dependabot-updater-github-actions latest > "$temp_dir/dependabot-updater-github-actions.json"
 


### PR DESCRIPTION
Switch the bundled proxy image to `ghcr.io/dependabot/proxy`. Dependabot CLI switched to this image in https://github.com/dependabot/cli/pull/538.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
