### PR TITLE
ffuf: 2.2.1 -> 2.3.0

### DIFF
--- a/pkgs/by-name/ff/ffuf/package.nix
+++ b/pkgs/by-name/ff/ffuf/package.nix
@@ -7,21 +7,21 @@
 
 buildGoModule (finalAttrs: {
   pname = "ffuf";
-  version = "2.2.1";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "ffuf";
     repo = "ffuf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xN7FxxxIpkaGlfBgs0RwEPlzo/HLMfioC6MAMVP2su8=";
+    hash = "sha256-bnxpfomvih4/SVs7aqVICsW9AML/E8LODP+peg7x64M=";
   };
 
   vendorHash = "sha256-SrC6Q7RKf+gwjJbxSZkWARw+kRtkwVv1UJshc/TkNdc=";
 
   ldflags = [
     "-s"
-    "-X github.com/ffuf/ffuf/v${(lib.versions.major finalAttrs.version)}/pkg/ffuf.VERSION=${finalAttrs.version}"
-    "-X github.com/ffuf/ffuf/v${(lib.versions.major finalAttrs.version)}/pkg/ffuf.VERSION_APPENDIX="
+    "-X=github.com/ffuf/ffuf/v${(lib.versions.major finalAttrs.version)}/pkg/ffuf.VERSION=${finalAttrs.version}"
+    "-X=github.com/ffuf/ffuf/v${(lib.versions.major finalAttrs.version)}/pkg/ffuf.VERSION_APPENDIX="
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
@@ -29,6 +29,11 @@ buildGoModule (finalAttrs: {
   doInstallCheck = true;
 
   versionCheckProgramArg = "-V";
+
+  checkFlags = [
+    # These integration tests require a local server
+    "-skip=^(TestE2E_JSONOutput|TestE2E_DefaultMatcher|TestE2E_MatcherSuppressesDefault)$"
+  ];
 
   meta = {
     description = "Tool for web fuzzing";


### PR DESCRIPTION
Changelog: https://github.com/ffuf/ffuf/releases/tag/v2.3.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
