### PR TITLE
dcpomatic: 2.19.1 -> 2.18.50

### DIFF
--- a/pkgs/by-name/dc/dcpomatic/libdcp.nix
+++ b/pkgs/by-name/dc/dcpomatic/libdcp.nix
@@ -26,12 +26,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libdcp";
-  version = "1.10.61";
+  version = "1.10.63";
 
   src = fetchgit {
     url = "https://git.carlh.net/git/libdcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MV2kANCq8IqsSJIk95rqIX7iSGmnDVetXPMLn5mEOEs=";
+    hash = "sha256-nT9wSOY/OPNRxpjnp+wblx7Jbx/S0uP7lL68zBK4NFk=";
   };
 
   # for some reason the version is not set properly upstream

--- a/pkgs/by-name/dc/dcpomatic/libsub.nix
+++ b/pkgs/by-name/dc/dcpomatic/libsub.nix
@@ -14,12 +14,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libsub";
-  version = "1.6.62";
+  version = "1.6.64";
 
   src = fetchgit {
     url = "https://git.carlh.net/git/libsub";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NSCg+YnxUPII16K1SGozBRYorm0UVGTGozJOhLti4kc=";
+    hash = "sha256-5umGV7qzh0iYkWbnnSVAtENhI9nIk+AE7pZHbDZuArk=";
   };
 
   # for some reason the version is not set properly upstream

--- a/pkgs/by-name/dc/dcpomatic/package.nix
+++ b/pkgs/by-name/dc/dcpomatic/package.nix
@@ -47,12 +47,12 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dcpomatic";
-  version = "2.19.1";
+  version = "2.18.50";
 
   src = fetchgit {
     url = "https://git.carlh.net/git/dcpomatic";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-c+An8V/A7Vk0ChGQULk9uj0zN5slLb8wSKlWl+3uL1Y=";
+    hash = "sha256-qYzV8tXISGCYAzoJJDhx/xDZAS4HD8VwE3Z0CsCjIZs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
When dcpomatic was added in #554828, it was added at 2.19.1, which weirdly [isn't what upstream is working on](https://git.carlh.net/cgit/dcpomatic/log).

This PR moves to 2.18.x, which has new commits, alongside required dependency bumps.

[Release notes](https://dcpomatic.com/release-notes?v=2.18.50)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
