### PR TITLE
[Backport staging-26.05] llvmPackages_{18,19,20,21,22}.libllvm: backport Darwin triple parsing; lldb: backport export trie fixes to LLDB 22 and older

### DIFF
--- a/pkgs/development/compilers/llvm/18/lldb/backport-ParseTrieEntries-fixes.patch
+++ b/pkgs/development/compilers/llvm/18/lldb/backport-ParseTrieEntries-fixes.patch
@@ -1,0 +1,124 @@
+diff --git a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+index 2c7005449f..e0c426afa0 100644
+--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
++++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+@@ -137,6 +137,14 @@
+ using namespace lldb_private;
+ using namespace llvm::MachO;
+ 
++/// Upper bound on the length of a symbol name assembled from export-trie edge
++/// labels.  A corrupt trie can encode an edge label whose terminator is far
++/// away in the trie data, so a single label is many megabytes long; appending
++/// it to the running name would otherwise request an unbounded allocation.  No
++/// legitimate symbol name comes close to this size.  Also 1 MiB is the
++/// symbol length limit in ld.
++static constexpr size_t kMaxTrieSymbolNameLength = 1 << 20; // 1 MiB
++
+ LLDB_PLUGIN_DEFINE(ObjectFileMachO)
+ 
+ static void PrintRegisterValue(RegisterContext *reg_ctx, const char *name,
+@@ -2050,15 +2058,21 @@
+   }
+ };
+ 
+-static bool ParseTrieEntries(DataExtractor &data, lldb::offset_t offset,
+-                             const bool is_arm, addr_t text_seg_base_addr,
+-                             std::vector<llvm::StringRef> &nameSlices,
+-                             std::set<lldb::addr_t> &resolver_addresses,
+-                             std::vector<TrieEntryWithOffset> &reexports,
+-                             std::vector<TrieEntryWithOffset> &ext_symbols) {
++static bool ParseTrieEntriesImpl(DataExtractor &data, lldb::offset_t offset,
++                          const bool is_arm, addr_t text_seg_base_addr,
++                          std::string &prefix,
++                          std::set<lldb::addr_t> &resolver_addresses,
++                          std::vector<TrieEntryWithOffset> &reexports,
++                          std::vector<TrieEntryWithOffset> &ext_symbols,
++                          std::set<lldb::offset_t> &visited_nodes) {
+   if (!data.ValidOffset(offset))
+     return true;
+ 
++  // Every node in a well-formed trie is reached by exactly one path, so a node
++  // offset seen twice means the trie is corrupt.
++  if (!visited_nodes.insert(offset).second)
++    return false;
++
+   // Terminal node -- end of a branch, possibly add this to
+   // the symbol table or resolver table.
+   const uint64_t terminalSize = data.GetULEB128(&offset);
+@@ -2098,14 +2112,9 @@
+       add_this_entry = true;
+     }
+     if (add_this_entry) {
+-      std::string name;
+-      if (!nameSlices.empty()) {
+-        for (auto name_slice : nameSlices)
+-          name.append(name_slice.data(), name_slice.size());
+-      }
+-      if (name.size() > 1) {
++      if (prefix.size() > 1) {
+         // Skip the leading '_'
+-        e.entry.name.SetCStringWithLength(name.c_str() + 1, name.size() - 1);
++        e.entry.name.SetString(llvm::StringRef(prefix).drop_front());
+       }
+       if (import_name) {
+         // Skip the leading '_'
+@@ -2126,23 +2135,36 @@
+   const uint8_t childrenCount = data.GetU8(&children_offset);
+   for (uint8_t i = 0; i < childrenCount; ++i) {
+     const char *cstr = data.GetCStr(&children_offset);
+-    if (cstr)
+-      nameSlices.push_back(llvm::StringRef(cstr));
+-    else
++    if (!cstr)
+       return false; // Corrupt data
++    if (prefix.size() + llvm::StringRef(cstr).size() > kMaxTrieSymbolNameLength)
++      return false; // Corrupt data: implausibly long symbol name.
++    const size_t prevSize = prefix.size();
++    prefix.append(cstr);
+     lldb::offset_t childNodeOffset = data.GetULEB128(&children_offset);
+-    if (childNodeOffset) {
+-      if (!ParseTrieEntries(data, childNodeOffset, is_arm, text_seg_base_addr,
+-                            nameSlices, resolver_addresses, reexports,
+-                            ext_symbols)) {
+-        return false;
+-      }
+-    }
+-    nameSlices.pop_back();
++    // A child offset of 0 points back at the root; like any other repeated
++    // offset it is a cycle, which ParseTrieEntriesImpl rejects as corrupt.
++    if (!ParseTrieEntriesImpl(data, childNodeOffset, is_arm, text_seg_base_addr,
++                              prefix, resolver_addresses, reexports,
++                              ext_symbols, visited_nodes))
++      return false;
++    prefix.resize(prevSize);
+   }
+   return true;
+ }
+ 
++static bool ParseTrieEntries(
++    DataExtractor &data, const bool is_arm, lldb::addr_t text_seg_base_addr,
++    std::set<lldb::addr_t> &resolver_addresses,
++    std::vector<TrieEntryWithOffset> &reexports,
++    std::vector<TrieEntryWithOffset> &ext_symbols) {
++  lldb::offset_t offset = 0;
++  std::set<lldb::offset_t> visited_nodes;
++  std::string prefix;
++  return ParseTrieEntriesImpl(data, offset, is_arm, text_seg_base_addr, prefix,
++                              resolver_addresses, reexports, ext_symbols,
++                              visited_nodes);
++}
+ static SymbolType GetSymbolType(const char *&symbol_name,
+                                 bool &demangled_is_synthesized,
+                                 const SectionSP &text_section_sp,
+@@ -2666,9 +2688,8 @@
+     lldb::addr_t text_segment_file_addr = LLDB_INVALID_ADDRESS;
+     if (text_segment_sp)
+       text_segment_file_addr = text_segment_sp->GetFileAddress();
+-    std::vector<llvm::StringRef> nameSlices;
+-    ParseTrieEntries(dyld_trie_data, 0, is_arm, text_segment_file_addr,
+-                     nameSlices, resolver_addresses, reexport_trie_entries,
++    ParseTrieEntries(dyld_trie_data, is_arm, text_segment_file_addr,
++                     resolver_addresses, reexport_trie_entries,
+                      external_sym_trie_entries);
+   }
+ 

--- a/pkgs/development/compilers/llvm/18/llvm/backport-darwin-triple-parsing.patch
+++ b/pkgs/development/compilers/llvm/18/llvm/backport-darwin-triple-parsing.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Tue, 11 Aug 2026 20:12:42 -0400
+Subject: [PATCH] backport-darwin-triple-parsing
+
+---
+ lib/TargetParser/Triple.cpp | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/lib/TargetParser/Triple.cpp b/lib/TargetParser/Triple.cpp
+index 0bbe8a3cedfd..4143c3eac05d 100644
+--- a/lib/TargetParser/Triple.cpp
++++ b/lib/TargetParser/Triple.cpp
+@@ -1253,9 +1253,15 @@ bool Triple::getMacOSXVersion(VersionTuple &Version) const {
+     }
+     if (Version.getMajor() <= 19) {
+       Version = VersionTuple(10, Version.getMajor() - 4);
+-    } else {
+-      // darwin20+ corresponds to macOS 11+.
++    } else if (Version.getMajor() < 25) {
++      // darwin20-24 corresponds to macOS 11-15.
+       Version = VersionTuple(11 + Version.getMajor() - 20);
++    } else if ((Version.getMajor() == 25) || (Version.getMajor() == 26)) {
++      // darwin25-26 corresponds to macOS 26-27.
++      Version = VersionTuple(Version.getMajor() + 1);
++    } else {
++      // Starting with darwin27, it naturally corresponds to the same macOS
++      // version.
+     }
+     break;
+   case MacOSX:
+-- 
+2.54.0
+

--- a/pkgs/development/compilers/llvm/21/llvm/backport-darwin-triple-parsing.patch
+++ b/pkgs/development/compilers/llvm/21/llvm/backport-darwin-triple-parsing.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Tue, 11 Aug 2026 20:19:29 -0400
+Subject: [PATCH] backport-darwin-triple-parsing
+
+---
+ lib/TargetParser/Triple.cpp | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/lib/TargetParser/Triple.cpp b/lib/TargetParser/Triple.cpp
+index 0584c941d2e6..30cf78dbaabc 100644
+--- a/lib/TargetParser/Triple.cpp
++++ b/lib/TargetParser/Triple.cpp
+@@ -1449,9 +1449,12 @@ bool Triple::getMacOSXVersion(VersionTuple &Version) const {
+     } else if (Version.getMajor() < 25) {
+       // darwin20-24 corresponds to macOS 11-15.
+       Version = VersionTuple(11 + Version.getMajor() - 20);
+-    } else {
+-      // darwin25 corresponds with macOS26+.
++    } else if ((Version.getMajor() == 25) || (Version.getMajor() == 26)) {
++      // darwin25-26 corresponds to macOS 26-27.
+       Version = VersionTuple(Version.getMajor() + 1);
++    } else {
++      // Starting with darwin27, it naturally corresponds to the same macOS
++      // version.
+     }
+     break;
+   case MacOSX:
+-- 
+2.54.0
+

--- a/pkgs/development/compilers/llvm/22/lldb/backport-ParseTrieEntries-fixes.patch
+++ b/pkgs/development/compilers/llvm/22/lldb/backport-ParseTrieEntries-fixes.patch
@@ -1,0 +1,125 @@
+diff --git a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+index 0be7b4c6f8..f9d9a05920 100644
+--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
++++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+@@ -137,6 +137,14 @@
+ static constexpr llvm::StringLiteral g_loader_path = "@loader_path";
+ static constexpr llvm::StringLiteral g_executable_path = "@executable_path";
+ 
++/// Upper bound on the length of a symbol name assembled from export-trie edge
++/// labels.  A corrupt trie can encode an edge label whose terminator is far
++/// away in the trie data, so a single label is many megabytes long; appending
++/// it to the running name would otherwise request an unbounded allocation.  No
++/// legitimate symbol name comes close to this size.  Also 1 MiB is the
++/// symbol length limit in ld.
++static constexpr size_t kMaxTrieSymbolNameLength = 1 << 20; // 1 MiB
++
+ LLDB_PLUGIN_DEFINE(ObjectFileMachO)
+ 
+ static void PrintRegisterValue(RegisterContext *reg_ctx, const char *name,
+@@ -1994,15 +2002,21 @@
+   }
+ };
+ 
+-static bool ParseTrieEntries(DataExtractor &data, lldb::offset_t offset,
+-                             const bool is_arm, addr_t text_seg_base_addr,
+-                             std::vector<llvm::StringRef> &nameSlices,
+-                             std::set<lldb::addr_t> &resolver_addresses,
+-                             std::vector<TrieEntryWithOffset> &reexports,
+-                             std::vector<TrieEntryWithOffset> &ext_symbols) {
++static bool ParseTrieEntriesImpl(DataExtractor &data, lldb::offset_t offset,
++                          const bool is_arm, addr_t text_seg_base_addr,
++                          std::string &prefix,
++                          std::set<lldb::addr_t> &resolver_addresses,
++                          std::vector<TrieEntryWithOffset> &reexports,
++                          std::vector<TrieEntryWithOffset> &ext_symbols,
++                          std::set<lldb::offset_t> &visited_nodes) {
+   if (!data.ValidOffset(offset))
+     return true;
+ 
++  // Every node in a well-formed trie is reached by exactly one path, so a node
++  // offset seen twice means the trie is corrupt.
++  if (!visited_nodes.insert(offset).second)
++    return false;
++
+   // Terminal node -- end of a branch, possibly add this to
+   // the symbol table or resolver table.
+   const uint64_t terminalSize = data.GetULEB128(&offset);
+@@ -2042,14 +2056,9 @@
+       add_this_entry = true;
+     }
+     if (add_this_entry) {
+-      std::string name;
+-      if (!nameSlices.empty()) {
+-        for (auto name_slice : nameSlices)
+-          name.append(name_slice.data(), name_slice.size());
+-      }
+-      if (name.size() > 1) {
++      if (prefix.size() > 1) {
+         // Skip the leading '_'
+-        e.entry.name.SetCStringWithLength(name.c_str() + 1, name.size() - 1);
++        e.entry.name.SetString(llvm::StringRef(prefix).drop_front());
+       }
+       if (import_name) {
+         // Skip the leading '_'
+@@ -2070,23 +2079,37 @@
+   const uint8_t childrenCount = data.GetU8(&children_offset);
+   for (uint8_t i = 0; i < childrenCount; ++i) {
+     const char *cstr = data.GetCStr(&children_offset);
+-    if (cstr)
+-      nameSlices.push_back(llvm::StringRef(cstr));
+-    else
++    if (!cstr)
+       return false; // Corrupt data
++    if (prefix.size() + llvm::StringRef(cstr).size() > kMaxTrieSymbolNameLength)
++      return false; // Corrupt data: implausibly long symbol name.
++    const size_t prevSize = prefix.size();
++    prefix.append(cstr);
+     lldb::offset_t childNodeOffset = data.GetULEB128(&children_offset);
+-    if (childNodeOffset) {
+-      if (!ParseTrieEntries(data, childNodeOffset, is_arm, text_seg_base_addr,
+-                            nameSlices, resolver_addresses, reexports,
+-                            ext_symbols)) {
+-        return false;
+-      }
+-    }
+-    nameSlices.pop_back();
++    // A child offset of 0 points back at the root; like any other repeated
++    // offset it is a cycle, which ParseTrieEntriesImpl rejects as corrupt.
++    if (!ParseTrieEntriesImpl(data, childNodeOffset, is_arm, text_seg_base_addr,
++                              prefix, resolver_addresses, reexports,
++                              ext_symbols, visited_nodes))
++      return false;
++    prefix.resize(prevSize);
+   }
+   return true;
+ }
+ 
++static bool ParseTrieEntries(
++    DataExtractor &data, const bool is_arm, lldb::addr_t text_seg_base_addr,
++    std::set<lldb::addr_t> &resolver_addresses,
++    std::vector<TrieEntryWithOffset> &reexports,
++    std::vector<TrieEntryWithOffset> &ext_symbols) {
++  lldb::offset_t offset = 0;
++  std::set<lldb::offset_t> visited_nodes;
++  std::string prefix;
++  return ParseTrieEntriesImpl(data, offset, is_arm, text_seg_base_addr, prefix,
++                              resolver_addresses, reexports, ext_symbols,
++                              visited_nodes);
++}
++
+ static bool
+ TryParseV2ObjCMetadataSymbol(const char *&symbol_name,
+                              const char *&symbol_name_non_abi_mangled,
+@@ -2659,9 +2682,8 @@
+     lldb::addr_t text_segment_file_addr = LLDB_INVALID_ADDRESS;
+     if (text_segment_sp)
+       text_segment_file_addr = text_segment_sp->GetFileAddress();
+-    std::vector<llvm::StringRef> nameSlices;
+-    ParseTrieEntries(dyld_trie_data, 0, is_arm, text_segment_file_addr,
+-                     nameSlices, resolver_addresses, reexport_trie_entries,
++    ParseTrieEntries(dyld_trie_data, is_arm, text_segment_file_addr,
++                     resolver_addresses, reexport_trie_entries,
+                      external_sym_trie_entries);
+   }
+ 

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -77,6 +77,10 @@ stdenv.mkDerivation (
       # Fix build with gcc15
       # https://github.com/llvm/llvm-project/commit/bb59f04e7e75dcbe39f1bf952304a157f0035314
       ./lldb-add-include-cstdint.patch
+    ]
+    ++ lib.optionals (lib.versionOlder (lib.versions.major release_version) "23") [
+      # Backports several fixes to export trie parsing. Otherwise, LLDB crashes when starting a debugging session on macOS 27.
+      (getVersionFile "lldb/backport-ParseTrieEntries-fixes.patch")
     ];
 
     nativeBuildInputs = [

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -305,16 +305,6 @@ stdenv.mkDerivation (
               --replace-fail "PhysicalFileSystemWorkingDirFailure" "DISABLED_PhysicalFileSystemWorkingDirFailure"
           ''
         +
-          # Fails on macOS ≥ 26 due to the changed OS version scheme.
-          #
-          # This was fixed upstream in LLVM 21 with
-          # 88f041f3e05e26617856cc096d2e2864dfaa1c7b, but it’s too
-          # painful to backport all the way.
-          lib.optionalString (lib.versionOlder release_version "21") ''
-            substituteInPlace unittests/TargetParser/Host.cpp \
-              --replace-fail "getMacOSHostVersion" "DISABLED_getMacOSHostVersion"
-          ''
-        +
           # This test fails with a `dysmutil` crash; have not yet dug into what's
           # going on here (TODO(@rrbutani)).
           lib.optionalString (stdenv.hostPlatform.isx86 && lib.versionOlder release_version "19") ''

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -222,7 +222,14 @@ stdenv.mkDerivation (
               hash = "sha256-3hkbYPUVRAtWpo5qBmc2jLZLivURMx8T0GQomvNZesc=";
               stripLen = 1;
             }
-          );
+          )
+      ++ lib.optionals (lib.versionOlder release_version "23") [
+        # As of macOS 27 (and iOS 27, etc), the Darwin version number is the same as the OS version number.
+        # This change breaks target parsing because `darwin27` is incorrectly interpreted as macOS 28.
+        # This patch is a backport of the target parsing changes in LLVM 23, which fixes the problem.
+        # Hopefully, Apple does not change the version number scheme again any time soon.
+        (getVersionFile "llvm/backport-darwin-triple-parsing.patch")
+      ];
 
     nativeBuildInputs = [
       cmake

--- a/pkgs/development/compilers/llvm/common/patches.nix
+++ b/pkgs/development/compilers/llvm/common/patches.nix
@@ -20,6 +20,17 @@
       path = ../18;
     }
   ];
+  "llvm/backport-darwin-triple-parsing.patch" = [
+    {
+      after = "18";
+      before = "21";
+      path = ../18;
+    }
+    {
+      after = "21";
+      path = ../21;
+    }
+  ];
   "llvm/gnu-install-dirs.patch" = [
     {
       after = "23";

--- a/pkgs/development/compilers/llvm/common/patches.nix
+++ b/pkgs/development/compilers/llvm/common/patches.nix
@@ -20,6 +20,17 @@
       path = ../18;
     }
   ];
+  "lldb/backport-ParseTrieEntries-fixes.patch" = [
+    {
+      before = "22";
+      path = ../18;
+    }
+    {
+      after = "22";
+      before = "23";
+      path = ../22;
+    }
+  ];
   "llvm/backport-darwin-triple-parsing.patch" = [
     {
       after = "18";


### PR DESCRIPTION
Fixes llvm builds on macOS 27. Fixed lldb on macOS 27.

- **llvmPackages_{18,19,20,21,22}.libllvm: backport Darwin triple parsing**
- **llvmPackages_{18,19,20}.libllvm: reenable disabled test**
- **lldb: backport export trie fixes to LLDB 22 and older**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
