### PR TITLE
ibus: fix crashes with latest gtk

### DIFF
--- a/pkgs/by-name/ib/ibus/package.nix
+++ b/pkgs/by-name/ib/ibus/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   replaceVars,
   fetchFromGitHub,
+  fetchpatch,
   autoreconfHook,
   gettext,
   makeWrapper,
@@ -88,6 +89,15 @@ stdenv.mkDerivation (finalAttrs: {
       PYTHON = null;
     })
     ./build-without-dbus-launch.patch
+
+    # Fix crashes in `gtk_im_multicontext_set_delegate` with latest GTK
+    # GTK issue: https://gitlab.gnome.org/GNOME/gtk/-/work_items/8341
+    # Upstream PR: https://github.com/ibus/ibus/pull/2929
+    (fetchpatch {
+      name = "fix-gtk-crashes.patch";
+      url = "https://github.com/ibus/ibus/commit/c534999a9dbea2666864250d74e058ecfb46e76f.patch";
+      hash = "sha256-1h48hvdrDh2Qh4+SufL147CxlfiwvP/Jv509X0WnbrA=";
+    })
   ];
 
   outputs = [


### PR DESCRIPTION
GTK issue: https://gitlab.gnome.org/GNOME/gtk/-/work_items/8341
Upstream PR: https://github.com/ibus/ibus/pull/2929

Issue popped up during the GNOME 51 update (https://github.com/NixOS/nixpkgs/pull/559510). Can be reproduced by running pretty much any GTK 4 application (I've tested with `adwaita-1-demo`) from https://github.com/NixOS/nixpkgs/pull/559510 on a GNOME system that runs ibus without this patch.

Tested the fix by cherry-picking onto `master` (6b4a11ea6232c988b3e6dcb2b3ae5ac8ec434c27).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. — `nixosTests.gnome`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
