### PR TITLE
panvimdoc: 4.0.1 -> 5.0.0

### DIFF
--- a/pkgs/by-name/pa/panvimdoc/package.nix
+++ b/pkgs/by-name/pa/panvimdoc/package.nix
@@ -10,20 +10,20 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "panvimdoc";
-  version = "4.0.1";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "kdheepak";
     repo = "panvimdoc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HmEBPkNELHC7Xy0v730sQWZyPPwFdIBUcELzNtrWwzQ=";
+    hash = "sha256-O1Ufn9TEO6M8dbPa0nxArXdG3Vsi1Q+zA82kTi5wjks";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
   buildPhase = ''
     runHook preBuild
-    install -Dm444 scripts/* -t $out/share/scripts
+    find scripts -maxdepth 1 -type f -exec install -Dm444 {} -t $out/share/scripts \;
     install -Dm444 lib/* -t $out/share/lib
     install -Dm755 panvimdoc.sh -t $out/share
     runHook postBuild


### PR DESCRIPTION
https://github.com/kdheepak/panvimdoc/compare/v4.0.1...v5.0.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: panvimdoc 4.0.1 -> 5.0.0 is a major upstream version update.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
