### PR TITLE
pnpm: point alias to pnpm_12

### DIFF
--- a/pkgs/by-name/bi/bichon/package.nix
+++ b/pkgs/by-name/bi/bichon/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   rustPlatform,
   fetchPnpmDeps,
-  pnpm,
+  pnpm_11,
   pnpmConfigHook,
   nodejs,
   openssl,
@@ -11,6 +11,9 @@
   versionCheckHook,
   nix-update-script,
 }:
+let
+  pnpm = pnpm_11;
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "bichon";
   version = "2.0.3";
@@ -27,6 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
+    inherit pnpm;
     sourceRoot = "${finalAttrs.src.name}/web";
     fetcherVersion = 4;
     hash = "sha256-Ax8z1sjt8v6XOenhw7eRuEEo0huPv9fbcfzqc8RxJEc=";

--- a/pkgs/by-name/es/esphome-device-builder/frontend.nix
+++ b/pkgs/by-name/es/esphome-device-builder/frontend.nix
@@ -4,12 +4,14 @@
   nodejs,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm,
+  pnpm_11,
   pyprojectVersionPatchHook,
   setuptools,
   meta,
 }:
-
+let
+  pnpm = pnpm_11;
+in
 buildPythonPackage (finalAttrs: {
   pname = "esphome-device-builder-frontend";
   version = "0.1.311";

--- a/pkgs/by-name/ma/matrix-authentication-service/package.nix
+++ b/pkgs/by-name/ma/matrix-authentication-service/package.nix
@@ -3,7 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   fetchPnpmDeps,
-  pnpm,
+  pnpm_11,
   pnpmConfigHook,
   nodejs,
   python3,
@@ -18,7 +18,9 @@
   buildPackages,
   nixosTests,
 }:
-
+let
+  pnpm = pnpm_11;
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-authentication-service";
   version = "1.24.0";
@@ -34,6 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
+    inherit pnpm;
     fetcherVersion = 4;
     hash = "sha256-DxEjMhYqZGbnobQ/F0WFXq7qaxSkWDcoZ0kmWJsdxEQ=";
   };

--- a/pkgs/by-name/mu/murmure/package.nix
+++ b/pkgs/by-name/mu/murmure/package.nix
@@ -13,7 +13,7 @@
   cargo-tauri,
   nodejs,
   pkg-config,
-  pnpm,
+  pnpm_11,
   pnpmConfigHook,
 
   # buildInputs
@@ -38,6 +38,8 @@
 }:
 
 let
+  pnpm = pnpm_11;
+
   parakeet-model = fetchzip {
     url = "https://github.com/Kieirra/murmure-model/releases/download/1.0.0/parakeet-tdt-0.6b-v3-int8.zip";
     hash = "sha256-rlV7mi5Y6qu/9jRWRPNBlABW8GxsvVAMCM6Ye2tVb2s=";
@@ -70,6 +72,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       version
       src
       ;
+    inherit pnpm;
     fetcherVersion = 4;
     hash = "sha256-ixBGVKYAk1FYcAayvKKJMT5v3JLjSK17ds0mrBEj850=";
   };

--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -6,13 +6,15 @@
   makeBinaryWrapper,
   nodejs,
   pnpmConfigHook,
-  pnpm,
+  pnpm_11,
   stdenv,
   versionCheckHook,
   yarn-berry,
   plugins ? [ ],
 }:
 let
+  pnpm = pnpm_11;
+
   ## Blame NodeJS
   exportRelativePathOf =
     let

--- a/pkgs/by-name/ru/rustfs/package.nix
+++ b/pkgs/by-name/ru/rustfs/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchPnpmDeps,
-  pnpm,
+  pnpm_11,
   pnpmConfigHook,
   nodejs,
   rustPlatform,
@@ -16,6 +16,8 @@
 }:
 
 let
+  pnpm = pnpm_11;
+
   console = stdenv.mkDerivation (finalAttrs: {
     pname = "rustfs-console";
     version = "0.1.25";
@@ -31,6 +33,7 @@ let
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
+      inherit pnpm;
       fetcherVersion = 4;
       hash = "sha256-wfaUMWTa8eFkzY/wCD5o7+G2OiSTWCqm+py3sgqDI04=";
     };

--- a/pkgs/by-name/sp/sparkle/package.nix
+++ b/pkgs/by-name/sp/sparkle/package.nix
@@ -4,7 +4,7 @@
   buildGoModule,
   buildNpmPackage,
   fetchFromGitHub,
-  pnpm,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeWrapper,
@@ -22,6 +22,8 @@
 }:
 
 let
+  pnpm = pnpm_11;
+
   sparkle-service = buildGoModule {
     pname = "sparkle-service";
     version = "0-unstable-2026-08-02";

--- a/pkgs/by-name/tr/tranquil-pds-frontend/package.nix
+++ b/pkgs/by-name/tr/tranquil-pds-frontend/package.nix
@@ -3,11 +3,13 @@
   stdenvNoCC,
   fetchFromTangled,
   nodejs,
-  pnpm,
+  pnpm_11,
   pnpmConfigHook,
   fetchPnpmDeps,
 }:
-
+let
+  pnpm = pnpm_11;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tranquil-frontend";
   version = "0.6.6";

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/weather-forecast-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/weather-forecast-card/package.nix
@@ -3,11 +3,13 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   nodejs,
-  pnpm,
+  pnpm_11,
   pnpmConfigHook,
   stdenvNoCC,
 }:
-
+let
+  pnpm = pnpm_11;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "weather-forecast-card";
   version = "1.1.0";

--- a/pkgs/test/pnpm/pnpm-workspaces/default.nix
+++ b/pkgs/test/pnpm/pnpm-workspaces/default.nix
@@ -18,7 +18,7 @@ let
         inherit (finalAttrs) src pnpmWorkspaces;
         inherit pnpm;
         fetcherVersion = 4;
-        hash = "sha256-dIp6CNh1Kn4aqJWku1G/FUdn/u+epzhqlqwnAkB2uW0=";
+        hash = "sha256-90OkzjIFr/JnjBBxdpM2sT185Yk+gWlLaxZ+eb64LDQ=";
       };
 
       pnpmWorkspaces = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2736,7 +2736,7 @@ with pkgs;
     pnpm_11
     pnpm_12
     ;
-  pnpm = pnpm_11;
+  pnpm = pnpm_12;
 
   inherit (callPackages ../build-support/node/fetch-pnpm-deps { })
     fetchPnpmDeps


### PR DESCRIPTION
Follow up to https://github.com/NixOS/nixpkgs/pull/547612

I assume most packages in-tree are pinned to a given pnpm major version (and if they aren't, this is a good time to change that). This would simply change the default for out-of-tree packages, and we should do it sometime before November (26.11).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
