### PR TITLE
matrix-tuwunel: 1.9.0 -> 1.9.1

### DIFF
--- a/pkgs/by-name/ma/matrix-tuwunel/package.nix
+++ b/pkgs/by-name/ma/matrix-tuwunel/package.nix
@@ -13,7 +13,6 @@
   matrix-tuwunel,
   # upstream tuwunel enables jemalloc by default, so we follow suit
   enableJemalloc ? true,
-  rust-jemalloc-sys,
   enableLiburing ? stdenv.hostPlatform.isLinux,
   enableLdap ? true,
   liburing,
@@ -23,18 +22,19 @@
   cacert,
 }:
 let
-  rust-jemalloc-sys' = rust-jemalloc-sys.override {
-    unprefixed = !stdenv.hostPlatform.isDarwin;
-  };
   # tuwunel uses a modified version of rocksdb.  The following overrides take a lot from the
   # official flake:
   # https://github.com/matrix-construct/tuwunel/blob/main/flake.nix#L54
   rocksdb' =
     (rocksdb.override {
       inherit enableLiburing;
-      # rocksdb does not support prefixed jemalloc, which is required on darwin
-      enableJemalloc = enableJemalloc && !stdenv.hostPlatform.isDarwin;
-      jemalloc = rust-jemalloc-sys';
+
+      # RocksDB's C++ allocations reach jemalloc by symbol interposition
+      # from the unprefixed allocator the Rust build links, so it needs
+      # none of its own. A second jemalloc here would serve only the
+      # opt-in nodump allocator and malloc-stats, out of a separate heap,
+      # and tuwunel uses neither.
+      enableJemalloc = false;
     }).overrideAttrs
       (
         final: old: {
@@ -44,8 +44,8 @@ let
             # The commit on the rocksdb fork, tuwunel-changes branch referenced by the upstream
             # tuwunel flake.lock:
             # https://github.com/matrix-construct/tuwunel/blob/main/flake.lock#L557C17-L557C57
-            rev = "eb79ddeff0ea32ebb8f8b69dd1df95c557328e85";
-            hash = "sha256-7hiKaIssPpqB8UTAR4ZE19pZTp09sVGOMht7sAitZAs=";
+            rev = "d8a89161c6a53e79d61694289d2b78be36e6ca12";
+            hash = "sha256-rNSA2RalASKbbXNQi86eEmIUC8W5YELKUOy0vhEn6Rc=";
           };
           version = "tuwunel-changes";
           patches = [ ];
@@ -89,16 +89,22 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-tuwunel";
-  version = "1.9.0";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "matrix-construct";
     repo = "tuwunel";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F9zmYanxCZjXBCh3GvSBiPQC6OFyugThq88MLvhLOyA=";
+    hash = "sha256-MBHChIMNLrP7u8ECRroGiniRGtZGArrpRPfAdkOaOXg=";
   };
 
-  cargoHash = "sha256-TT+dGr3DD9aPWYDxLTYPK0aZpQu64Ja8z+dJJmZQho8=";
+  # Integration tests require networking. Only run the unit tests.
+  cargoTestFlags = [
+    "--lib"
+    "--bins"
+  ];
+
+  cargoHash = "sha256-NDjFv0iKDfkKwOQ3RZ4gO9eQufGf/dmFaGLTcFWH5uw=";
 
   nativeBuildInputs = [
     pkg-config
@@ -115,7 +121,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     bzip2
     zstd
   ]
-  ++ lib.optional enableJemalloc rust-jemalloc-sys'
   ++ lib.optional enableLiburing liburing;
 
   env = {
@@ -168,15 +173,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
       export TUWUNEL_DATABASE_PATH="$(mktemp -d)/smoketest.db"
     '';
 
-  doCheck = true;
-
-  # 2026-06-24: Tuwunel has 16 integration tests. Cargo turns each of these
-  # into a separate binary that links in all 110 MB worth of tuwunel.  Linking
-  # 16 big binaries like this takes a really long time and was causing Hydra
-  # to time out the build during `checkPhase`.  So, we run the checks in the
-  # "debug" profile.  This reduces the build+test time on my machine from
-  # 44min to 12min.
-  checkType = "debug";
+  # The check phase reaches /etc/resolv.conf through libredirect, which works
+  # by LD_PRELOAD and is therefore inert in a statically linked binary. A
+  # static build would run the tests with no resolver configuration at all and
+  # fail before reaching them, so it packages without checking; the unit and
+  # integ jobs cover that code on the dynamic path.
+  doCheck = !stdenv.hostPlatform.isStatic;
 
   passthru = {
     rocksdb = rocksdb'; # make used rocksdb version available (e.g., for backup scripts)


### PR DESCRIPTION
Changelog:
https://github.com/matrix-construct/tuwunel/releases/tag/v1.9.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 562613`
Commit: `6cd4bf8a5e68db4cc1ddb67c5286296e5b18c437`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>matrix-tuwunel</li>
  </ul>
</details>