### PR TITLE
sngrep: fix CVE-2026-90558

### DIFF
--- a/pkgs/by-name/sn/sngrep/package.nix
+++ b/pkgs/by-name/sn/sngrep/package.nix
@@ -10,6 +10,7 @@
   openssl,
   pcre2,
   pkg-config,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -46,6 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
+    # TODO: Remove this patch when updating to version 1.8.5
+    (fetchpatch {
+      name = "CVE-2026-90558.patch";
+      url = "https://github.com/irontec/sngrep/commit/1ff74ee3ab5ff280e8ba976aa8c744dca57eb35b.patch";
+      hash = "sha256-QizEvKztbosj3GoRtG9yxeqTglyBNLuuOmPF92XU7BE=";
+    })
+
     ./fix-sng_strncpy-declaration.patch
   ];
 


### PR DESCRIPTION
Fixes: NixOS/nixpkgs#562879
Stack Buffer Overflow via SIP Headers
A patch from the repository: https://github.com/irontec/sngrep/commit/1ff74ee3ab5ff280e8ba976aa8c744dca57eb35b fixes this CVE.
I have tested the build and basic functionality on NixOS-WSL.




<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
