### PR TITLE
[26.05] pnpm_12: init at 12.3.4

### DIFF
--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -69,7 +69,7 @@ in
     ) true;
 
     lib.warnIf (fetcherVersion < 3)
-      "fetchPnpmDeps: `fetcherVersion = ${toString fetcherVersion}` is deprecated and scheduled for removal in the 26.11 release. Please migrate `${pname}` to `fetcherVersion = 3` and regenerate the hash. See https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."
+      "fetchPnpmDeps: `fetcherVersion = ${toString fetcherVersion}` is deprecated and scheduled for removal in the 26.11 release. Please migrate `${pname}` to `fetcherVersion = 4` and regenerate the hash. See https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."
 
       stdenvNoCC.mkDerivation
       (
@@ -84,6 +84,7 @@ in
               jq
               moreutils
               pnpm # from args
+              pnpm.nodejs-slim
               pnpm-fixup-state-db'
               sqlite
               writableTmpDirAsHomeHook
@@ -148,13 +149,20 @@ in
 
               # pnpm is going to warn us about using --force
               # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
+              local installFlagsArray=(
+                "--force"
+                "--ignore-scripts"
+                "--frozen-lockfile"
+              )
+
+              if [[ -n "$NIX_NPM_REGISTRY" ]]; then
+                installFlagsArray+=("--registry=$NIX_NPM_REGISTRY")
+              fi
+
               pnpm install \
-                  --force \
-                  --ignore-scripts \
                   ${lib.escapeShellArgs filterFlags} \
                   ${lib.escapeShellArgs pnpmInstallFlags} \
-                  --registry="$NIX_NPM_REGISTRY" \
-                  --frozen-lockfile
+                  "''${installFlagsArray[@]}"
 
               # Store newer fetcherVersion in case pnpmConfigHook also needs it
               if [[ ${toString fetcherVersion} -gt 1 ]]; then

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -56,9 +56,14 @@ let
       version = "11.25.0";
       hash = "sha256-M90HSPJ+eRbE8ci2lDRhmD40U7BrvaYxKmKAEwtIgeU=";
     };
+    "12" = {
+      version = "12.3.4";
+      srcHash = "sha256-EAF5ZeABBX4Wdn08OVria9zKcTIJ8i9EIjb9gsaCAo4=";
+      cargoHash = "sha256-I54W1Ig6mn3/BsBiL5qc8aUZmSY2IGEY2QSXG0V1W1w=";
+    };
   };
 
-  callPnpm =
+  callPnpmNode =
     variant:
     callPackage ./generic.nix (
       variant
@@ -67,6 +72,10 @@ let
         nodejs = null; # Passing null to detect out-of-tree overrides
       }
     );
+
+  callPnpmRust = callPackage ./generic-rust.nix;
+
+  callPnpm = variant: if variant ? cargoHash then callPnpmRust variant else callPnpmNode variant;
 
   mkPnpm = versionSuffix: variant: nameValuePair "pnpm_${versionSuffix}" (callPnpm variant);
 in

--- a/pkgs/development/tools/pnpm/generic-rust.nix
+++ b/pkgs/development/tools/pnpm/generic-rust.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  makeWrapper,
+  nodejs-slim,
+  rustPackages_1_97,
+  stdenv,
+  testers,
+  tests,
+  writeScript,
+
+  version,
+  srcHash,
+  cargoHash,
+  knownVulnerabilities ? [ ],
+}:
+let
+  majorVersion = lib.versions.major version;
+in
+rustPackages_1_97.rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pnpm";
+  inherit version cargoHash;
+
+  src = fetchFromGitHub {
+    owner = "pnpm";
+    repo = "pnpm";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  cargoBuildFlags = [
+    "--bin=pnpm"
+  ];
+
+  postInstall = ''
+    makeWrapper "$out"/bin/pnpm "$out"/bin/pnpx \
+      --add-flag "dlx"
+
+    ln -s "$out"/bin/pnpm "$out"/bin/pn
+    ln -s "$out"/bin/pnpx "$out"/bin/pnx
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    "$out"/bin/pnpm completion bash > pnpm.bash
+    "$out"/bin/pnpm completion fish > pnpm.fish
+    "$out"/bin/pnpm completion zsh > pnpm.zsh
+    installShellCompletion pnpm.{bash,fish,zsh}
+  '';
+
+  passthru = {
+    inherit majorVersion nodejs-slim;
+
+    tests = {
+      inherit (tests) pnpm;
+      version = testers.testVersion { package = finalAttrs.finalPackage; };
+    };
+
+    updateScript = writeScript "pnpm-update-script" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell --pure --keep GITHUB_TOKEN -i bash -p curl cacert jq nix-update git
+      set -eou pipefail
+
+      curl_github() {
+        curl -L ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "$@"
+      }
+
+      latestTag=$(
+        curl_github https://api.github.com/repos/pnpm/pnpm/releases?per_page=100 | \
+        jq -r --arg major "v${majorVersion}" \
+          '[.[] | select(.tag_name | startswith($major)) | select(.prerelease == false)][0].tag_name'
+      )
+
+      # Exit if there is no tag with this major version
+      if [ "$latestTag" = "null" ]; then
+        echo "No releases starting with v${majorVersion}"
+        exit 0
+      fi
+
+      latestVersion="''${latestTag#v}"
+
+      nix-update pnpm_${majorVersion} --version="$latestVersion" --override-filename=./pkgs/development/tools/pnpm/default.nix
+    '';
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # Tests take way too long to run
+  doCheck = false;
+
+  meta = {
+    description = "Fast, disk space efficient package manager for JavaScript";
+    homepage = "https://pnpm.io/";
+    changelog = "https://github.com/pnpm/pnpm/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      Scrumplex
+      gepbird
+    ];
+    mainProgram = "pnpm";
+    inherit knownVulnerabilities;
+  };
+})

