### PR TITLE
python3Packages.plastexdepgraph: fix version

### DIFF
--- a/pkgs/development/python-modules/plastexdepgraph/default.nix
+++ b/pkgs/development/python-modules/plastexdepgraph/default.nix
@@ -35,6 +35,7 @@ buildPythonPackage rec {
   meta = {
     description = "PlasTeX plugin allowing to build dependency graphs";
     homepage = "https://github.com/PatrickMassot/plastexdepgraph";
+    changelog = "https://github.com/PatrickMassot/plastexdepgraph/releases/tag/${version}";
     maintainers = with lib.maintainers; [ niklashh ];
     license = lib.licenses.asl20;
   };

--- a/pkgs/development/python-modules/plastexdepgraph/default.nix
+++ b/pkgs/development/python-modules/plastexdepgraph/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
     plasTeX
   ];
 
+  pythonImportsCheck = [ "plastexdepgraph" ];
+
   meta = {
     description = "PlasTeX plugin allowing to build dependency graphs";
     homepage = "https://github.com/PatrickMassot/plastexdepgraph";

--- a/pkgs/development/python-modules/plastexdepgraph/default.nix
+++ b/pkgs/development/python-modules/plastexdepgraph/default.nix
@@ -11,7 +11,7 @@
   plasTeX,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "plastexdepgraph";
   version = "0.0.5";
   pyproject = true;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     repo = "plastexdepgraph";
     owner = "PatrickMassot";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-GOTQmcWrmEZ2DkAMcE1ZknLOyVorGC87+qhO8jxcGJ4=";
   };
 
@@ -35,8 +35,8 @@ buildPythonPackage rec {
   meta = {
     description = "PlasTeX plugin allowing to build dependency graphs";
     homepage = "https://github.com/PatrickMassot/plastexdepgraph";
-    changelog = "https://github.com/PatrickMassot/plastexdepgraph/releases/tag/${version}";
+    changelog = "https://github.com/PatrickMassot/plastexdepgraph/releases/tag/${finalAttrs.src.tag}";
     maintainers = with lib.maintainers; [ niklashh ];
     license = lib.licenses.asl20;
   };
-}
+})

--- a/pkgs/development/python-modules/plastexdepgraph/default.nix
+++ b/pkgs/development/python-modules/plastexdepgraph/default.nix
@@ -10,7 +10,8 @@
   pygraphviz,
   plasTeX,
 }:
-buildPythonPackage {
+
+buildPythonPackage rec {
   pname = "plastexdepgraph";
   version = "0.0.5";
   pyproject = true;
@@ -18,8 +19,8 @@ buildPythonPackage {
   src = fetchFromGitHub {
     repo = "plastexdepgraph";
     owner = "PatrickMassot";
-    rev = "0.0.4";
-    hash = "sha256-Q13uYYZe1QgZHS4Nj8ugr+Fmhva98ttJj3AlXTK6XDw=";
+    tag = version;
+    hash = "sha256-GOTQmcWrmEZ2DkAMcE1ZknLOyVorGC87+qhO8jxcGJ4=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
