### PR TITLE
blastem: 0.6.2-unstable-2024-08-14 -> 1.0.0

### DIFF
--- a/pkgs/by-name/bl/blastem/package.nix
+++ b/pkgs/by-name/bl/blastem/package.nix
@@ -2,43 +2,48 @@
   lib,
   stdenv,
   fetchhg,
-  pkg-config,
+
   makeBinaryWrapper,
-  SDL2,
+  pkg-config,
+  python3,
+
   glew,
   gtk3,
+  SDL2,
+
   testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "blastem";
-  version = "0.6.2-unstable-2024-08-14";
+  version = "1.0.0";
 
   src = fetchhg {
     url = "https://www.retrodev.com/repos/blastem";
-    rev = "aa888682faa0";
-    hash = "sha256-0xw9O0o1pkJiXHyZer4nMJeLlRXS3Z4YYoLgfkrz3Yo=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Fs78GFmvndJz+Ngpzw3bRyL8IX8UUJBAbV3TcNbHJHA=";
   };
 
-  # will probably be fixed in https://github.com/NixOS/nixpkgs/pull/302481
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+  postPatch = ''
     substituteInPlace Makefile \
-        --replace-fail "-flto" ""
+      --replace-fail '/bin/echo' 'echo'
+    patchShebangs cpu_dsl.py
   '';
 
   nativeBuildInputs = [
-    pkg-config
     makeBinaryWrapper
+    pkg-config
+    python3
   ];
 
   buildInputs = [
     gtk3
-    SDL2
     glew
+    SDL2
   ];
 
   # Note: menu.bin cannot be generated yet, because it would
-  # need the `vasmm68k_mot` executable (part of vbcc for amigaos68k
+  # need the `vasmm68k_mot` executable (part of vbcc for amigaos68k)
   # Luckily, menu.bin doesn't need to be present for the emulator to function
 
   makeFlags = [ "HOST_ZLIB=1" ];
@@ -49,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     # not sure if any executable other than blastem is really needed here
-    install -Dm755 blastem dis zdis termhelper -t $out/share/blastem
+    install -Dm755 blastem dis zdis upddis sh2dis termhelper -t $out/share/blastem
     install -Dm644 gamecontrollerdb.txt default.cfg rom.db -t $out/share/blastem
     cp -r shaders $out/share/blastem/shaders
 
@@ -62,18 +67,20 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;
     command = "blastem -v";
-    version = "0.6.3-pre"; # remove line when moving to a stable version
   };
 
   meta = {
-    description = "Fast and accurate Genesis emulator";
+    description = "Fast and accurate emulator for Sega's 16-bit and 8-bit consoles";
+    longDescription = ''
+      BlastEm is a free and Open Source emulator for Sega's 16-bit and 8-bit consoles.
+      It's fast enough for your old PC and accurate enough for the most demanding demos.
+      While BlastEm's primary focus is the Genesis (known as the Megadrive outside North America),
+      it also supports the Sega CD, 32X, Master System, Game Gear, SG-1000, SC-3000, Sega Pico and Yamaha Copera.
+    '';
     homepage = "https://www.retrodev.com/blastem/";
     license = lib.licenses.gpl3Plus;
     mainProgram = "blastem";
     maintainers = with lib.maintainers; [ tomasajt ];
-    platforms = [
-      "i686-linux"
-      "x86_64-linux"
-    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
https://www.retrodev.com/blastem/announce_1.0.0.html
https://www.retrodev.com/blastem/changes.html#v1.0.0

Untested, as I don't have access to ROMs I could run.

@keenanweaver if you are able to, could you test it out?

Also, apparently non x86 platforms are supported now. nixpkgs-review-gha says that aarch64-linux and aarch64-darwin build fine. I cannot test it further, though, as I have no machines I could use for testing the GUI.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