--- a/pkgs/development/tools/pnpm/generic.nix
+++ b/pkgs/development/tools/pnpm/generic.nix
@@ -135,7 +135,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         set -eou pipefail
 
         curl_github() {
-            curl -L ''${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} "$@"
+          curl -L ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "$@"
         }
 
         latestTag=$(

--- a/pkgs/test/pnpm/default.nix
+++ b/pkgs/test/pnpm/default.nix
@@ -5,4 +5,5 @@
   pnpm-workspaces = lib.recurseIntoAttrs (callPackage ./pnpm-workspaces { });
   pnpm_11_v3 = callPackage ./pnpm_11_v3 { };
   pnpm_11_v4 = callPackage ./pnpm_11_v4 { };
+  pnpm_12_v4 = callPackage ./pnpm_12_v4 { };
 }

--- a/pkgs/test/pnpm/pnpm_12_v4/default.nix
+++ b/pkgs/test/pnpm/pnpm_12_v4/default.nix
@@ -1,0 +1,60 @@
+{
+  fetchPnpmDeps,
+  lib,
+  makeShellWrapper,
+  nodejs-slim,
+  pnpmConfigHook,
+  pnpm_12,
+  stdenv,
+  testers,
+}:
+let
+  pnpm = pnpm_12;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pnpm-test";
+  inherit (pnpm) version;
+
+  src = ./src;
+
+  pnpmDeps = testers.invalidateFetcherByDrvHash fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-NDGKyqZasK13YkmNQ1ypP14rCP8wp2llT8bnKUi4/zo=";
+  };
+
+  nativeBuildInputs = [
+    makeShellWrapper
+    nodejs-slim
+    pnpm
+    pnpmConfigHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 -t $out/lib/pnpm-12-test dist/index.js
+
+    makeWrapper ${lib.getExe nodejs-slim} $out/bin/pnpm-12-test \
+      --add-flags "$out/lib/pnpm-12-test"
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    license = lib.licenses.mit;
+    mainProgram = "pnpm-12-test";
+    inherit (pnpm.meta) maintainers;
+  };
+})

--- a/pkgs/test/pnpm/pnpm_12_v4/src/.gitignore
+++ b/pkgs/test/pnpm/pnpm_12_v4/src/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/pkgs/test/pnpm/pnpm_12_v4/src/index.ts
+++ b/pkgs/test/pnpm/pnpm_12_v4/src/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello World");

--- a/pkgs/test/pnpm/pnpm_12_v4/src/package.json
+++ b/pkgs/test/pnpm/pnpm_12_v4/src/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pnpm12test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "license": "MIT",
+  "packageManager": "pnpm",
+  "type": "module",
+  "files": [
+    "dist/"
+  ],
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "typescript": "^6.0.2"
+  }
+}

--- a/pkgs/test/pnpm/pnpm_12_v4/src/pnpm-lock.yaml
+++ b/pkgs/test/pnpm/pnpm_12_v4/src/pnpm-lock.yaml
@@ -1,0 +1,39 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.9.6
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+
+packages:
+
+  '@types/node@25.9.6':
+    resolution: {integrity: sha512-JR6Q/PV5DKFvjrGFVqQJdeG0qvsqQQLDa3TzFrqVwhqRXqwNaxPo2KYCtCQXpOdIulCouKwT7a6in9nFthBAzw==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+snapshots:
+
+  '@types/node@25.9.6':
+    dependencies:
+      undici-types: 7.24.6
+
+  typescript@6.0.3: {}
+
+  undici-types@7.24.6: {}

--- a/pkgs/test/pnpm/pnpm_12_v4/src/tsconfig.json
+++ b/pkgs/test/pnpm/pnpm_12_v4/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2967,6 +2967,7 @@ with pkgs;
     pnpm_10_29_2
     pnpm_10
     pnpm_11
+    pnpm_12
     ;
   pnpm = pnpm_11;
 


### PR DESCRIPTION
Backport of:
- https://github.com/NixOS/nixpkgs/pull/547612

~~Does not currently build because it needs rustc 1.97 and stable only has rustc 1.95.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
