### PR TITLE
obliteratus: 0-unstable-2026-08-14 -> 0.1.3

### DIFF
--- a/pkgs/by-name/ob/obliteratus/package.nix
+++ b/pkgs/by-name/ob/obliteratus/package.nix
@@ -1,23 +1,30 @@
 {
   lib,
   stdenv,
-  python3Packages,
   fetchFromGitHub,
   nix-update-script,
+  python3Packages,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "obliteratus";
-  version = "0-unstable-2026-08-14";
+  version = "0.1.3";
   pyproject = true;
+
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "elder-plinius";
     repo = "OBLITERATUS";
-    rev = "2295ef3571f64dec95e3fb3e42036b35d2efa43d";
-    hash = "sha256-LgtJQrIrOvWyxZ0vtPwQfzA4GRPJDjcO+gTwFAUKBgo=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+HjRn5DvTrG1eBv3oDP8KTwFIbAqnXhBp6tzH4qyWng=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools==80.9.0" "setuptools" \
+      --replace-fail "wheel==0.45.1" "wheel"
+  '';
 
   build-system = with python3Packages; [ setuptools ];
 
@@ -45,6 +52,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pythonImportsCheck = [ "obliteratus" ];
 
   nativeCheckInputs = with python3Packages; [
+    gradio
+    hypothesis
     pytest-cov-stub
     pytestCheckHook
   ];
@@ -66,6 +75,16 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test_linear_cone_fewer_directions"
     "test_methods_exist"
     "test_prompt_count_512"
+    # Calls CLI
+    "test_installed_package_cli_executes_offline_checkpoint_to_report_slice"
+    "test_installed_wheel_cli_loads_local_model_without_repository_imports"
+    # Tests require network access
+    "test_pinned_mistral4_config_resolves_composite_contract_without_remote_code"
+    "test_pinned_tiny_model_download_inference_and_offline_cache"
+    "test_pinned_tiny_model_evaluator_produces_finite_perplexity"
+    # Tests are hardware-dependent
+    "test_jetson_cuda_runtime_contract"
+    "test_jetson_cuda_offloaded_surgery_contract"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
@@ -80,6 +99,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Ablation Suite for HuggingFace transformers";
     homepage = "https://github.com/elder-plinius/OBLITERATUS";
+    changelog = "https://github.com/elder-plinius/OBLITERATUS/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "obliteratus";


### PR DESCRIPTION
Changelog: https://github.com/elder-plinius/OBLITERATUS/releases/tag/v0.1.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
