### PR TITLE
jellyfin: miscellaneous security fixes from 12.0

### DIFF
--- a/pkgs/by-name/je/jellyfin/fix-playlist-visibility.patch
+++ b/pkgs/by-name/je/jellyfin/fix-playlist-visibility.patch
@@ -1,0 +1,26 @@
+From 5f13afa1cecfae398ff7d84ed89fc45b14b71c61 Mon Sep 17 00:00:00 2001
+From: Shadowghost <Ghost_of_Stone@web.de>
+Date: Thu, 4 Jun 2026 19:00:03 +0200
+Subject: [PATCH] Fix playlist visibility
+
+---
+ MediaBrowser.Controller/Entities/Folder.cs | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/MediaBrowser.Controller/Entities/Folder.cs b/MediaBrowser.Controller/Entities/Folder.cs
+--- a/MediaBrowser.Controller/Entities/Folder.cs
++++ b/MediaBrowser.Controller/Entities/Folder.cs
+@@ -811,7 +811,10 @@ namespace MediaBrowser.Controller.Entities
+ 
+         private bool RequiresPostFiltering2(InternalItemsQuery query)
+         {
+-            if (query.IncludeItemTypes.Length == 1 && query.IncludeItemTypes[0] == BaseItemKind.BoxSet)
++            // BoxSets and Playlists can have per-user visibility (shares/open access) that is stored in the
++            // serialized item data and cannot be evaluated by the database query, so filter them in memory.
++            if (query.IncludeItemTypes.Length > 0
++                && query.IncludeItemTypes.All(t => t == BaseItemKind.BoxSet || t == BaseItemKind.Playlist))
+             {
+                 Logger.LogDebug("Query requires post-filtering due to BoxSet query");
+                 return true;
+-- 
+2.51.0

--- a/pkgs/by-name/je/jellyfin/package.nix
+++ b/pkgs/by-name/je/jellyfin/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   nixosTests,
   dotnetCorePackages,
   buildDotnetModule,
@@ -22,6 +23,34 @@ buildDotnetModule (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-HCs4ZsutVoVH+bBZANjpPeMyV8e63Yemjg9DSr0R9zg=";
   };
+
+  patches = [
+    # Prevent SSRF, local file disclosure and DoS via external references in SVG rendering.
+    # (No public PR.)
+    (fetchpatch {
+      url = "https://github.com/jellyfin/jellyfin/commit/cefa78fc1de2410e5c5c6da5062c98fe98b22d17.patch";
+      hash = "sha256-TxGo+sLLG+C9omxrwvO6byzw+iRqONVLXrQKwkrY22s=";
+    })
+
+    # Fix MaxLoginAttempts not honored.
+    # https://github.com/jellyfin/jellyfin/pull/17274
+    (fetchpatch {
+      url = "https://github.com/jellyfin/jellyfin/commit/8b826d981bcfec22063d6008e38016f4b77790d0.patch";
+      hash = "sha256-Nav05TcpjBJABybU0BVyJ0UyxKi+6nDNBQ6tjY0DPT8=";
+    })
+
+    # GHSA-9x85-gx46-6522
+    # Reject user impersonation when retrieving private playlist items.
+    # (No public PR.)
+    (fetchpatch {
+      url = "https://github.com/jellyfin/jellyfin/commit/911ac3769cdcce50a8f6e0b3c0739d509bd9a23f.patch";
+      hash = "sha256-MwaTwqhuBc7yWW3cL6htlyDQ9O1wt5iFCOM/oVTi6P0=";
+    })
+
+    # Don't let unauthorized users to list other's private playlists.
+    # https://github.com/jellyfin/jellyfin/pull/17025
+    ./fix-playlist-visibility.patch
+  ];
 
   propagatedBuildInputs = [ sqlite ];
 


### PR DESCRIPTION
These go directly to 26.05 because master is on 12.0 which has all the
fixes. Jellyfin team is not going to release another 10.11.x version.
Hence these backports.

Only one patch is marked with a GHSA marker, and none are currently
listed in their official roster. Which doesn't mean much since the
project practices a 14-day delay for disclosures.

https://github.com/jellyfin/jellyfin/security#post-disclosure-process

Two fixed scenarios require an authenticated user (one bug allows to
SSRF or DoS with a SVG file; another allows a user to read others'
private playlists). Another patch fixes max limit for login attempts,
which was broken in 10.11.11.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
