### PR TITLE
mkSaneConfig: use lib.extendMkDerivation

### DIFF
--- a/pkgs/applications/graphics/sane/config.nix
+++ b/pkgs/applications/graphics/sane/config.nix
@@ -1,10 +1,4 @@
 { lib, stdenv }:
-
-{
-  paths,
-  disabledDefaultBackends ? [ ],
-}:
-
 let
   installSanePath = path: ''
     if [ -e "${path}/lib/sane" ]; then
@@ -35,21 +29,37 @@ let
     sed -i 's/\b${backend}\b/# ${backend} disabled by nixos config/' $out/etc/sane.d/dll.conf
   '';
 in
-stdenv.mkDerivation {
-  name = "sane-config";
-  dontUnpack = true;
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
 
-  installPhase = ''
-    function symlink () {
-      local target=$1 linkname=$2
-      if [ -e "$linkname" ]; then
-        echo "warning: conflict for $linkname. Overriding $(readlink $linkname) with $target."
-      fi
-      ln -sfn "$target" "$linkname"
-    }
+  excludeDrvArgNames = [
+    "paths"
+    "disabledDefaultBackends"
+  ];
 
-    mkdir -p $out/etc/sane.d $out/etc/sane.d/dll.d $out/lib/sane
-  ''
-  + (lib.concatMapStrings installSanePath paths)
-  + (lib.concatMapStrings disableBackend disabledDefaultBackends);
+  extendDrvArgs =
+    finalAttrs:
+    {
+      paths,
+      disabledDefaultBackends ? [ ],
+      ...
+    }:
+    {
+      name = "sane-config";
+      dontUnpack = true;
+
+      installPhase = ''
+        function symlink () {
+          local target=$1 linkname=$2
+          if [ -e "$linkname" ]; then
+            echo "warning: conflict for $linkname. Overriding $(readlink $linkname) with $target."
+          fi
+          ln -sfn "$target" "$linkname"
+        }
+
+        mkdir -p $out/etc/sane.d $out/etc/sane.d/dll.d $out/lib/sane
+      ''
+      + (lib.concatMapStrings installSanePath paths)
+      + (lib.concatMapStrings disableBackend disabledDefaultBackends);
+    };
 }


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/489490

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
