### PR TITLE
[staging] gnupg: update freepg patches to source-2.4.9-freepg-1

### DIFF
--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -90,8 +90,8 @@ stdenv.mkDerivation (finalAttrs: {
   freepgPatches = fetchFromGitLab {
     owner = "freepg";
     repo = "gnupg";
-    tag = "source-2.4.9-freepg";
-    hash = "sha256-wF+iR0OgnU8VI90NlFOXtN5aCRC0YY/X7sPiDXjJm5M=";
+    tag = "source-2.4.9-freepg-1";
+    hash = "sha256-hoSuIrq7Epco1LLlc77tGr/YZdp2w04Eq0rGbBCurWU=";
   };
 
   patches = [
@@ -132,6 +132,15 @@ stdenv.mkDerivation (finalAttrs: {
     "0033-Support-large-RSA-keygen-in-non-batch-mode.patch"
     "0034-gpg-Verify-Text-mode-Signatures-over-binary-Literal-.patch"
     "0039-gpg-Do-not-use-a-default-when-asking-for-another-out.patch"
+    "0040-Add-missing-test-files-to-EXTRA_DIST.patch"
+    "0045-gpg-Fix-edge-case-in-refresh-keys.patch"
+    "0046-gpgsm-Require-a-minimum-tag-length-for-GCM-decryptio.patch"
+    "0047-gpg-Fix-handling-with-no-CRC-armor.patch"
+    "0048-gpg-Fix-armored-input-parsing.patch"
+    "0049-gpg-Fix-armor-parsing-when-no-CRC-is-found.patch"
+    "0050-tpm-Fix-possible-buffer-overflow-in-PKDECRYPT.patch"
+    "0051-agent-Fix-the-regression-in-pkdecrypt-with-TPM-RSA.patch"
+    "0052-dirmngr-Fix-a-call-of-calloc.patch"
   ];
 
   postPatch =


### PR DESCRIPTION
Updates the freepg patchset, notably with fixes for:

- CVE-2026-24882
- CVE-2026-57062



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
