### PR TITLE
ispc: fix riscv64-linux build

### DIFF
--- a/pkgs/by-name/is/ispc/package.nix
+++ b/pkgs/by-name/is/ispc/package.nix
@@ -87,10 +87,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CLANGPP_EXECUTABLE" "${llvmPackages.clang}/bin/clang++")
     (lib.cmakeBool "ISPC_INCLUDE_EXAMPLES" false)
     (lib.cmakeBool "ISPC_INCLUDE_UTILS" false)
-    (lib.cmakeFeature "ARM_ENABLED=" (
+    (lib.cmakeFeature "ARM_ENABLED" (
       if stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isAarch32 then "TRUE" else "FALSE"
     ))
-    (lib.cmakeFeature "X86_ENABLED=" (
+    (lib.cmakeFeature "X86_ENABLED" (
       if stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isx86_32 then "TRUE" else "FALSE"
     ))
   ];

--- a/pkgs/by-name/is/ispc/package.nix
+++ b/pkgs/by-name/is/ispc/package.nix
@@ -15,6 +15,8 @@
   testedTargets ?
     if stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isAarch32 then
       [ "neon-i32x4" ]
+    else if stdenv.hostPlatform.isRiscV64 then
+      [ "rvv-x4" ]
     else
       [ "sse2-i32x4" ],
 }:
@@ -58,6 +60,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   inherit testedTargets;
 
+  # run_tests.py does not know riscv64 hosts and defaults to x86 targets
+  patches = lib.optionals stdenv.hostPlatform.isRiscV64 [
+    ./run-tests-riscv64.patch
+  ];
+
   doCheck = true;
 
   # the compiler enforces -Werror, and -fno-strict-overflow makes it mad.
@@ -93,6 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "X86_ENABLED" (
       if stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isx86_32 then "TRUE" else "FALSE"
     ))
+    (lib.cmakeFeature "RISCV_ENABLED" (if stdenv.hostPlatform.isRiscV64 then "TRUE" else "FALSE"))
   ];
 
   meta = {

--- a/pkgs/by-name/is/ispc/run-tests-riscv64.patch
+++ b/pkgs/by-name/is/ispc/run-tests-riscv64.patch
@@ -1,0 +1,12 @@
+--- a/scripts/run_tests.py
++++ b/scripts/run_tests.py
+@@ -1368,6 +1368,9 @@
+ elif platform.machine() == "ppc64le":
+     default_target = "generic-i32x4"
+     default_arch = "ppc64le"
++elif platform.machine() == "riscv64":
++    default_target = "rvv-x4"
++    default_arch = "riscv64"
+ elif "86" in platform.machine() or platform.machine() == "AMD64":
+     # Some variant of x86: x86_64, i386, i486, i586, i686
+     # Windows reports platform as AMD64


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] riscv64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
