### PR TITLE
tailspin: 6.1.0 -> 7.0.0

### DIFF
--- a/pkgs/by-name/ta/tailspin/package.nix
+++ b/pkgs/by-name/ta/tailspin/package.nix
@@ -2,28 +2,25 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  stdenv,
+  procps,
   versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tailspin";
-  version = "6.1.0";
+  version = "7.0.0";
 
   src = fetchFromGitHub {
     owner = "bensadeh";
     repo = "tailspin";
     tag = finalAttrs.version;
-    hash = "sha256-9+uu9q9tGIWFnyYpy+HHD5UUCsxUDLRlZlo0Ap4ezsY=";
+    hash = "sha256-RI604v8ImQSgvNUGsnCLe6FuzEMJwE0tNVuFLmJLwvM=";
   };
 
-  cargoHash = "sha256-C3OORW5aeDrRDTlfvRNW3RLE0p8wFs1qbIKl/XpzThs=";
+  cargoHash = "sha256-kcd6rBoonoCKuybVIVtZqt+njHFhVDTjTyF2UURuOSI=";
 
-  postPatch = ''
-    substituteInPlace tests/utils.rs --replace-fail \
-      'target/debug' "target/${stdenv.hostPlatform.rust.rustcTargetSpec}/$cargoCheckType"
-  '';
+  nativeCheckInputs = [ procps ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/tspin";


### PR DESCRIPTION
https://github.com/bensadeh/tailspin/blob/7.0.0/CHANGELOG.md

Also:
- Drop the postPatch that rewrote tests/utils.rs's hardcoded target/debug path, and the now-unused stdenv argument it relied on. That file is gone upstream; tests now locate the binary via Cargo's CARGO_BIN_EXE_tspin, which is target-triple aware, so the workaround is obsolete.
- Add procps to nativeCheckInputs: new e2e tests in this release supervise the pager subprocess via pgrep/kill, which requires procps to be on PATH during the check phase.

Assisted-by: Claude Sonnet 5

Note: 7.0.0 has breaking changes for CLI users  `--disable-builtin-keywords`, `--config-path`, and the per-shell `--generate-*-completions` flags were all renamed/removed, and the `[ip_addresses]` theme table was split into `[ipv4]`/`[ipv6]`. See the changelog's "Breaking Changes" section.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

This PR message was prepared with assistance from Claude Sonnet 5.