### PR TITLE
term39: 1.5.1 -> 1.5.2, add darwin support

### DIFF
--- a/pkgs/by-name/te/term39/package.nix
+++ b/pkgs/by-name/te/term39/package.nix
@@ -8,17 +8,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "term39";
-  version = "1.5.1";
+  version = "1.5.2";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "alejandroqh";
     repo = "term39";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-IFJXBTjGedDl+FY7HDE5p+jYqA3c5EHHxQfn8hPY/es=";
+    hash = "sha256-DjseOO3oSNdsYvl+L+x9g45cwwbEWKf33w5CIj/iEI4=";
   };
 
-  cargoHash = "sha256-RguJr5xtuLcn4OO/8hmg06AmUT6WPzGtCpB0J+xw8+I=";
+  cargoHash = "sha256-W6kYUEYsbic+Oc0CVYjrb1q35jJkuzd9ierPeMWDPXs=";
 
   nativeBuildInputs = [
     pkg-config
@@ -32,6 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Modern, retro-styled terminal multiplexer with a classic MS-DOS aesthetic";
     homepage = "https://github.com/alejandroqh/term39";
+    changelog = "https://github.com/alejandroqh/term39/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ alejandroqh ];
     mainProgram = "term39";

--- a/pkgs/by-name/te/term39/package.nix
+++ b/pkgs/by-name/te/term39/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
@@ -22,11 +23,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    # pam-sys (lockscreen) generates its bindings with bindgen; Linux only
     rustPlatform.bindgenHook
   ];
 
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     pam
+  ];
+
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Reads the USER environment variable, which is unset in the sandbox
+    "--skip=lockscreen::auth::macos_auth::tests::test_get_username"
   ];
 
   meta = {
@@ -36,6 +45,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ alejandroqh ];
     mainProgram = "term39";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
Update term39 to 1.5.2 and enable it on darwin.

Changelog: https://github.com/alejandroqh/term39/releases/tag/v1.5.2

The second commit adds `x86_64-darwin` / `aarch64-darwin` to `platforms`. On macOS term39 authenticates the lockscreen through a native authenticator rather than PAM (upstream only pulls in the `pam-client` crate on Linux/FreeBSD/NetBSD), so `pam` and `rustPlatform.bindgenHook` become Linux-only inputs. One unit test, `lockscreen::auth::macos_auth::tests::test_get_username`, is skipped on darwin because it reads `$USER`, which is unset in the build environment. The Linux build is unchanged apart from the version bump.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
