### PR TITLE
diffoscope: patch for crash when r2 is in PATH

### DIFF
--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -128,6 +128,7 @@ python.pkgs.buildPythonApplication rec {
   patches = [
     ./androguard-4.1.4.patch
     ./ignore_links.patch
+    ./radare2.patch
   ];
 
   postPatch = ''
@@ -154,9 +155,7 @@ python.pkgs.buildPythonApplication rec {
   # otool
   # Other tools:
   # docx2txt (needs Debian's package called this, not the python package)
-  # radare2
-  # > FAILED tests/comparators/test_elf_decompiler.py::test_radare2_diff - KeyError: 'offset'
-  # > FAILED tests/comparators/test_macho_decompiler.py::test_radare2_diff - KeyError: 'offset'
+  # radare2 (the exact output of the r2 version debian ships is expected, and our more recent version has a slightly different one)
   #
   # We filter automatically all packages for the host platform (some dependencies are not supported on Darwin, aarch64, etc.).
   # Packages which are marked broken for a platform are not automatically filtered to avoid accidentally removing them without noticing it.

--- a/pkgs/by-name/di/diffoscope/radare2.patch
+++ b/pkgs/by-name/di/diffoscope/radare2.patch
@@ -1,0 +1,26 @@
+Fix comparing ELF objects when r2 is in PATH
+
+https://github.com/radareorg/radare2/issues/21201 renamed the "offset" key of
+the json output diffoscope uses to "addr". As a result running diffoscope on an
+ELF object results in this error:
+KeyError: 'offset'
+
+This patch does not include the modifications to the test suite required to
+submit it upstream.
+
+Upstream issue: https://salsa.debian.org/reproducible-builds/diffoscope/-/work_items/432
+
+diff --git a/diffoscope/comparators/decompile.py b/diffoscope/comparators/decompile.py
+index bf85deb9..f6a5564f 100644
+--- a/diffoscope/comparators/decompile.py
++++ b/diffoscope/comparators/decompile.py
+@@ -242,6 +242,9 @@ class AsmFunction(File):
+ 
+     @property
+     def offset(self):
++        if "addr" in self.data_dict:
++            return self.data_dict["addr"]
++        # backward compat with r2 version < 5.9.0
+         return self.data_dict["offset"]
+ 
+     @property


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nixpkgs/issues/553088

The patch cannot be sent upstream as-is because we also would need to fix tests.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
