### PR TITLE
python3Packages.hmmlearn: fix numpy 2.5 deprecation, modernize

### DIFF
--- a/pkgs/development/python-modules/hmmlearn/default.nix
+++ b/pkgs/development/python-modules/hmmlearn/default.nix
@@ -4,32 +4,43 @@
   buildPythonPackage,
   numpy,
   scikit-learn,
+  scipy,
   pybind11,
+  setuptools,
   setuptools-scm,
   cython,
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hmmlearn";
   version = "0.3.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-HTxdxMUlfgwjjcH+U4dwC4y5h+q4CO2z4Mc4KfHMROw=";
   };
 
-  buildInputs = [
+  build-system = [
+    setuptools
     setuptools-scm
     cython
     pybind11
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     numpy
     scikit-learn
+    scipy
   ];
+
+  postPatch = ''
+    substituteInPlace src/hmmlearn/utils.py \
+      --replace-fail \
+        'a_sum.shape = shape' \
+        'a_sum = np.reshape(a_sum, shape, copy=False)'
+  '';
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -46,4 +57,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
Numpy 2.5 deprecation error in hydra build https://hydra.nixos.org/build/344997034

```
        a_sum = a.sum(axis)
        if axis and a.ndim > 1:
            # Make sure we don't divide by zero.
            a_sum[a_sum == 0] = 1
            shape = list(a.shape)
            shape[axis] = 1
>           a_sum.shape = shape
            ^^^^^^^^^^^
E           DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
E           As an alternative, you can create a new view using np.reshape (with copy=False if needed).
```

https://numpy.org/devdocs/release/2.5.0-notes.html

> Setting the shape attribute is deprecated because mutating an array is unsafe if an array is shared, especially by multiple threads. As an alternative, you can create a new view via np.reshape or np.ndarray.reshape. For example: x = np.arange(15); x = np.reshape(x, (3, 5)). To ensure that no copy is made from the data, one can use np.reshape(..., copy=False).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixed the deprecated numpy pattern and modernized according to https://github.com/NixOS/nixpkgs/issues/515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
