### PR TITLE
compare50: fix build error, use pythonRemoveDeps

### DIFF
--- a/pkgs/by-name/co/compare50/package.nix
+++ b/pkgs/by-name/co/compare50/package.nix
@@ -20,9 +20,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   postPatch = ''
     substituteInPlace setup.py --replace-fail \
       'scripts=["bin/compare50"]' 'entry_points={"console_scripts": ["compare50=compare50.__main__:main"]}'
-    # auto included in current python version, no install needed
-    substituteInPlace setup.py --replace-fail \
-      'importlib' ' '
+
     # Fix "AttributeError: module 'importlib' has no attribute 'resources'"
     substituteInPlace compare50/passes.py \
       --replace-fail "import importlib" "import importlib, importlib.resources"
@@ -48,6 +46,11 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "attrs"
     "numpy"
     "termcolor"
+  ];
+
+  # Safely strip out the obsolete `importlib` PyPI package
+  pythonRemoveDeps = [
+    "importlib"
   ];
 
   pythonImportsCheck = [ "compare50" ];

--- a/pkgs/by-name/co/compare50/package.nix
+++ b/pkgs/by-name/co/compare50/package.nix
@@ -23,6 +23,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # auto included in current python version, no install needed
     substituteInPlace setup.py --replace-fail \
       'importlib' ' '
+    # Fix "AttributeError: module 'importlib' has no attribute 'resources'"
+    substituteInPlace compare50/passes.py \
+      --replace-fail "import importlib" "import importlib, importlib.resources"
   '';
 
   build-system = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Hydra error log: https://hydra.nixos.org/build/345083199
The build is failing during the test phase because of a missing import in the compare50 package's source code.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
