### PR TITLE
monocle: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/by-name/mo/monocle/package.nix
+++ b/pkgs/by-name/mo/monocle/package.nix
@@ -3,32 +3,27 @@
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "monocle";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "bgpkit";
     repo = "monocle";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UF4i1Nq0gZIZ2nZy9Lx9yeCVdl3uv5eQo8uVPvKuodE=";
+    hash = "sha256-Z+0YKohmgSNnGtw6yDTrLsx4Q5LFOOyIUt0ji0x18BQ=";
   };
 
-  cargoHash = "sha256-D5khIguUPvUT1Sa/m141BSnT0qkaXDreVpsTNSnH7x4=";
+  cargoHash = "sha256-h/FWi+LmGObU6FEOC0yNRhN8wQS6UzYN7Gxe9YO8fos=";
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
   # require internet access
   checkFlags = map (t: "--skip=${t}") [
-    "datasets::as2org::tests::test_crawling"
-    "datasets::ip::tests::test_fetch_ip_info"
-    "datasets::rpki::validator::tests::test_bgp"
-    "datasets::rpki::validator::tests::test_list_asn"
-    "datasets::rpki::validator::tests::test_list_prefix"
-    "datasets::rpki::validator::tests::test_validation"
-    "filters::search::tests::test_build_broker_with_filters"
-    "filters::search::tests::test_pagination_logic"
     "lens::country::tests::test_all"
     "lens::country::tests::test_lookup_by_code"
     "lens::country::tests::test_lookup_by_name"
@@ -37,8 +32,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "lens::ip::tests::test_fetch_ip_info"
     "lens::search::tests::test_build_broker_with_filters"
     "lens::search::tests::test_pagination_logic"
-    "rejects_invalid_historical_rpki_selections"
-    "server::handlers::country::tests::test_country_lens_lookup"
   ];
 
   doInstallCheck = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/bgpkit/monocle/releases/tag/v1.6.0

also cleanup some deleted test references

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
