### PR TITLE
libcap_ng: disable tests on static

### DIFF
--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -86,7 +86,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   # assumption: build machine runs linux kernel 5.0 or newer
   # see https://github.com/stevegrubb/libcap-ng?tab=readme-ov-file#note-to-distributions
-  doCheck = true;
+  # disabled on static due to symbol collision in test file compilation
+  # see https://github.com/stevegrubb/libcap-ng/issues/85
+  doCheck = !stdenv.hostPlatform.isStatic;
 
   pythonImportsCheck = [
     "capng"


### PR DESCRIPTION
https://github.com/stevegrubb/libcap-ng/issues/85
https://github.com/NixOS/nixpkgs/pull/555423#issuecomment-5649811155
https://github.com/NixOS/nixpkgs/issues/562705

Should be zero rebuild for anything but static.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (static)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
