### PR TITLE
steel{,-language-server}: use STEEL_SEARCH_PATHS instead of STEEL_HOME

### DIFF
--- a/pkgs/by-name/st/steel-language-server/package.nix
+++ b/pkgs/by-name/st/steel-language-server/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage {
   doCheck = false;
 
   postFixup = ''
-    wrapProgram $out/bin/steel-language-server --set-default STEEL_HOME "${steel}/lib/steel"
+    wrapProgram "$out/bin/steel-language-server" --prefix STEEL_SEARCH_PATHS : "${steel}/lib/steel/cogs"
   '';
 
   meta = steel.meta // {

--- a/pkgs/by-name/st/steel/package.nix
+++ b/pkgs/by-name/st/steel/package.nix
@@ -89,12 +89,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --zsh <($out/bin/steel completions zsh)
   '';
 
-  postFixup = ''
-    wrapProgram $out/bin/steel --set-default STEEL_HOME "$out/lib/steel"
-    wrapProgram $out/bin/steel-language-server --set-default STEEL_HOME "$out/lib/steel"
-    wrapProgram $out/bin/forge --set-default STEEL_HOME "$out/lib/steel"
-    wrapProgram $out/bin/cargo-steel-lib --set-default STEEL_HOME "$out/lib/steel"
-  '';
+  postFixup =
+    lib.concatMapStringsSep "\n"
+      (bin: ''wrapProgram "$out/bin/${bin}" --prefix SEARCH_STEEL_PATHS : "$out/lib/steel/cogs"'')
+      [
+        "cargo-steel-lib"
+        "forge"
+        "steel"
+        "steel-language-server"
+      ];
 
   env = {
     OPENSSL_NO_VENDOR = true;


### PR DESCRIPTION
Wrap binaries with --prefix STEEL_SEARCH_PATHS so multiple cogs directories can be combined, rather than overwriting STEEL_HOME with --set-default. Also deduplicate the wrapProgram calls using lib.concatMapStringsSep.

Closes #539326

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
