### PR TITLE
tclPackages.pgtcl: 3.3.0 -> 3.3.1

### DIFF
--- a/pkgs/development/tcl-modules/by-name/pg/pgtcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/pg/pgtcl/package.nix
@@ -8,21 +8,14 @@
 
 mkTclDerivation (finalAttrs: {
   pname = "pgtcl";
-  version = "3.3.0";
+  version = "3.3.1";
 
   src = fetchFromGitHub {
     owner = "flightaware";
     repo = "Pgtcl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rvGtQRmbWnvMGfPf7azjAdeVppjthTmFLuROBKZaD+A=";
+    hash = "sha256-+1qwU5ukbaeTHoOIIj1xU9XR7AvtkHnssIcNLLFDLjY=";
   };
-
-  # Fix Tcl9 stubs build
-  # https://github.com/flightaware/Pgtcl/pull/62
-  postPatch = ''
-    substituteInPlace generic/pgtcl.c \
-      --replace-fail 'Tcl_InitStubs(interp, "8.1"' 'Tcl_InitStubs(interp, "8.1-"'
-  '';
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
