### PR TITLE
pretendard: use installFonts

### DIFF
--- a/pkgs/data/fonts/pretendard/default.nix
+++ b/pkgs/data/fonts/pretendard/default.nix
@@ -1,7 +1,8 @@
 {
   lib,
-  stdenvNoCC,
   fetchzip,
+  stdenvNoCC,
+  installFonts,
 }:
 
 let
@@ -13,7 +14,7 @@ let
       typeface,
       hash,
     }:
-    stdenvNoCC.mkDerivation {
+    stdenvNoCC.mkDerivation (finalAttrs: {
       inherit pname version;
 
       src = fetchzip {
@@ -22,13 +23,12 @@ let
         inherit hash;
       };
 
-      installPhase = ''
-        runHook preInstall
+      nativeBuildInputs = [ installFonts ];
+      dontInstallFonts = true;
 
-        install -Dm644 public/static/*.otf -t $out/share/fonts/opentype
+      preInstall = ''installFont 'otf' "$out/share/fonts/opentype"'';
 
-        runHook postInstall
-      '';
+      sourceRoot = "${finalAttrs.src.name}/public/static";
 
       meta = {
         homepage = "https://github.com/orioncactus/pretendard";
@@ -37,8 +37,7 @@ let
         platforms = lib.platforms.all;
         maintainers = with lib.maintainers; [ sudosubin ];
       };
-    };
-
+    });
 in
 {
   pretendard = mkPretendard {


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/495640

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
