### PR TITLE
brlcad: fix build; tinygltf_2: init at 2.9.7

### DIFF
--- a/pkgs/by-name/br/brlcad/package.nix
+++ b/pkgs/by-name/br/brlcad/package.nix
@@ -29,7 +29,7 @@
   qt6,
   stepcode,
   tcl,
-  tinygltf,
+  tinygltf_2,
   tk,
   zlib,
 
@@ -224,7 +224,7 @@ stdenv.mkDerivation (finalAttrs: {
     pugixml
     stepcode
     tcl
-    tinygltf
+    tinygltf_2
     tk
     zlib
   ]

--- a/pkgs/by-name/ti/tinygltf_2/package.nix
+++ b/pkgs/by-name/ti/tinygltf_2/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # nativeBuildInputs
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tinygltf";
+  version = "2.9.7";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "syoyo";
+    repo = "tinygltf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tG9hrR2rsfgS8zCBNdcplig2vyiIcNspSVKop03Zx9A=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    # unvendoring will break downstream applications
+    # unless at least patch the CMake modules
+    (lib.cmakeBool "TINYGLTF_INSTALL_VENDOR" true)
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex=^v(2\\..*)"
+    ];
+  };
+
+  meta = {
+    description = "Header only C++11 tiny glTF 2.0 library";
+    homepage = "https://github.com/syoyo/tinygltf";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ onny ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
build failed since bump to tinygltf >= 3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
