### PR TITLE
_7zz: fixup build on darwin

### DIFF
--- a/pkgs/by-name/_7/_7zz/package.nix
+++ b/pkgs/by-name/_7/_7zz/package.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
   preBuild = "cd CPP/7zip/Bundles/Alone2";
 
   postBuild = ''
-    make $makeFlags -j $NIX_BUILD_CORES -C ../Format7zF -f ../../cmpl_gcc.mak
+    make $makeFlags -j $NIX_BUILD_CORES -C ../Format7zF -f ${makefile}
   '';
 
   installPhase = ''
@@ -142,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm444 -t $out/share/doc/7zz ../../../../DOC/*.txt
 
     mkdir -p $lib/lib
-    install -Dm555 -t $lib/lib ../Format7zF/b/g/*
+    install -Dm555 -t $lib/lib ../Format7zF/b/*/7z.*
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

caught this early in nixos-unstable-small

https://github.com/NixOS/nixpkgs/pull/543477/changes/4d0febb4d68e8e5771cf093ce243179699615806 in https://github.com/NixOS/nixpkgs/pull/543477 broke darwin build see https://github.com/stepbrobd/inc/actions/runs/34704514178/job/103582739623

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
