### PR TITLE
invoice2data: 0.4.4 -> 1.0.1

### DIFF
--- a/pkgs/by-name/in/invoice2data/package.nix
+++ b/pkgs/by-name/in/invoice2data/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
   ghostscript,
   imagemagick,
   poppler-utils,
@@ -11,36 +10,30 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "invoice2data";
-  version = "0.4.4";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "invoice-x";
     repo = "invoice2data";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-pAvkp8xkHYi/7ymbxaT7/Jhu44j2P8emm8GyXC6IBnI=";
+    hash = "sha256-tbPl23r8j+LdlzOvP37D9SBAdeFVTx1+rAflSo+XqRM=";
   };
-
-  patches = [
-    # https://github.com/invoice-x/invoice2data/pull/522
-    (fetchpatch {
-      name = "clean-up-build-dependencies.patch";
-      url = "https://github.com/invoice-x/invoice2data/commit/ccea3857c7c8295ca51dc24de6cde78774ea7e64.patch";
-      hash = "sha256-BhqPW4hWG/EaR3qBv5a68dcvIMrCCT74GdDHr0Mss5Q=";
-    })
-  ];
 
   build-system = with python3.pkgs; [
     setuptools
-    setuptools-git
+    mypy
+    ast-serialize
+    click
+    pyyaml
+    regex
   ];
 
   dependencies = with python3.pkgs; [
-    dateparser
-    pdfminer-six
-    pillow
+    click
+    python-dateutil
     pyyaml
-    setuptools # pkg_resources is imported during runtime
+    regex
   ];
 
   makeWrapperArgs = [

--- a/pkgs/by-name/in/invoice2data/package.nix
+++ b/pkgs/by-name/in/invoice2data/package.nix
@@ -6,6 +6,7 @@
   poppler-utils,
   python3,
   tesseract5,
+  versionCheckHook,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
@@ -48,8 +49,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ])
   ];
 
-  # Tests fails even when ran manually on my ubuntu machine !!
-  doCheck = false;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   pythonImportsCheck = [
     "invoice2data"


### PR DESCRIPTION
invoice2data: 0.4.4 -> 1.0.1

Diff: https://github.com/invoice-x/invoice2data/compare/v0.4.4...v1.0.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
