### PR TITLE
cuneiform: switch to gcc14Stdenv to fix build error

### DIFF
--- a/pkgs/by-name/cu/cuneiform/package.nix
+++ b/pkgs/by-name/cu/cuneiform/package.nix
@@ -1,14 +1,14 @@
 {
   lib,
-  stdenv,
+  gcc14Stdenv,
   fetchurl,
   cmake,
   imagemagick,
   testers,
 }:
 
-# Deprecated: unmaintained, no consumers in nixpkgs as of 2025-10-05, and doesn't compile with gcc 15.
-stdenv.mkDerivation (finalAttrs: {
+# Deprecated: unmaintained, no consumers in nixpkgs as of 2025-10-05, and doesn't compile with gcc 15. Switched to gcc14Stdenv as of 2026-09-13 to fix hydra build error
+gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "cuneiform";
   version = "1.1.0";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Hydra error logs:
[nixpkgs.cuneiform.x86_64-linux](https://hydra.nixos.org/build/345084385)
[nixpkgs.cuneiform.aarch64-linux](https://hydra.nixos.org/build/345084387)

Worth considering removal. I propose switching to gcc14Stdenv for now since I'm not entirely familiar with the package, but the git history and comments seem to indicate it's reaching its EOL. I've added a comment to document when the stdenv switch was made, which should make it easier to decide on removal at a later date.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
